### PR TITLE
Add big_map utility module to Python client library

### DIFF
--- a/debug_gas.py
+++ b/debug_gas.py
@@ -1,0 +1,141 @@
+from typing import Any, Dict, Set
+from pytezos import pytezos
+from pytezos.contract.call import ContractCall
+from pytezos.contract.interface import ContractInterface
+from pytezos.michelson.micheline import micheline_value_to_python_object
+from pytezos.rpc.protocol import BlockQuery
+from pytezos.rpc.search import BlockSliceQuery
+from pytezos.michelson.types.big_map import BigMapType, big_map_diff_to_lazy_diff
+
+client = pytezos.using(
+    "http://localhost:11112",
+    key="edsk3RFfvaFaxbHx8BMtEW1rKQcPtDML3LXjNqMNLCzC3wLC1bWbAt",
+)
+
+
+# client.shell.blocks[1:].find_origination("KT1KFKFgNv5Di2bDwdRk1cUyud4npZ1Pv727")
+
+# entrypoint = checker.create_burrow((2, None))
+
+# # TODO: Can we can run_operation to run with a higher gas limit?
+# group = entrypoint.with_amount(10_000_000)
+# group.run_operation()
+# # .as_transaction()
+# # for c in group.contents:
+# #     c["gas_limit"] = 200_000_000
+
+
+# entrypoint.run_code(storage=checker.storage())
+
+
+# Construct block slice query
+# Replay from block 1 until you find the contract, then start collecting storage diffs
+
+contract_id = "KT1ALzpYUkwUi5dXkDvix95fUeJjZRUVAUuR"
+lastCall = "sealContract"
+diffs = []
+
+end_scan_blocks = 10
+
+
+blocks_since_update = None
+blocks: BlockSliceQuery = client.shell.blocks[2000:]
+for b in blocks:
+    block_diffs = []
+    if contract_id in b.context.contracts():
+        # Contract exists in this operation. Let's look for ops on it
+        ops = client.shell.blocks[b.hash()].operations.managers()
+        for op_group in ops:
+            # contents.metadata.operation_result.big_map_diff
+            op_group = op_group["contents"]
+            for op in op_group:
+                op_result = op["metadata"]["operation_result"]
+                # Skip ops which don't operate on the contract of interest
+                if (
+                    op["kind"] == "origination"
+                    and contract_id not in op_result["originated_contracts"]
+                ):
+                    continue
+                if op["kind"] == "transaction" and op["destination"] != contract_id:
+                    continue
+                block_diffs += op_result["lazy_storage_diff"]
+                print(op_result["lazy_storage_diff"])
+                # if (
+                #     op["kind"] == "transaction"
+                #     and op["parameters"]["entrypoint"] == lastCall
+                # ):
+                #     print("Found last call for preparing contract")
+                #     break
+    diffs += block_diffs
+    if block_diffs:
+        blocks_since_update = 0
+    if not block_diffs and blocks_since_update is not None:
+        blocks_since_update += 1
+
+    if blocks_since_update is not None and blocks_since_update > end_scan_blocks:
+        print(f"No storage updates found since {blocks_since_update}. Ending scan.")
+        break
+
+keys = {}
+for diff in diffs:
+    if diff["kind"] != "big_map":
+        continue
+    bigmap_id = diff["id"]
+    diff = diff["diff"]
+    if diff["action"] != "update":
+        continue
+
+    if bigmap_id not in keys:
+        keys[bigmap_id] = set([])
+    for update in diff["updates"]:
+        keys[bigmap_id].add(micheline_value_to_python_object(update["key"]))
+
+checker = client.contract("KT1ALzpYUkwUi5dXkDvix95fUeJjZRUVAUuR")
+s = checker.storage()
+
+
+# If a key is updated with a non-None value, keep it. Otherwise remove it.
+
+
+def render_bigmap(
+    field: str, bigmap_id: int, keys: Dict[int, Set[Any]], contract: ContractInterface
+):
+    full_map = {}
+    for key in keys[f"{bigmap_id}"]:
+        # Call tezos to get the value for this key
+        full_map[key] = contract.storage[field][key]()
+    return full_map
+
+
+def rec_render_bigmap(contract: ContractInterface, keys):
+    the_map = {}
+    for mich_field in checker.storage.data:
+        if isinstance(mich_field, BigMapType):
+            the_map[mich_field.field_name] = render_bigmap(
+                mich_field.field_name,
+                mich_field.to_python_object(),
+                keys,
+                contract,
+            )
+    data = checker.storage()
+    data.update(the_map)
+
+    # TODO: Recurse subfields
+    return data
+
+
+with_funcs = rec_render_bigmap(checker, keys)
+
+# Create call to `default` entrypoint
+call = checker.sealContract(
+    ("KT1FCu6H8kL5ortBaXFRK7hv2Rb3CuJR8kZ1", "KT1J17YAMFPJz6DdSWsSsQzSqvi2KYyinwmk")
+)
+
+# Node interpreter
+result = call.trace_code(
+    storage=with_funcs,
+    source="tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6",
+    gas_limit=100_000_000,
+)
+
+# TODO: Can we get the gas used from this??

