### PR TITLE
Updates to e2e tests

### DIFF
--- a/client/checker_client/checker.py
+++ b/client/checker_client/checker.py
@@ -391,7 +391,7 @@ def deploy_ctez(tz: PyTezosClient, ctez_dir, num_blocks_wait=100, ttl: Optional[
         fa12_ctez_storage = {
             "tokens": {"tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU": 1},
             "allowances": {},
-            "admin": tz.key.public_key_hash(),
+            "admin": ctez.context.address,
             "total_supply": 1,
         }
         fa12_ctez = deploy_contract(


### PR DESCRIPTION
I was working on testing the CFMM functionality of checker.

To do that, I had to use the `ctez` contract to get some ctez. While doing that; I

* Found a bug on `ctez` contract's deployment script on our side (see the first commit).
* Reused the docker sandbox logic from `checker_client` library on e2e tests
* Slightly tweaked the parameters we pass to `inject` function to make them more reliable. Currently the tests work more often than they fail, but unfortunately there still are some intermitten failures. However it takes a really long time to try out a change, so I couldn't delve into them so much.

In the end, I ended up being able to mint some `ctez`, but didn't have time finish the test I want to write. I can do it tomorrow, but the PR as-is is mergeable state, so we might as well review & merge this one.