### PR TITLE
Implement views suggested by FA2

### DIFF
--- a/scripts/generate-entrypoints
+++ b/scripts/generate-entrypoints
@@ -9,7 +9,7 @@ ARGF.each_line do |line|
    case line
    when /^val +entrypoint_(\S+).*checker\s+\*\s+(.*?)\s+->/ then entrypoints << EntrypointInfo.new( $1, $2)
    when /^val +entrypoint_/ then raise "#{ARGF.filename}:#{ARGF.lineno}: Unrecognised entrypoint decl #{line}"
-   when /^val view_(\S+) *: *\(([^*]*)\*.*-> *(.*)/ then views << ViewInfo.new($1, $2.strip, $3.strip)
+   when /^val view_(\S+) *: *\((.*?) *\* *checker\) *-> *(.*)/ then views << ViewInfo.new($1, $2.strip, $3.strip)
    when /^val +view/ then raise "#{ARGF.filename}:#{ARGF.lineno}: Unrecognised view decl #{line}"
    end
 end

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -791,3 +791,33 @@ let view_is_burrow_overburrowed (burrow_id, state: burrow_id * checker) : bool =
 
 let view_is_burrow_liquidatable (burrow_id, state: burrow_id * checker) : bool =
   burrow_is_liquidatable state.parameters (find_burrow state.burrows burrow_id)
+
+(* ************************************************************************* *)
+(**                            FA2_VIEWS                                     *)
+(* ************************************************************************* *)
+
+let view_get_balance ((owner, token_id), state: (Ligo.address * fa2_token_id) * checker) : Ligo.nat =
+  fa2_get_balance (state.fa2_state, owner, token_id)
+
+let view_total_supply (token_id, state: fa2_token_id * checker) : Ligo.nat =
+  (* TODO: we should have assertions that the total amounts in parameters and cfmm is consistent with
+     what's in the ledger. Alternatively, we can use the ledger as a source of truth and remove
+     parameters.circulating_kit and cfmm.lqt.
+   *)
+  if token_id = kit_token_id then kit_to_mukit_nat state.parameters.circulating_kit
+  else if token_id = liquidity_token_id then  state.cfmm.lqt
+  else failwith "FA2_TOKEN_UNDEFINED"
+
+let view_all_tokens ((), _state: unit * checker) : fa2_token_id list =
+  fa2_all_tokens
+
+let view_is_operator ((owner, (operator, token_id)), state: (Ligo.address * (Ligo.address * fa2_token_id)) * checker): bool =
+  fa2_is_operator (state.fa2_state, owner, operator, token_id)
+
+(* TODO
+This corresponds to the "Custom" method specified in TZIP-12 [1]. We should either implement this one or the "Basic" method.
+
+[1]: https://gitlab.com/tzip/tzip/-/blob/4b3c67/proposals/tzip-12/tzip-12.md#token-metadata-storage-access
+*)
+let view_token_metadata (_token_id, _state: fa2_token_id * checker) : fa2_token_id * (string, Ligo.bytes) Ligo.map =
+  failwith "FA2_NOT_IMPLEMENTED"

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -260,3 +260,9 @@ val view_remove_liquidity_min_kit_withdrawn : (liquidity * checker) -> kit
 val view_burrow_max_mintable_kit : (burrow_id * checker) -> kit
 val view_is_burrow_overburrowed : (burrow_id * checker) -> bool
 val view_is_burrow_liquidatable : (burrow_id * checker) -> bool
+
+val view_get_balance : ((Ligo.address * fa2_token_id) * checker) -> Ligo.nat
+val view_total_supply : (fa2_token_id * checker) -> Ligo.nat
+val view_all_tokens : (unit * checker) -> fa2_token_id list
+val view_is_operator : ((Ligo.address * (Ligo.address * fa2_token_id)) * checker) -> bool
+val view_token_metadata : (fa2_token_id * checker) -> fa2_token_id * (string, Ligo.bytes) Ligo.map

--- a/src/fa2Interface.ml
+++ b/src/fa2Interface.ml
@@ -154,7 +154,7 @@ https://gitlab.com/tzip/tzip/-/blob/4b3c67aad5abbf04ec36caea4a1809e7b6e55bb8/pro
 let[@inline] kit_token_id = Ligo.nat_from_literal "0n"
 let[@inline] liquidity_token_id = Ligo.nat_from_literal "1n"
 
-let assert_valid_fa2_token (n: fa2_token_id): unit =
+let ensure_valid_fa2_token (n: fa2_token_id): unit =
   if n = kit_token_id || n = liquidity_token_id
   then ()
   else failwith "FA2_TOKEN_UNDEFINED" (* FIXME: error message *)
@@ -249,7 +249,7 @@ let[@inline] fa2_run_update_operators
 let[@inline] fa2_get_balance (st, owner, token_id: fa2_state * Ligo.address * fa2_token_id): Ligo.nat =
   let ledger = st.ledger in
   let key = (token_id, owner) in
-  let () = assert_valid_fa2_token token_id in
+  let () = ensure_valid_fa2_token token_id in
   get_fa2_ledger_value ledger key
 
 let[@inline] fa2_all_tokens : Ligo.nat list =
@@ -281,7 +281,7 @@ let[@inline] fa2_run_transfer
                 let amnt = x.amount in
                 let to_ = x.to_ in
 
-                let () = assert_valid_fa2_token token_id in
+                let () = ensure_valid_fa2_token token_id in
 
                 let st = ledger_withdraw (st, token_id, from_, amnt) in
                 let st = ledger_issue (st, token_id, to_, amnt) in

--- a/src/fa2Interface.ml
+++ b/src/fa2Interface.ml
@@ -259,7 +259,6 @@ let[@inline] fa2_run_balance_of (st, xs: fa2_state * fa2_balance_of_request list
   : fa2_balance_of_response list =
   List.map
     (fun (req: fa2_balance_of_request) ->
-       let () = assert_valid_fa2_token req.token_id in
        let blnc = fa2_get_balance (st, req.owner, req.token_id) in
        { request=req; balance = blnc; }
     )


### PR DESCRIPTION
Pretty much implementing the following: https://gitlab.com/tzip/tzip/-/blob/4b3c67/proposals/tzip-12/tzip-12.md#off-chain-views

* I had to fix the regex on generate-entrypoints since it didn't handle parameter type containing `*` correctly.
* I also noticed that previously I had implemented the operator logic in FA2 incorrectly, it turns out operators are per token_id. This commit also fixes that.

This PR omits the FA2 "token_metadata" section that we should implement separately.

@gkaracha, could you double check the "view_total_supply" function? I _think_ I am using correct values there, but I am wondering if there could be issues with rounding.