### PR TITLE
Make liquidity use a scaling factor, and set the factor to 1_000_000

### DIFF
--- a/client/checker_client/checker.py
+++ b/client/checker_client/checker.py
@@ -46,7 +46,7 @@ def get_token_metadata_view_from_file(*, token_metadata_file: Optional[str], tok
 
     # insert the required metadata
     metadata["kit"]["decimals"] = token_info["kit_decimal_digits"]
-    metadata["liquidity"]["decimals"] = 0
+    metadata["liquidity"]["decimals"] = token_info["lqt_decimal_digits"]
 
     # convert the attributes to bytes
     for attrs in metadata.values():
@@ -66,7 +66,7 @@ def get_token_metadata_view_from_file(*, token_metadata_file: Optional[str], tok
     # create the TokenMetadata objects
     tokens = [
         TokenMetadata(token_info["kit_token_id"], metadata["kit"]),
-        TokenMetadata(token_info["liquidity_token_id"], metadata["liquidity"]),
+        TokenMetadata(token_info["lqt_token_id"], metadata["liquidity"]),
     ]
 
     # compile and return the view

--- a/docs/spec/functional_spec.rst
+++ b/docs/spec/functional_spec.rst
@@ -211,7 +211,7 @@ liquidity tokens.
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | kit           | nat                   | The amount of kit to supply as liquidity, in mukit                      |
 +---------------+-----------------------+-------------------------------------------------------------------------+
-| min_tokens    | nat                   | The minimum number of liquidity tokens expected to be bought            |
+| min_tokens    | nat                   | The minimum number of liquidity tokens expected to be bought, in mulqt  |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | deadline      | timestamp             | The deadline for the transaction to be valid                            |
 +---------------+-----------------------+-------------------------------------------------------------------------+
@@ -228,7 +228,7 @@ ratio.
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
 +===============+=======================+=========================================================================+
-| amount        | nat                   | The number of liquidity tokens to redeem                                |
+| amount        | nat                   | The number of liquidity tokens to redeem, in mulqt                      |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | ctez          | nat                   | The minimum amount of ctez expected, in muctez                          |
 +---------------+-----------------------+-------------------------------------------------------------------------+
@@ -368,7 +368,7 @@ Estimate yield when adding liquidity
 
 ``add_liquidity_min_lqt_minted : nat -> nat``
 
-Get the maximum amount of the liquidity token that can be expected for the given amount of ctez, based on the current market price
+Get the maximum amount of the liquidity token (in ``mulqt``) that can be expected for the given amount of ctez, based on the current market price
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
@@ -386,7 +386,7 @@ Get the maximum amount of ctez (in ``muctez``) that can be expected for the give
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
 +===============+=======================+=========================================================================+
-| liquidity     | nat                   | The amount of liquidity token                                           |
+| liquidity     | nat                   | The amount of liquidity token, in mulqt                                 |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 
 Estimate kit yield when removing liquidity
@@ -399,7 +399,7 @@ Get the maximum amount of kit (in ``mukit``) that can be expected for the given 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
 +===============+=======================+=========================================================================+
-| liquidity     | nat                   | The amount of liquidity token                                           |
+| liquidity     | nat                   | The amount of liquidity token, in mulqt                                 |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 
 

--- a/scripts/compile-ligo.rb
+++ b/scripts/compile-ligo.rb
@@ -133,8 +133,9 @@ stdout, stderr, exit_status = Open3.capture3(
   "--init-file", MAIN_FILE, "--michelson-format", "json",
   '''Map.literal
        [ ("kit_token_id", kit_token_id)
-       ; ("liquidity_token_id", liquidity_token_id)
+       ; ("lqt_token_id", lqt_token_id)
        ; ("kit_decimal_digits", kit_decimal_digits)
+       ; ("lqt_decimal_digits", lqt_decimal_digits)
        ]
   '''
 )

--- a/scripts/generate-entrypoints
+++ b/scripts/generate-entrypoints
@@ -25,12 +25,12 @@ puts <<EOF
 open CheckerTypes
 open Checker
 open Kit
+open Lqt
 open LiquidationAuctionTypes
 open LiquidationAuctionPrimitiveTypes
 open Ctez
 open Fa2Interface
 open Error
-open CfmmTypes
 
 EOF
 

--- a/scripts/generate-ligo.sh
+++ b/scripts/generate-ligo.sh
@@ -18,6 +18,7 @@ inputs=(
   fixedPoint
   ctez
   kit
+  lqt
   cfmmTypes
   fa2Interface
   liquidationAuctionPrimitiveTypes

--- a/src/cfmm.mli
+++ b/src/cfmm.mli
@@ -1,5 +1,6 @@
 open Ctez
 open Kit
+open Lqt
 open CfmmTypes
 
 (* The general concept of cfmm is that you have quantity a of an asset A
@@ -57,7 +58,7 @@ val cfmm_sell_kit :
 
 (** Compute the minimum [max_kit_deposited] and the maximum [min_lqt_minted]
     for [cfmm_add_liquidity] to succeed. *)
-val cfmm_view_max_kit_deposited_min_lqt_minted_cfmm_add_liquidity : cfmm -> ctez -> (liquidity * kit * cfmm)
+val cfmm_view_max_kit_deposited_min_lqt_minted_cfmm_add_liquidity : cfmm -> ctez -> (lqt * kit * cfmm)
 
 (** Buy some liquidity from the cfmm contract, by giving it some ctez and
     some kit. If the given amounts does not have the right ratio, we
@@ -78,13 +79,13 @@ val cfmm_add_liquidity :
   cfmm ->
   ctez (* amount *) ->
   kit (* max kit deposited *) ->
-  liquidity (* min lqt minted *) ->
+  lqt (* min lqt minted *) ->
   Ligo.timestamp (* deadline *) ->
-  (liquidity * kit * cfmm)
+  (lqt * kit * cfmm)
 
 (** Compute the maximum [min_ctez_withdrawn] and the minimum
     [min_kit_withdrawn] for [cfmm_remove_liquidity] to succeed. *)
-val cfmm_view_min_ctez_withdrawn_min_kit_withdrawn_cfmm_remove_liquidity : cfmm -> liquidity -> (ctez * kit * cfmm)
+val cfmm_view_min_ctez_withdrawn_min_kit_withdrawn_cfmm_remove_liquidity : cfmm -> lqt -> (ctez * kit * cfmm)
 
 (** Sell some liquidity to the cfmm contract. Selling liquidity always
     succeeds, but might leave the contract without ctez and kit if everybody
@@ -93,7 +94,7 @@ val cfmm_view_min_ctez_withdrawn_min_kit_withdrawn_cfmm_remove_liquidity : cfmm 
 *)
 val cfmm_remove_liquidity :
   cfmm ->
-  liquidity (* lqt burned *) ->
+  lqt (* lqt burned *) ->
   ctez (* min ctez withdrawn *) ->
   kit (* min kit withdrawn *) ->
   Ligo.timestamp (* deadline *) ->

--- a/src/cfmmTypes.ml
+++ b/src/cfmmTypes.ml
@@ -1,13 +1,12 @@
 open Ctez
 open Kit
+open Lqt
 open Ratio
-
-type liquidity = Ligo.nat
 
 type cfmm =
   { ctez: ctez;
     kit: kit;
-    lqt: Ligo.nat;
+    lqt: lqt;
     kit_in_ctez_in_prev_block: ratio [@printer pp_ratio];
     last_level: Ligo.nat;
   }
@@ -21,7 +20,7 @@ type cfmm =
 let initial_cfmm () : cfmm =
   { ctez = ctez_of_muctez (Ligo.nat_from_literal "1n");
     kit = kit_of_mukit (Ligo.nat_from_literal "1n");
-    lqt = Ligo.nat_from_literal "1n";
+    lqt = lqt_of_denomination (Ligo.nat_from_literal "1n");
     kit_in_ctez_in_prev_block = one_ratio; (* Same as ctez/kit now. *)
     last_level = !Ligo.Tezos.level;
   }

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -1,11 +1,11 @@
 open Ctez
 open Kit
+open Lqt
 open LiquidationAuctionTypes
 open LiquidationAuctionPrimitiveTypes
 open CheckerTypes
 open Fa12Interface
 open Fa2Interface
-open CfmmTypes
 
 (** Perform housekeeping tasks on the contract state. This includes:
     - Updating the system parameters
@@ -184,7 +184,7 @@ val entrypoint_sell_kit : checker * (kit * ctez * Ligo.timestamp) -> LigoOp.oper
     - The minimum number of liquidity tokens expected to be bought
     - The deadline for the transaction to be valid
 *)
-val entrypoint_add_liquidity : checker * (ctez * kit * Ligo.nat * Ligo.timestamp) -> LigoOp.operation list * checker
+val entrypoint_add_liquidity : checker * (ctez * kit * lqt * Ligo.timestamp) -> LigoOp.operation list * checker
 
 (** Sell some liquidity (liquidity tokens) to the cfmm contract in
     exchange for the corresponding ctez and kit of the right ratio.
@@ -195,7 +195,7 @@ val entrypoint_add_liquidity : checker * (ctez * kit * Ligo.nat * Ligo.timestamp
     - The minimum amount of kit expected to be bought
     - The deadline for the transaction to be valid
 *)
-val entrypoint_remove_liquidity : checker * (Ligo.nat * ctez * kit * Ligo.timestamp) -> (LigoOp.operation list * checker)
+val entrypoint_remove_liquidity : checker * (lqt * ctez * kit * Ligo.timestamp) -> (LigoOp.operation list * checker)
 
 (*****************************************************************************)
 (**                      {1 LIQUIDATION AUCTIONS}                            *)
@@ -253,9 +253,9 @@ val entrypoint_update_operators : checker * fa2_update_operator list -> LigoOp.o
 val view_buy_kit_min_kit_expected : (ctez * checker) -> kit
 val view_sell_kit_min_ctez_expected : (kit * checker) -> ctez
 val view_add_liquidity_max_kit_deposited : (ctez * checker) -> kit
-val view_add_liquidity_min_lqt_minted : (ctez * checker) -> liquidity
-val view_remove_liquidity_min_ctez_withdrawn : (liquidity * checker) -> ctez
-val view_remove_liquidity_min_kit_withdrawn : (liquidity * checker) -> kit
+val view_add_liquidity_min_lqt_minted : (ctez * checker) -> lqt
+val view_remove_liquidity_min_ctez_withdrawn : (lqt * checker) -> ctez
+val view_remove_liquidity_min_kit_withdrawn : (lqt * checker) -> kit
 
 val view_burrow_max_mintable_kit : (burrow_id * checker) -> kit
 val view_is_burrow_overburrowed : (burrow_id * checker) -> bool

--- a/src/dune
+++ b/src/dune
@@ -27,6 +27,7 @@
   Avl
   Ctez
   Kit
+  Lqt
   FixedPoint
   Parameters
   Burrow

--- a/src/fa2Interface.ml
+++ b/src/fa2Interface.ml
@@ -1,5 +1,5 @@
 open Kit
-open CfmmTypes
+open Lqt
 
 (*
  * INTERFACE
@@ -139,10 +139,10 @@ https://gitlab.com/tzip/tzip/-/blob/4b3c67aad5abbf04ec36caea4a1809e7b6e55bb8/pro
 *)
 
 let[@inline] kit_token_id = Ligo.nat_from_literal "0n"
-let[@inline] liquidity_token_id = Ligo.nat_from_literal "1n"
+let[@inline] lqt_token_id = Ligo.nat_from_literal "1n"
 
 let ensure_valid_fa2_token (n: fa2_token_id): unit =
-  if n = kit_token_id || n = liquidity_token_id
+  if n = kit_token_id || n = lqt_token_id
   then ()
   else failwith "FA2_TOKEN_UNDEFINED"
 
@@ -224,7 +224,7 @@ let[@inline] fa2_get_balance (st, owner, token_id: fa2_state * Ligo.address * fa
   get_fa2_ledger_value ledger key
 
 let[@inline] fa2_all_tokens : Ligo.nat list =
-  [ kit_token_id; liquidity_token_id ]
+  [ kit_token_id; lqt_token_id ]
 
 let[@inline] fa2_run_balance_of (st, xs: fa2_state * fa2_balance_of_request list)
   : fa2_balance_of_response list =
@@ -325,13 +325,13 @@ let[@inline] ledger_issue_then_withdraw_kit
     (st, addr, amnt_to_issue, amnt_to_withdraw: fa2_state * Ligo.address * kit * kit) : fa2_state =
   ledger_issue_then_withdraw (st, kit_token_id, addr, kit_to_mukit_nat amnt_to_issue, kit_to_mukit_nat amnt_to_withdraw)
 
-let[@inline] ledger_issue_liquidity
-    (st, addr, amnt: fa2_state * Ligo.address * liquidity) : fa2_state =
-  ledger_issue (st, liquidity_token_id, addr, amnt)
+let[@inline] ledger_issue_lqt
+    (st, addr, amnt: fa2_state * Ligo.address * lqt) : fa2_state =
+  ledger_issue (st, lqt_token_id, addr, lqt_to_denomination_nat amnt)
 
-let[@inline] ledger_withdraw_liquidity
-    (st, addr, amnt: fa2_state * Ligo.address * liquidity) : fa2_state =
-  ledger_withdraw (st, liquidity_token_id, addr, amnt)
+let[@inline] ledger_withdraw_lqt
+    (st, addr, amnt: fa2_state * Ligo.address * lqt) : fa2_state =
+  ledger_withdraw (st, lqt_token_id, addr, lqt_to_denomination_nat amnt)
 
 (* BEGIN_OCAML *)
 type fa2_balance_of_response_list = fa2_balance_of_response list
@@ -343,6 +343,6 @@ let fa2_get_token_balance (st: fa2_state) (token_id: fa2_token_id): Ligo.nat =
   |> List.map (fun ((_id, _owner), amnt) -> amnt)
   |> List.fold_left (fun x y -> Ligo.add_nat_nat x y) (Ligo.nat_from_literal "0n")
 
-let fa2_get_total_kit_balance (st: fa2_state) : Ligo.nat = fa2_get_token_balance st kit_token_id
-let fa2_get_total_lqt_balance (st: fa2_state) : Ligo.nat = fa2_get_token_balance st liquidity_token_id
+let fa2_get_total_kit_balance (st: fa2_state) : kit = kit_of_mukit (fa2_get_token_balance st kit_token_id)
+let fa2_get_total_lqt_balance (st: fa2_state) : lqt = lqt_of_denomination (fa2_get_token_balance st lqt_token_id)
 (* END_OCAML *)

--- a/src/lqt.ml
+++ b/src/lqt.ml
@@ -1,0 +1,57 @@
+open Common
+
+type lqt = Ligo.nat
+
+let[@inline] lqt_decimal_digits = Ligo.nat_from_literal "0n"
+let[@inline] lqt_scaling_factor_int = Ligo.int_from_literal "1"
+let[@inline] lqt_scaling_factor_nat = Ligo.nat_from_literal "1n"
+
+(* Basic arithmetic operations. *)
+let[@inline] lqt_add (x: lqt) (y: lqt) = Ligo.add_nat_nat x y
+let lqt_sub (x: lqt) (y: lqt) =
+  match Ligo.is_nat (Ligo.sub_nat_nat x y) with
+  | Some n -> n
+  | None -> (failwith "Lqt.lqt_sub: negative" : lqt)
+
+let[@inline] lqt_zero = Ligo.nat_from_literal "0n"
+let[@inline] lqt_one = lqt_scaling_factor_nat
+
+(* Conversions to/from other types. *)
+let[@inline] lqt_of_denomination (amnt: Ligo.nat) : lqt = amnt
+let[@inline] lqt_to_denomination_int (amnt: lqt) : Ligo.int = Ligo.int amnt
+let[@inline] lqt_to_denomination_nat (amnt: lqt) : Ligo.nat = amnt
+
+let lqt_of_fraction_ceil (x_num: Ligo.int) (x_den: Ligo.int) : lqt =
+  assert (Ligo.gt_int_int x_den (Ligo.int_from_literal "0"));
+  if Ligo.lt_int_int x_num (Ligo.int_from_literal "0")
+  then (failwith "Lqt.lqt_of_fraction_ceil: negative" : lqt)
+  else Ligo.abs (cdiv_int_int (Ligo.mul_int_int x_num lqt_scaling_factor_int) x_den)
+
+let lqt_of_fraction_floor (x_num: Ligo.int) (x_den: Ligo.int) : lqt =
+  assert (Ligo.gt_int_int x_den (Ligo.int_from_literal "0"));
+  if Ligo.lt_int_int x_num (Ligo.int_from_literal "0")
+  then (failwith "Lqt.lqt_of_fraction_floor: negative" : lqt)
+  else Ligo.abs (fdiv_int_int (Ligo.mul_int_int x_num lqt_scaling_factor_int) x_den)
+
+(* BEGIN_OCAML *)
+open Ratio
+let[@inline] lqt_to_ratio (amnt: lqt) : ratio = make_real_unsafe (Ligo.int amnt) lqt_scaling_factor_int
+
+let lqt_compare x y = compare_nat x y
+
+let show_lqt amnt =
+  let zfill s width = match Stdlib.(width - (String.length s)) with
+    | to_fill when to_fill <= 0 -> s
+    | to_fill -> (String.make to_fill '0') ^ s
+  in
+  let as_string =
+    if lqt_decimal_digits = Ligo.nat_from_literal "0n" then
+      Ligo.string_of_nat amnt
+    else
+      let d, r = Option.get (Ligo.ediv_nat_nat amnt lqt_scaling_factor_nat) in
+      let lqt_decimal_digits = Stdlib.int_of_string (Ligo.string_of_nat lqt_decimal_digits) in (* little hacky *)
+      (Ligo.string_of_nat d) ^ "." ^ zfill (Ligo.string_of_nat r) lqt_decimal_digits
+  in as_string ^ "lqt"
+
+let pp_lqt ppf amnt = Format.fprintf ppf "%s" (show_lqt amnt)
+(* END_OCAML *)

--- a/src/lqt.ml
+++ b/src/lqt.ml
@@ -2,9 +2,9 @@ open Common
 
 type lqt = Ligo.nat
 
-let[@inline] lqt_decimal_digits = Ligo.nat_from_literal "0n"
-let[@inline] lqt_scaling_factor_int = Ligo.int_from_literal "1"
-let[@inline] lqt_scaling_factor_nat = Ligo.nat_from_literal "1n"
+let[@inline] lqt_decimal_digits = Ligo.nat_from_literal "6n"
+let[@inline] lqt_scaling_factor_int = Ligo.int_from_literal "1_000_000"
+let[@inline] lqt_scaling_factor_nat = Ligo.nat_from_literal "1_000_000n"
 
 (* Basic arithmetic operations. *)
 let[@inline] lqt_add (x: lqt) (y: lqt) = Ligo.add_nat_nat x y

--- a/src/lqt.mli
+++ b/src/lqt.mli
@@ -1,0 +1,29 @@
+type lqt
+
+(* Basic operations. *)
+val lqt_add : lqt -> lqt -> lqt
+val lqt_sub : lqt -> lqt -> lqt
+
+val lqt_zero : lqt
+val lqt_one : lqt
+
+val lqt_decimal_digits : Ligo.nat
+val lqt_scaling_factor_int : Ligo.int
+val lqt_scaling_factor_nat : Ligo.nat
+
+(* Conversions to/from other types. *)
+val lqt_of_denomination : Ligo.nat -> lqt
+val lqt_to_denomination_int : lqt -> Ligo.int
+val lqt_to_denomination_nat : lqt -> Ligo.nat
+
+val lqt_of_fraction_ceil : Ligo.int -> Ligo.int -> lqt
+val lqt_of_fraction_floor : Ligo.int -> Ligo.int -> lqt
+
+(* BEGIN_OCAML *)
+val lqt_compare : lqt -> lqt -> int
+
+val lqt_to_ratio : lqt -> Ratio.ratio
+
+val pp_lqt : Format.formatter -> lqt -> unit
+val show_lqt : lqt -> string
+(* END_OCAML *)

--- a/tests/dune
+++ b/tests/dune
@@ -8,6 +8,7 @@
   TestFixedPoint
   TestTez
   TestKit
+  TestLqt
   TestParameters
   TestLiquidation
   TestCfmm

--- a/tests/testArbitrary.ml
+++ b/tests/testArbitrary.ml
@@ -1,5 +1,6 @@
 open Ctez
 open Kit
+open Lqt
 
 let arb_tez = QCheck.map (fun x -> Ligo.tez_from_literal ((string_of_int x) ^ "mutez")) QCheck.(0 -- max_int)
 
@@ -17,6 +18,9 @@ let arb_small_tez =
 
 let arb_kit = QCheck.map (fun x -> kit_of_mukit (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(0 -- max_int)
 let arb_positive_kit = QCheck.map (fun x -> kit_of_mukit (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(1 -- max_int)
+
+let arb_lqt = QCheck.map (fun x -> lqt_of_denomination (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(0 -- max_int)
+let arb_positive_lqt = QCheck.map (fun x -> lqt_of_denomination (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(1 -- max_int)
 
 let arb_nat = QCheck.map (fun x -> Ligo.nat_from_literal ((string_of_int x) ^ "n")) QCheck.(0 -- max_int)
 

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -1,5 +1,6 @@
 open Ctez
 open Kit
+open Lqt
 open Burrow
 open OUnit2
 open TestCommon
@@ -31,17 +32,14 @@ let _ = Checker.assert_checker_invariants empty_checker
 (* Enhance the initial checker state with a populated cfmm in a consistent way. *)
 let empty_checker_with_cfmm (cfmm: CfmmTypes.cfmm) =
   let checker_kit = kit_sub cfmm.kit (kit_of_mukit (Ligo.nat_from_literal "1n")) in
-  let checker_liquidity =
-    match Ligo.is_nat (Ligo.sub_nat_nat cfmm.lqt (Ligo.nat_from_literal "1n")) with
-    | None -> failwith "empty_checker_with_cfmm: cfmm with zero liquidity in it"
-    | Some lqt -> lqt in
+  let checker_liquidity = lqt_sub cfmm.lqt (lqt_of_denomination (Ligo.nat_from_literal "1n")) in
   let checker =
     { empty_checker with
       parameters = { empty_checker.parameters with circulating_kit = checker_kit };
       cfmm = cfmm;
       fa2_state =
         let fa2_state = initial_fa2_state in
-        let fa2_state = ledger_issue_liquidity (fa2_state, !Ligo.Tezos.self_address, checker_liquidity) in
+        let fa2_state = ledger_issue_lqt (fa2_state, !Ligo.Tezos.self_address, checker_liquidity) in
         let fa2_state = ledger_issue_kit (fa2_state, !Ligo.Tezos.self_address, checker_kit) in
         fa2_state;
     } in
@@ -614,7 +612,7 @@ let suite =
              { empty_checker.cfmm with
                ctez = ctez_of_muctez (Ligo.nat_from_literal "2n");
                kit = kit_of_mukit (Ligo.nat_from_literal "2n");
-               lqt = Ligo.nat_from_literal "1n";
+               lqt = lqt_of_denomination (Ligo.nat_from_literal "1n");
              } in
          { checker with
            parameters =
@@ -653,7 +651,7 @@ let suite =
 
        let min_kit_expected = kit_of_mukit (Ligo.nat_from_literal "1n") in
        let min_ctez_expected = ctez_of_muctez (Ligo.nat_from_literal "1n") in
-       let my_liquidity_tokens = Ligo.nat_from_literal "1n" in
+       let my_liquidity_tokens = lqt_of_denomination (Ligo.nat_from_literal "1n") in
        let sender = alice_addr in
 
        (* Populate the cfmm with some liquidity (carefully crafted) *)
@@ -664,11 +662,11 @@ let suite =
              { empty_checker.cfmm with
                ctez = ctez_of_muctez (Ligo.nat_from_literal "2n");
                kit = kit_of_mukit (Ligo.nat_from_literal "2n");
-               lqt = Ligo.nat_from_literal "2n";
+               lqt = lqt_of_denomination (Ligo.nat_from_literal "2n");
              };
            fa2_state =
              let fa2_state = initial_fa2_state in
-             let fa2_state = ledger_issue_liquidity (fa2_state, sender, my_liquidity_tokens) in
+             let fa2_state = ledger_issue_lqt (fa2_state, sender, my_liquidity_tokens) in
              let fa2_state = ledger_issue_kit (fa2_state, !Ligo.Tezos.self_address, kit_of_mukit (Ligo.nat_from_literal "1n")) in
              fa2_state;
          } in
@@ -696,7 +694,7 @@ let suite =
        Ligo.Tezos.reset ();
        let min_kit_expected = kit_of_mukit (Ligo.nat_from_literal "1n") in
        let min_ctez_expected = ctez_of_muctez (Ligo.nat_from_literal "1n") in
-       let my_liquidity_tokens = Ligo.nat_from_literal "1n" in
+       let my_liquidity_tokens = lqt_of_denomination (Ligo.nat_from_literal "1n") in
 
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "1mutez");
        assert_raises
@@ -763,7 +761,7 @@ let suite =
            ( checker
            , ( ctez_of_muctez (Ligo.nat_from_literal "1_000_000n")
              , kit_one
-             , Ligo.nat_from_literal "1n"
+             , lqt_of_denomination (Ligo.nat_from_literal "1n")
              , Ligo.timestamp_from_seconds_literal 1
              )
            ) in (* barely on time *)

--- a/tests/testCommon.ml
+++ b/tests/testCommon.ml
@@ -7,6 +7,7 @@ let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
 
 let assert_nat_equal ~expected:expected ~real:real = OUnit2.assert_equal ~printer:Ligo.string_of_nat expected real
 let assert_kit_equal ~expected:expected ~real:real = OUnit2.assert_equal ~printer:Kit.show_kit expected real
+let assert_lqt_equal ~expected:expected ~real:real = OUnit2.assert_equal ~printer:Lqt.show_lqt expected real
 
 let cfmm_make_for_test ~ctez ~kit ~lqt ~kit_in_ctez_in_prev_block ~last_level =
   { CfmmTypes.ctez = ctez;
@@ -16,16 +17,13 @@ let cfmm_make_for_test ~ctez ~kit ~lqt ~kit_in_ctez_in_prev_block ~last_level =
     CfmmTypes.last_level = last_level;
   }
 
-(* Issue an arbitrary number of liquidity tokens (checker-issued) *)
-let arb_liquidity = QCheck.map (fun x -> Ligo.abs (Ligo.int_from_literal (string_of_int x))) QCheck.(0 -- max_int)
-
 (* Create an arbitrary state for the cfmm contract (NB: some values are fixed). *)
 let arbitrary_non_empty_cfmm (kit_in_ctez_in_prev_block: Ratio.ratio) (last_level: Ligo.nat) =
   QCheck.map
     (fun (ctez, kit, lqt) ->
        (ctez, kit, lqt, cfmm_make_for_test ~ctez ~kit ~lqt ~kit_in_ctez_in_prev_block ~last_level)
     )
-    (QCheck.triple TestArbitrary.arb_positive_ctez TestArbitrary.arb_positive_kit arb_liquidity)
+    (QCheck.triple TestArbitrary.arb_positive_ctez TestArbitrary.arb_positive_kit TestArbitrary.arb_lqt)
 
 (* amount >= cfmm_tez * (1 - fee) / fee *)
 (* 1mukit <= min_kit_expected < FLOOR{amount * (cfmm_kit / (cfmm_tez + amount)) * FACTOR} *)

--- a/tests/testLqt.ml
+++ b/tests/testLqt.ml
@@ -34,7 +34,7 @@ let suite =
        (* show *)
        assert_equal
          ~printer:(fun x -> x)
-         "50309951lqt"
+         "50.309951lqt"
          (show_lqt (lqt_of_denomination (Ligo.nat_from_literal "50_309_951n")));
     )
   ]

--- a/tests/testLqt.ml
+++ b/tests/testLqt.ml
@@ -1,0 +1,40 @@
+open OUnit2
+open Lqt
+open TestCommon
+
+let suite =
+  "LqtTests" >::: [
+    "lqt arithmetic" >::
+    (fun _ ->
+       (* scaling factor (int) *)
+       assert_equal ~printer:Ligo.string_of_int
+         (Common.pow_int_nat (Ligo.int_from_literal "10") lqt_decimal_digits)
+         lqt_scaling_factor_int;
+
+       (* scaling factor (nat) *)
+       assert_equal ~printer:Ligo.string_of_int
+         lqt_scaling_factor_int
+         (Ligo.int lqt_scaling_factor_nat);
+
+       (* add *)
+       assert_lqt_equal
+         ~expected:(lqt_of_denomination (Ligo.nat_from_literal "8_000_000n"))
+         ~real:(lqt_add (lqt_of_denomination (Ligo.nat_from_literal "5_000_000n")) (lqt_of_denomination (Ligo.nat_from_literal "3_000_000n")));
+
+       (* subtract *)
+       assert_lqt_equal
+         ~expected:(lqt_of_denomination (Ligo.nat_from_literal "2_000_000n"))
+         ~real:(lqt_sub (lqt_of_denomination (Ligo.nat_from_literal "5_000_000n")) (lqt_of_denomination (Ligo.nat_from_literal "3_000_000n")));
+
+       (* compare *)
+       assert_lqt_equal
+         ~expected:(lqt_of_denomination (Ligo.nat_from_literal "5_000_000n"))
+         ~real:(max (lqt_of_denomination (Ligo.nat_from_literal "5_000_000n")) (lqt_of_denomination (Ligo.nat_from_literal "3_000_000n")));
+
+       (* show *)
+       assert_equal
+         ~printer:(fun x -> x)
+         "50309951lqt"
+         (show_lqt (lqt_of_denomination (Ligo.nat_from_literal "50_309_951n")));
+    )
+  ]

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -7,6 +7,7 @@ let suite =
     TestFixedPoint.suite;
     TestTez.suite;
     TestKit.suite;
+    TestLqt.suite;
     TestBurrow.suite;
     TestParameters.suite;
     TestCfmm.suite;


### PR DESCRIPTION
Fixes #146.

First changed the codebase so that liquidity uses a scaling
factor (also made it opaque), and then updated the scaling
factor to 1_000_000. Apart from the show instance test,
no test broke, since we compute no prices using liquidity
in the codebase.

Also exposed `lqt_decimal_digits` as metadata; I hope I
didn't miss anything on the deployment side of things or the
functional spec.
