### PR TITLE
Show size of packed endpoints during build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -42,7 +42,7 @@ in
     let pkgs = pkgsLinux;
     in pkgs.stdenv.mkDerivation {
          name = "huxian-michelson";
-         buildInputs = [ ligoBinary pkgs.ruby pkgs.perl ] ++ ocamlDeps pkgs;
+         buildInputs = [ ligoBinary ] ++ (with pkgs; [ ruby perl bc ]) ++ ocamlDeps pkgs;
          src =
            let filter =
              let ignored = gitignoreNix.gitignoreFilter ./.;

--- a/scripts/compile-ligo.sh
+++ b/scripts/compile-ligo.sh
@@ -21,14 +21,19 @@ functions=$(perl -n -e'/let lazy_fun_(\S+)/ && print "$1\n"' "$checkerEntrypoint
 
 for fun in $functions; do
   echo "Packing: $fun"
+  prefix="$target_dir/lazy_fun_$fun.tz."
   ligo compile-expression cameligo \
      --warn false \
      --init-file "$main" \
     "Bytes.pack lazy_fun_$fun" \
-    | split -b 32000 -d - "$target_dir/lazy_fun_$fun.tz."
+    | split -b 32000 -d - $prefix
 
  # Make sure that everything is prefixed by 0x
- sed -z -e 's/^0x//g' -e 's/^/0x/g' -i "$target_dir/lazy_fun_$fun.tz."*
+ sed -z -e 's/^0x//g' -e 's/^/0x/g' -i "$prefix"*
+
+ # Size of endpoints in storage will be almost exactly half the encoded size
+ size=$(echo "$(cat "$prefix"*|wc -c) / 2"|bc)
+ echo " -> ~$size bytes"
 done
 
 echo "done." 1>&2


### PR DESCRIPTION
```
 Packing: delegation_auction_place_bid
 -> ~958 bytes
Packing: delegation_auction_claim_win
 -> ~906 bytes
Packing: delegation_auction_reclaim_bid
 -> ~1086 bytes
```
etc.