### PR TITLE
Use cachix on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
     - uses: cachix/cachix-action@v10
       with:
         name: tezos-checker
-        authToken: '${{ secrets.CACHIX_SIGNING_KEY }}'
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Build and test
       run: nix-build -A michelson --arg doCheck true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         name: tezos-checker
         authToken: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: Build and test
-      run: nix-build -A michelson --arg doCheck true --arg isCi true
+      run: nix-build -A michelson --arg doCheck true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,9 @@ jobs:
     steps:
     - uses: cachix/install-nix-action@v13
     - uses: actions/checkout@v2
+    - uses: cachix/cachix-action@v10
+      with:
+        name: tezos-checker
+        authToken: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: Build and test
       run: nix-build -A michelson --arg doCheck true --arg isCi true

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -10,5 +10,9 @@ jobs:
     steps:
     - uses: cachix/install-nix-action@v13
     - uses: actions/checkout@v2
+    - uses: cachix/cachix-action@v10
+      with:
+        name: tezos-checker
+        authToken: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: Build spec
       run: nix-build -A spec

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,6 +13,6 @@ jobs:
     - uses: cachix/cachix-action@v10
       with:
         name: tezos-checker
-        authToken: '${{ secrets.CACHIX_SIGNING_KEY }}'
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN}}'
     - name: Build spec
       run: nix-build -A spec

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ doCheck ? false, isCi ? false }:
+{ doCheck ? false }:
 
 let
   sources = import ./nix/sources.nix { };
@@ -104,7 +104,7 @@ in rec
            # ligo does not compile on macos, also we don't want to
            # compile it in CI
            pkgs.lib.optionals (pkgsHost.stdenv.isLinux) [ ligoBinary ]
-           ++ pkgs.lib.optionals (pkgsHost.stdenv.isLinux && !isCi) [ tezosClient ]
+           ++ pkgs.lib.optionals (pkgsHost.stdenv.isLinux) [ tezosClient ]
            ++ (with pkgs; [ niv ruby bc sphinx poetry ])
            ++ spec.buildInputs
            ++ ocamlDeps pkgs


### PR DESCRIPTION
Since checker is now open source, we can easily use Cachix.

This PR also removes the `isCI` parameter that we used to have to avoid compiling tezos-client on CI, which now will come from the cache.