--- a/debug_gas.py
+++ b/debug_gas.py
@@ -1,11 +1,13 @@
-from typing import Any, Dict, Set
+from typing import Any, Dict, Optional, Set
 from pytezos import operation, pytezos
+from pytezos.client import PyTezosClient
 from pytezos.contract.call import ContractCall
 from pytezos.contract.interface import ContractInterface
 from pytezos.michelson.micheline import micheline_value_to_python_object
 from pytezos.michelson.types.adt import ADTMixin
 from pytezos.michelson.types.base import MichelsonType, Undefined
 from pytezos.michelson.types.pair import PairType
+from pytezos.michelson.types import ListType
 from pytezos.operation.group import OperationGroup
 from pytezos.rpc.helpers import ForgeOperationsQuery
 from pytezos.rpc.protocol import BlockQuery
@@ -15,107 +17,107 @@ from checker_client import checker as checker_lib
 import json
 from pytezos.michelson.sections.storage import StorageSection
 from pytezos.operation.content import format_mutez
+from pprint import pprint
+
+# def skip_nones(**kwargs) -> dict:
+#     return {k: v for k, v in kwargs.items() if v is not None}
 
 
-def skip_nones(**kwargs) -> dict:
-    return {k: v for k, v in kwargs.items() if v is not None}
+def scan_bigmap_keys(
+    tz: PyTezosClient,
+    contract_address: str,
+    start_block: int = 1,
+    end_after_blocks: Optional[int] = None,
+) -> Dict[str, Set[Any]]:
+    """Scans for all big_map keys in a contract's storage
+
+    This function works by scanning the main chain for any operations on
+    the specified contract which produce a lazy_storage_diff.
+
+    Args:
+        tz: pytezos client instance
+        contract_address: The address of the contract of interest
+        start_block: The block at which to start scanning. Note that setting this to a block after
+            the contract's origination may cause you to miss keys.
+        end_after_blocks: Optionally end the scan after this many blocks without an update
+            to a big_map. The default value of None will cause the function to scan the entire
+            chain.
+    Returns:
+        A dict mapping bigmap_ids to their keys. Note that ids may be missing from here if no
+            keys are ever added to the big_map (i.e. it is only allocated).
+    """
+    diffs = []
+    blocks_since_update = None
+    blocks: BlockSliceQuery = tz.shell.blocks[start_block:]
+    # First, need to collect the lazy storage diffs
+    for b in blocks:
+        block_diffs = []
+        if contract_address in b.context.contracts():
+            # Contract exists in this operation. Let's look for operations on it
+            ops = tz.shell.blocks[b.hash()].operations.managers()
+            for op_group in ops:
+                op_group = op_group["contents"]
+                for op in op_group:
+                    op_result = op["metadata"]["operation_result"]
+                    # Skip ops which don't operate on the contract of interest
+                    if (
+                        op["kind"] == "origination"
+                        and contract_address not in op_result["originated_contracts"]
+                    ):
+                        continue
+                    if (
+                        op["kind"] == "transaction"
+                        and op["destination"] != contract_address
+                    ):
+                        continue
+                    block_diffs += op_result["lazy_storage_diff"]
+        diffs += block_diffs
+        if block_diffs:
+            blocks_since_update = 0
+        # Only increment if we have already found the first block operating on this contract
+        if not block_diffs and blocks_since_update is not None:
+            blocks_since_update += 1
+
+        if (
+            end_after_blocks
+            and blocks_since_update is not None
+            and blocks_since_update > end_after_blocks
+        ):
+            print(
+                f"No storage updates found since {blocks_since_update} blocks. Ending scan."
+            )
+            break
+    # Now we can extract the keys from the diffs
+    keys = {}
+    for diff in diffs:
+        if diff["kind"] != "big_map":
+            continue
+        bigmap_id = diff["id"]
+        diff = diff["diff"]
+        # Note: diffs of action type "alloc" allocate a big map, and those with
+        # action "update" update a key value pair
+        if diff["action"] != "update":
+            continue
+        if bigmap_id not in keys:
+            keys[bigmap_id] = set([])
+        for update in diff["updates"]:
+            key = micheline_value_to_python_object(update["key"])
+            # If the update removes the key value pair, remove it from our map
+            # TODO: I am pretty sure this is safe for cases where the value gets updated to
+            # an Option with value None, but am not 100% sure.
+            if micheline_value_to_python_object(update["value"]) is None:
+                keys[bigmap_id].remove(key)
+            # Otherwise record the key
+            else:
+                keys[bigmap_id].add(key)
+    return keys
 
 
-client = pytezos.using(
-    "http://localhost:11112",
-    key="edsk3RFfvaFaxbHx8BMtEW1rKQcPtDML3LXjNqMNLCzC3wLC1bWbAt",
-)
-
-# client.shell.blocks[1:].find_origination("KT1KFKFgNv5Di2bDwdRk1cUyud4npZ1Pv727")
-
-# entrypoint = checker.create_burrow((2, None))
-
-# # TODO: Can we can run_operation to run with a higher gas limit?
-# Answer: NO :'(
-# group = entrypoint.with_amount(10_000_000)
-# group.run_operation()
-# # .as_transaction()
-# # for c in group.contents:
-# #     c["gas_limit"] = 200_000_000
-
-
-# entrypoint.run_code(storage=checker.storage())
-
-
-# The contract for which we want to read all big maps
-contract_id = "KT1PwzHsf6FkA3EsRe7WrfMscNfer5krHQMd"
-# Which block to start scanning for diffs
-start_from_block = 1
-# End the scan after N blocks without updates to the contract storage
-end_scan_blocks = 10
-
-diffs = []
-blocks_since_update = None
-
-blocks: BlockSliceQuery = client.shell.blocks[start_from_block:]
-for b in blocks:
-    block_diffs = []
-    if contract_id in b.context.contracts():
-        # Contract exists in this operation. Let's look for ops on it
-        ops = client.shell.blocks[b.hash()].operations.managers()
-        for op_group in ops:
-            # contents.metadata.operation_result.big_map_diff
-            op_group = op_group["contents"]
-            for op in op_group:
-                op_result = op["metadata"]["operation_result"]
-                # Skip ops which don't operate on the contract of interest
-                if (
-                    op["kind"] == "origination"
-                    and contract_id not in op_result["originated_contracts"]
-                ):
-                    continue
-                if op["kind"] == "transaction" and op["destination"] != contract_id:
-                    continue
-                block_diffs += op_result["lazy_storage_diff"]
-
-    diffs += block_diffs
-    if block_diffs:
-        blocks_since_update = 0
-    if not block_diffs and blocks_since_update is not None:
-        blocks_since_update += 1
-
-    if blocks_since_update is not None and blocks_since_update > end_scan_blocks:
-        print(f"No storage updates found since {blocks_since_update}. Ending scan.")
-        break
-
-keys = {}
-for diff in diffs:
-    if diff["kind"] != "big_map":
-        continue
-    bigmap_id = diff["id"]
-    diff = diff["diff"]
-    # Note: diffs of action type "alloc" allocate a big map, and those with
-    # action "update" update a key value pair
-    if diff["action"] != "update":
-        continue
-
-    if bigmap_id not in keys:
-        keys[bigmap_id] = set([])
-    for update in diff["updates"]:
-        key = micheline_value_to_python_object(update["key"])
-        # If the update removes the key value pair, remove it from our map
-        # TODO: I am pretty sure this is safe for cases where the value gets updated to
-        # an Option, but am not 100% sure.
-        if micheline_value_to_python_object(update["value"]) is None:
-            keys[bigmap_id].remove(key)
-        # Otherwise record the key
-        else:
-            keys[bigmap_id].add(key)
-
-checker = client.contract(contract_id)
-s = checker.storage()
-
-
-def render_bigmap(
+def _render_bigmap(
     field: str, bigmap_id: int, keys: Dict[int, Set[Any]], contract: ContractInterface
 ):
     full_map = {}
-    bigmap_id = bigmap_id
+    bigmap_id = str(bigmap_id)
     if bigmap_id not in keys:
         return {}
     for key in keys[bigmap_id]:
@@ -127,162 +129,141 @@ def render_bigmap(
 def storage_with_bigmaps(
     contract: ContractInterface,
     contract_bigmap_keys: Dict[int, Set[Any]],
-    michelson_data: MichelsonType,
-):
-    storage = {}
-    # This node is a big map, let's populate it with its data
-    if isinstance(michelson_data, BigMapType):
-        return render_bigmap(
-            michelson_data.field_name,
-            michelson_data.to_python_object(),
-            keys,
-            contract,
-        )
-    # This node is not a big map and has no children, just return it
-    if not hasattr(michelson_data, "items"):
-        # Only render items which are not "undefined". Pytezos uses same behavior internally.
-        if michelson_data is Undefined:
-            return Undefined
-        return michelson_data.to_python_object()
-    # Otherwise, this element is a container with child elements, recurse into them
-    if isinstance(michelson_data, ADTMixin):
-        # Because reasons, need to select the second element from this generator
-        child_iterator = map((lambda e: e[1]), michelson_data.iter_values())
-    else:
-        child_iterator = iter(michelson_data.items)
-    for child in child_iterator:
-        child_data = storage_with_bigmaps(contract, contract_bigmap_keys, child)
-        if child_data is Undefined:
-            continue
-        storage[child.field_name] = child_data
-    return storage
+) -> Any:
+    """Queries a contract's storage, rendering bigmaps with their full contents.
 
+    Warning: since this method forces big_maps which are usually lazy, it will load all of
+    their contents into memory.
 
-# def rec_render_bigmap(michelson_data: MichelsonType):
-#     the_map = {}
-#     if isinstance(michelson_data, BigMapType):
-#         the_map[michelson_data.field_name] = render_bigmap(
-#             mich_field.field_name,
-#             mich_field.to_python_object(),
-#             keys,
-#             contract,
-#         )
-#     if hasattr(michelson_data, "items"):
-#         for field in michelson_data:
-#             rec_render_bigmap(field)
-
-#         # .items has a list of subfields
-
-#     data = checker.storage()
-#     data.update(the_map)
-
-#     # TODO: Recurse subf
-
-test = storage_with_bigmaps(checker, keys, checker.storage.data)
-
-with_funcs = rec_render_bigmap(checker, keys)
-
-# Create call to `default` entrypoint
-call = checker.create_burrow((2, None)).with_amount(2_000_000)
-
-
-def trace_code(
-    call: ContractCall,
-    storage=None,
-    source=None,
-    sender=None,
-    amount=None,
-    balance=None,
-    chain_id=None,
-    gas_limit=None,
-):
-    """Execute using RPC interpreter.
-
-    :param storage: initial storage as Python object, leave None if you want to generate a dummy one
-    :param source: patch SOURCE
-    :param sender: patch SENDER
-    :param amount: patch AMOUNT
-    :param balance: patch BALANCE
-    :param chain_id: patch CHAIN_ID
-    :param gas_limit: restrict max consumed gas
-    :rtype: ContractCallResult
+    Args:
+        contract: The contract of interest
+        contract_bigmap_keys: The keys in this contract's bigmaps. Missing bigmap_ids will be loaded as
+            empty dicts.
+    Returns:
+        A python representation of the contract's storage (similar to calling contract.storage())
     """
-    storage_ty = StorageSection.match(call.context.storage_expr)
-    if storage is None:
-        initial_storage = storage_ty.dummy(call.context).to_micheline_value(
-            lazy_diff=True
-        )
-    else:
-        initial_storage = storage_ty.from_python_object(storage).to_micheline_value(
-            lazy_diff=True
-        )
-    script = [
-        call.context.parameter_expr,
-        call.context.storage_expr,
-        call.context.code_expr,
-    ]
-    query = skip_nones(
-        script=script,
-        storage=initial_storage,
-        entrypoint=call.parameters["entrypoint"],
-        input=call.parameters["value"],
-        amount=format_mutez(amount or call.amount),
-        chain_id=chain_id or call.context.get_chain_id(),
-        source=sender,
-        payer=source,
-        balance=str(balance or 0),
-        gas=str(gas_limit) if gas_limit is not None else None,
-    )
-    res = call.shell.blocks[call.block_id].helpers.scripts.trace_code.post(query)
-    op_results = []
-    query_op = OperationGroup(context=call.context, contents=res["operations"])
 
-    # t = OperationGroup(context=client.context).origination(
-    #     script=op["script"],
-    #     balance=op["balance"],
-    #     delegate=None,
-    # )
+    def _rec_load_storage(contract, contract_bigmap_keys, michelson_data):
+        storage = {}
+        # This node is a big map, let's populate it with its data
+        if isinstance(michelson_data, BigMapType):
+            return _render_bigmap(
+                michelson_data.field_name,
+                michelson_data.to_python_object(),
+                contract_bigmap_keys,
+                contract,
+            )
+        # This node is not a big map and has no children, just return it
+        # Currently this also catches lists, which means that bigmaps nested within a list
+        # will not be rendered.
+        if not hasattr(michelson_data, "items") or isinstance(michelson_data, ListType):
+            # Only render items which are not "undefined". Pytezos uses same behavior internally.
+            if michelson_data is Undefined:
+                return Undefined
+            return michelson_data.to_python_object()
+        # Otherwise, this element is a container with child elements, recurse into them
+        if isinstance(michelson_data, ADTMixin):
+            # Because reasons, need to select the second element from this generator
+            child_iterator = map((lambda e: e[1]), michelson_data.iter_values())
+        else:
+            child_iterator = iter(michelson_data.items)
+        for child in child_iterator:
+            child_data = _rec_load_storage(contract, contract_bigmap_keys, child)
+            if child_data is Undefined:
+                continue
+            storage[child.field_name] = child_data
+        return storage
 
-    for op in res["operations"]:
-        #     # Only works shallowly at the moment
-        query_op = skip_nones(
-            script=op["script"]["code"],
-            storage=op["script"]["storage"],
-            entrypoint=None,
-            input={},
-            amount=str(0),
-            chain_id=chain_id or call.context.get_chain_id(),
-            source=None,
-            payer=None,
-            balance=format_mutez(op["balance"]),
-            gas=str(gas_limit) if gas_limit is not None else None,
-        )
-        op_res = call.shell.blocks[call.block_id].helpers.scripts.trace_code.post(
-            query_op
-        )
-    # TODO: Add a contructor here for the trace_code output
-    # ContractCallResult.from_run_code(res, parameters=call.parameters, context=call.context)
-    return res, op_results
+    return _rec_load_storage(contract, contract_bigmap_keys, contract.storage.data)
 
 
-result = trace_code(
-    call,
-    storage=with_funcs,
-    source="tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6",
-    gas_limit=None,
+client = pytezos.using(
+    "http://localhost:11112",
+    key="edsk3RFfvaFaxbHx8BMtEW1rKQcPtDML3LXjNqMNLCzC3wLC1bWbAt",
 )
+checker_address = "KT1PwzHsf6FkA3EsRe7WrfMscNfer5krHQMd"
+checker = client.contract(checker_address)
 
-with open("test_trace.json", "w") as f:
-    json.dump(result, f)
+checker_bigmap_keys = scan_bigmap_keys(client, checker_address, end_after_blocks=5)
+storage = storage_with_bigmaps(checker, checker_bigmap_keys)
+
+pprint(storage)
+
+# # Create call to `default` entrypoint
+# call = checker.create_burrow((2, None)).with_amount(2_000_000)
 
 
-gas_trace = [int(t["gas"]) for t in result["trace"]]
-print(call.as_transaction().autofill().contents)
+# def trace_code(
+#     call: ContractCall,
+#     storage=None,
+#     source=None,
+#     sender=None,
+#     amount=None,
+#     balance=None,
+#     chain_id=None,
+#     gas_limit=None,
+# ):
+#     """Execute using RPC interpreter.
 
-print((1_040_000_000 - min(gas_trace)) / 1000)
+#     :param storage: initial storage as Python object, leave None if you want to generate a dummy one
+#     :param source: patch SOURCE
+#     :param sender: patch SENDER
+#     :param amount: patch AMOUNT
+#     :param balance: patch BALANCE
+#     :param chain_id: patch CHAIN_ID
+#     :param gas_limit: restrict max consumed gas
+#     :rtype: ContractCallResult
+#     """
+#     storage_ty = StorageSection.match(call.context.storage_expr)
+#     if storage is None:
+#         initial_storage = storage_ty.dummy(call.context).to_micheline_value(
+#             lazy_diff=True
+#         )
+#     else:
+#         initial_storage = storage_ty.from_python_object(storage).to_micheline_value(
+#             lazy_diff=True
+#         )
+#     script = [
+#         call.context.parameter_expr,
+#         call.context.storage_expr,
+#         call.context.code_expr,
+#     ]
+#     query = skip_nones(
+#         script=script,
+#         storage=initial_storage,
+#         entrypoint=call.parameters["entrypoint"],
+#         input=call.parameters["value"],
+#         amount=format_mutez(amount or call.amount),
+#         chain_id=chain_id or call.context.get_chain_id(),
+#         source=sender,
+#         payer=source,
+#         balance=str(balance or 0),
+#         gas=str(gas_limit) if gas_limit is not None else None,
+#     )
+#     res = call.shell.blocks[call.block_id].helpers.scripts.trace_code.post(query)
+#     # TODO: Add a contructor here for the trace_code output
+#     # ContractCallResult.from_run_code(res, parameters=call.parameters, context=call.context)
+#     return res
 
-# Node interpreter
-call.run_operation()
 
-print(result)
-# TODO: Can we get the gas used from this??
+# result = trace_code(
+#     call,
+#     storage=test,
+#     source="tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6",
+#     gas_limit=100_000_000,
+# )
+
+# with open("test_trace.json", "w") as f:
+#     json.dump(result, f)
+
+
+# gas_trace = [int(t["gas"]) for t in result["trace"]]
+# print(call.as_transaction().autofill().contents)
+
+# print((1_040_000_000 - min(gas_trace)) / 1000)
+
+# # Node interpreter
+# call.run_operation()
+
+# print(result)
+# # TODO: Can we get the gas used from this??


### PR DESCRIPTION
This PR includes some of the more generally-useful content from my exploration into gas costs.

Adds a utility module to `checker_client` which provides some helpers for working with big_maps in pytezos. Specifically this library has functions for identifying keys in a contract's big_maps by scanning a chain for diffs and a supplementary method for rendering the contract's storage with the full content of the big_map. This is useful in cases where you want to call RPCs such as `run_code`, which require you to pass the full storage state.
