### PR TITLE
Eliminate ratio abstraction from parameters.ml (68472 => 67878)

### DIFF
--- a/src/fixedPoint.ml
+++ b/src/fixedPoint.ml
@@ -7,7 +7,7 @@ type fixedpoint = Ligo.int
 (* BEGIN_OCAML *)
 let[@inline] fixedpoint_scaling_exponent = 64
 (* END_OCAML *)
-let[@inline] fixedpoint_scaling_factor = Ligo.int_from_literal "18446744073709551616" (* 2 (scaling_base) ^ 64 (scaling_exponent) *)
+let fixedpoint_scaling_factor = Ligo.int_from_literal "18446744073709551616" (* 2 (scaling_base) ^ 64 (scaling_exponent) *)
 
 (* Predefined values. *)
 let[@inline] fixedpoint_zero = Ligo.int_from_literal "0"

--- a/src/fixedPoint.mli
+++ b/src/fixedPoint.mli
@@ -3,6 +3,7 @@ type fixedpoint
 (* Predefined values. *)
 val fixedpoint_zero : fixedpoint
 val fixedpoint_one : fixedpoint
+val fixedpoint_scaling_factor : Ligo.int
 
 (* Arithmetic operations. *)
 val fixedpoint_add : fixedpoint -> fixedpoint -> fixedpoint

--- a/src/ratio.ml
+++ b/src/ratio.ml
@@ -77,18 +77,28 @@ let[@inline] zero_ratio : ratio = { num = Ligo.int_from_literal "0"; den = Ligo.
 let[@inline] one_ratio : ratio = { num = Ligo.int_from_literal "1"; den = Ligo.int_from_literal "1"; }
 
 (* NOTE: this implementation relies on the fact that the denominator is always positive. *)
-let leq_ratio_ratio (x: ratio) (y: ratio) : bool =
-  let { num = x_num; den = x_den; } = x in
-  let { num = y_num; den = y_den; } = y in
-  Ligo.leq_int_int
-    (Ligo.mul_int_int x_num y_den)
-    (Ligo.mul_int_int y_num x_den)
-
-(* NOTE: this implementation relies on the fact that the denominator is always positive. *)
 let lt_ratio_ratio (x: ratio) (y: ratio) : bool =
   let { num = x_num; den = x_den; } = x in
   let { num = y_num; den = y_den; } = y in
   Ligo.lt_int_int
+    (Ligo.mul_int_int x_num y_den)
+    (Ligo.mul_int_int y_num x_den)
+
+(* NOTE: this implementation does not rely on the fact that the denominator is
+ * always positive, but it definitely preserves it. *)
+let mul_ratio (x: ratio) (y: ratio) : ratio =
+  let { num = x_num; den = x_den; } = x in
+  let { num = y_num; den = y_den; } = y in
+  make_real_unsafe
+    (Ligo.mul_int_int x_num y_num)
+    (Ligo.mul_int_int x_den y_den)
+
+(* BEGIN_OCAML *)
+(* NOTE: this implementation relies on the fact that the denominator is always positive. *)
+let leq_ratio_ratio (x: ratio) (y: ratio) : bool =
+  let { num = x_num; den = x_den; } = x in
+  let { num = y_num; den = y_den; } = y in
+  Ligo.leq_int_int
     (Ligo.mul_int_int x_num y_den)
     (Ligo.mul_int_int y_num x_den)
 
@@ -123,15 +133,6 @@ let sub_ratio (x: ratio) (y: ratio) : ratio =
        (Ligo.mul_int_int y_num x_den))
     (Ligo.mul_int_int x_den y_den)
 
-(* NOTE: this implementation does not rely on the fact that the denominator is
- * always positive, but it definitely preserves it. *)
-let mul_ratio (x: ratio) (y: ratio) : ratio =
-  let { num = x_num; den = x_den; } = x in
-  let { num = y_num; den = y_den; } = y in
-  make_real_unsafe
-    (Ligo.mul_int_int x_num y_num)
-    (Ligo.mul_int_int x_den y_den)
-
 (* NOTE: this implementation relies on the fact that the denominator is always positive. *)
 let div_ratio (x: ratio) (y: ratio) : ratio =
   let { num = y_num; den = y_den; } = y in
@@ -146,7 +147,6 @@ let qexp (x: ratio) : ratio =
   let { num = x_num; den = x_den; } = x in
   { num = Ligo.add_int_int x_num x_den; den = x_den; }
 
-(* BEGIN_OCAML *)
 let show_ratio n = (Ligo.string_of_int n.num) ^ "/" ^ (Ligo.string_of_int n.den)
 let pp_ratio f x = Format.pp_print_string f (show_ratio x)
 


### PR DESCRIPTION
Continuation of #44. This one shaves off another 594 bytes. By now only superficial dependencies to `ratio.ml` remain; I shall remove the last ones next week and remove `ratio` from `generate-ligo.sh`.