### PR TITLE
Ability to build via nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,4 @@ jobs:
     - uses: cachix/install-nix-action@v12
     - uses: actions/checkout@v2
     - name: Build and test
-      run: nix-shell --run 'make all'
+      run: nix-build


### PR DESCRIPTION
Previously we were only using Nix to provide the shell. This PR
adds a `default.nix` which can be used to build the project
(via `make`). This should allow building the project on MacOS
with using a Linux build machine.

This also updates CI to run `nix-build` instead.