### PR TITLE
Ignore PRs which only include markdown files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+    - '**/*.md'
   push:
     paths-ignore:
     - '**/*.md'


### PR DESCRIPTION
This should help us avoid exceeding the project's limits on GitHub Actions as we did last month.