### PR TITLE
Ensure the FA2-related entrypoints fail if Tezos.amount > 0

### DIFF
--- a/src/checker.ml
+++ b/src/checker.ml
@@ -849,12 +849,14 @@ let entrypoint_receive_price (state, price: checker * Ligo.nat) : (LigoOp.operat
 
 let strict_entrypoint_transfer (state, xs: checker * fa2_transfer list) : (LigoOp.operation list * checker) =
   assert_checker_invariants state;
+  let _ = ensure_no_tez_given () in
   let state = { state with fa2_state = fa2_run_transfer (state.fa2_state, xs) } in
   assert_checker_invariants state;
   (([]: LigoOp.operation list), state)
 
 let[@inline] strict_entrypoint_balance_of (state, param: checker * fa2_balance_of_param) : (LigoOp.operation list * checker) =
   assert_checker_invariants state;
+  let _ = ensure_no_tez_given () in
   let { requests = requests; callback = callback; } = param in
   let response = fa2_run_balance_of (state.fa2_state, requests) in
   let op = LigoOp.Tezos.fa2_balance_of_response_transaction response (Ligo.tez_from_literal "0mutez") callback in
@@ -863,6 +865,7 @@ let[@inline] strict_entrypoint_balance_of (state, param: checker * fa2_balance_o
 
 let entrypoint_update_operators (state, xs: checker * fa2_update_operator list) : (LigoOp.operation list * checker) =
   assert_checker_invariants state;
+  let _ = ensure_no_tez_given () in
   let state = { state with fa2_state = fa2_run_update_operators (state.fa2_state, xs) } in
   assert_checker_invariants state;
   (([]: LigoOp.operation list), state)

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -706,6 +706,41 @@ let suite =
          )
     );
 
+    (* ************************************************************************* *)
+    (**                               FA2                                        *)
+    (* ************************************************************************* *)
+    ("strict_entrypoint_transfer (FA2) - transaction with value > 0 fails" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "1mutez");
+       assert_raises
+         (Failure (Ligo.string_of_int error_UnwantedTezGiven))
+         (fun () -> Checker.strict_entrypoint_transfer (empty_checker, []))
+    );
+
+    ("strict_entrypoint_balance_of (FA2) - transaction with value > 0 fails" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "1mutez");
+
+       let fa2_balance_of_param =
+         { requests = [];
+           callback = Ligo.contract_of_address (Ligo.address_of_string "test address");
+         } in
+       assert_raises
+         (Failure (Ligo.string_of_int error_UnwantedTezGiven))
+         (fun () -> Checker.strict_entrypoint_balance_of (empty_checker, fa2_balance_of_param))
+    );
+
+    ("entrypoint_update_operators (FA2) - transaction with value > 0 fails" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "1mutez");
+       assert_raises
+         (Failure (Ligo.string_of_int error_UnwantedTezGiven))
+         (fun () -> Checker.entrypoint_update_operators (empty_checker, []))
+    );
+
     (* FIXME: There are no tests currently for Checker.Transfer. *)
     (* FIXME: There are no tests currently for Checker.Balance_of. *)
     (* FIXME: There are no tests currently for Checker.Update_operators. *)


### PR DESCRIPTION
I am not entirely sure about this one, to be honest. While adding tests I noticed that our FA2-related entrypoints do not fail if `Tezos.amount <> 0tez`, which is the common practice if no tez is expected, so I added the checks myself (plus unit tests). However, I couldn't find such a restriction in the [FA1.2/TZIP7](https://gitlab.com/tzip/tzip/-/blob/master/proposals/tzip-7/tzip-7.md) or the [FA2/TZIP12](https://gitlab.com/tzip/tzip/-/blob/master/proposals/tzip-12/tzip-12.md) spec. For what it's worth, ctez which conforms to TZIP7 also performs [this check](https://github.com/tezos-checker/ctez/blob/8cc56059c4c6785e98e1b7d8d0267048fd17f5a7/fa12.mligo#L154-L156).

Size updates:

Because of the two strict entrypoints (`strict_entrypoint_transfer` and `strict_entrypoint_balance_of`) the size of the main contract goes up a little, and the lazy entrypoint `update_operators` increases slightly in size as well:
```
Main contract    : ~8875 bytes => ~8987 bytes
update_operators :  ~454 bytes =>  ~487 bytes
```
I've tested locally and the contract is still deployable though; gas consumption changes must be negligible as well.