### PR TITLE
FA2 Token Metadata

### DIFF
--- a/client/checker_client/checker.py
+++ b/client/checker_client/checker.py
@@ -19,8 +19,8 @@ default_token_metadata = {
      "symbol": "KIT",
   },
   "liquidity": {
-     "name": "liquidity",
-     "symbol": "LQDT",
+     "name": "kit liquidity",
+     "symbol": "KTLQ",
   }
 }
 

--- a/client/checker_client/cli.py
+++ b/client/checker_client/cli.py
@@ -155,8 +155,9 @@ def deploy(config: Config, address=None, port=None, key=None):
 )
 @click.option("--oracle", type=str, help="Oracle contract address")
 @click.option("--ctez", type=str, help="ctez contract address")
+@click.option("--token-metadata", type=click.Path(exists=True), help="optional JSON file containing the TZIP-12 token_metadata.")
 @click.pass_obj
-def checker(config: Config, checker_dir, oracle, ctez):
+def checker(config: Config, checker_dir, oracle, ctez, token_metadata):
     """
     Deploy checker. Requires addresses for oracle and ctez contracts.
     """
@@ -176,7 +177,10 @@ def checker(config: Config, checker_dir, oracle, ctez):
     click.echo(f"Connecting to tezos node at: {shell}")
     client = pytezos.pytezos.using(shell=shell, key=config.tezos_key)
     checker = checker_lib.deploy_checker(
-        client, checker_dir, oracle=config.oracle_address, ctez=config.ctez_address
+        client, checker_dir,
+        oracle=config.oracle_address,
+        ctez=config.ctez_address,
+        token_metadata_file=token_metadata
     )
     click.echo(f"Checker contract deployed with address: {checker.context.address}")
     config.checker_address = checker.context.address

--- a/src/kit.ml
+++ b/src/kit.ml
@@ -2,6 +2,8 @@ open Common
 open FixedPoint
 
 type kit = Ligo.nat
+
+let[@inline] kit_decimal_digits = Ligo.nat_from_literal "6n"
 let[@inline] kit_scaling_factor_int = Ligo.int_from_literal "1_000_000"
 let[@inline] kit_scaling_factor_nat = Ligo.nat_from_literal "1_000_000n"
 

--- a/src/kit.mli
+++ b/src/kit.mli
@@ -12,6 +12,7 @@ val kit_max : kit -> kit -> kit
 
 val kit_zero : kit
 val kit_one : kit
+val kit_decimal_digits : Ligo.nat
 val kit_scaling_factor_int : Ligo.int
 
 (* Conversions to/from other types. *)

--- a/src/kit.mli
+++ b/src/kit.mli
@@ -14,6 +14,7 @@ val kit_zero : kit
 val kit_one : kit
 val kit_decimal_digits : Ligo.nat
 val kit_scaling_factor_int : Ligo.int
+val kit_scaling_factor_nat : Ligo.nat
 
 (* Conversions to/from other types. *)
 val kit_of_mukit : Ligo.nat -> kit

--- a/tests/testKit.ml
+++ b/tests/testKit.ml
@@ -10,6 +10,16 @@ let suite =
   "KitTests" >::: [
     "kit arithmetic" >::
     (fun _ ->
+       (* scaling factor (int) *)
+       assert_equal ~printer:Ligo.string_of_int
+         (Common.pow_int_nat (Ligo.int_from_literal "10") kit_decimal_digits)
+         kit_scaling_factor_int;
+
+       (* scaling factor (nat) *)
+       assert_equal ~printer:Ligo.string_of_int
+         kit_scaling_factor_int
+         (Ligo.int kit_scaling_factor_nat);
+
        (* add *)
        assert_equal ~printer:show_kt
          (kit_of_mukit (Ligo.nat_from_literal "8_000_000n"))


### PR DESCRIPTION
This PR implements the [token_metadata functionality of TZIP-12][token-metadata-docs].

The way it is implemented is via supplying a `token_metadata` off-chain view of a certain type, which essentially is a `(string, bytes) map` per token type (kit and liquidity in our case).

It would be easy to just hardcode the values in the code, but that'd force people to recompile checker in order to customize token metadata. So I ended up writing the view by hand at deployment time. This is not so tricky here because it pretty much is only static data and does not require looking at our view.

The user can supply a JSON file containing their overrides with `--token-metadata` parameter, but without it we have some minimal defaults which seems to work:

```
>>> client.contract("KT19YUWzmowLnu5rQdWBNqiKBfWcoYF9XxjQ").token_metadata[0]
Trying to fetch token 0 metadata from off-chain view
Trying to fetch contract metadata from `tezos-storage:m`
ContractTokenMetadata(name='kit', symbol='KIT', decimals=6, symbolPreference=None, thumbnailUri=None, artifactUri=None, displayUri=None, description=None, minter=None, creators=None, isBooleanAmount=None, formats=None, tags=None, contributors=None, publishers=None, date=None, blockLevel=None, type=None, genres=None, language=None, identifier=None, rights=None, rightsUri=None, externalUri=None, isTransferable=None, shouldPreferSymbol=None, attributes=None, assets=None)
```

I also tried using Temple Wallet and it seems to be able to recognize the metadata, so the format seems to be ok.

In future, we can rename the `token-metadata` parameter to `metadata` and make it also include [TZIP-16 contract metadata][contract-metadata-docs].

[token-metadata-docs]: https://gitlab.com/tzip/tzip/-/blob/4b3c67/proposals/tzip-12/tzip-12.md#token-metadata
[contract-metadata-docs]: https://gitlab.com/tzip/tzip/-/blob/master/proposals/tzip-16/tzip-16.md#metadata-json-format