### PR TITLE
Long overdue fiddling in the tests folder

### DIFF
--- a/tests/testAvl.ml
+++ b/tests/testAvl.ml
@@ -142,7 +142,7 @@ let suite =
        let (mem, _) = avl_push mem root (mk_liquidation_slice 0) Right in
        let actual = avl_to_list mem root in
        let expected = [mk_liquidation_slice 0] in
-       assert_equal expected actual);
+       assert_equal expected actual ~printer:show_liquidation_slice_list);
 
     "test_from_list" >::
     (fun _ ->
@@ -182,9 +182,9 @@ let suite =
        let (mem, root) = avl_mk_empty mem_empty None in
        let (mem, elem) = avl_push mem root (mk_liquidation_slice 1) Left in
        let (mem, root_) = avl_del mem elem in
-       assert_equal root root_;
-       assert_equal [] (avl_to_list mem root);
-       assert_equal 1 (List.length (Mem.mem_bindings mem))
+       assert_equal root root_ ~printer:show_avl_ptr;
+       assert_equal [] (avl_to_list mem root) ~printer:show_liquidation_slice_list;
+       assert_equal 1 (List.length (Mem.mem_bindings mem)) ~printer:string_of_int;
     );
 
     "test_del" >::
@@ -203,7 +203,7 @@ let suite =
        avl_assert_dangling_pointers mem [root];
 
        let (mem, root_) = avl_del mem elem in
-       assert_equal root root_;
+       assert_equal root root_ ~printer:show_avl_ptr;
 
        assert_avl_invariants mem root;
        avl_assert_dangling_pointers mem [root];
@@ -218,7 +218,7 @@ let suite =
        let (mem, root) = avl_from_list mem_empty None elements in
        let actual = avl_to_list mem root in
        let expected = [] in
-       assert_equal expected actual);
+       assert_equal expected actual ~printer:show_liquidation_slice_list);
 
     (qcheck_to_ounit
      @@ QCheck.Test.make ~name:"prop_from_list_to_list" ~count:property_test_count (QCheck.list TestArbitrary.arb_liquidation_slice)
@@ -248,7 +248,7 @@ let suite =
      assert_avl_invariants mem root;
 
      let (mem, root_) = avl_del mem to_del in
-     assert_equal root root_;
+     assert_equal root root_ ~printer:show_avl_ptr;
      (*
      printf "- %s %s %s ----------\n"
        (show_liquidation_slice_list left_items)
@@ -310,15 +310,9 @@ let suite =
 
      let (expected_left, expected_right) = split_list limit xs in
 
-     assert_equal
-       expected_left
-       actual_left
-       ~printer:show_liquidation_slice_list;
+     assert_equal expected_left actual_left ~printer:show_liquidation_slice_list;
 
-     assert_equal
-       expected_right
-       actual_right
-       ~printer:show_liquidation_slice_list;
+     assert_equal expected_right actual_right ~printer:show_liquidation_slice_list;
 
      true
     );
@@ -370,7 +364,7 @@ let suite =
            let (mem, root) = avl_from_list mem_empty None xs in
            assert_avl_invariants mem root;
            let actual = avl_to_list mem root in
-           assert_equal actual xs
+           assert_equal xs actual ~printer:show_liquidation_slice_list
          )
     );
   ]

--- a/tests/testAvl.ml
+++ b/tests/testAvl.ml
@@ -362,7 +362,7 @@ let suite =
            let (mem, root) = avl_from_list mem_empty None xs in
            assert_avl_invariants mem root;
            let actual = avl_to_list mem root in
-           assert_liquidation_slice_list_equal ~expected:xs ~real:actual
+           assert_equal xs actual
          )
     );
   ]

--- a/tests/testAvlModel.ml
+++ b/tests/testAvlModel.ml
@@ -20,6 +20,7 @@ type queue_op =
   | Take of Ligo.tez
 [@@deriving show]
 
+type slice_option = liquidation_slice option [@@deriving show]
 type liquidation_slice_list = liquidation_slice list [@@deriving show]
 
 (* ========================================================================= *)
@@ -178,7 +179,7 @@ let apply_op ((impl: Mem.mem * avl_ptr), (model: model)) op =
       | None -> None
       | Some (_, slice) -> Some slice
     in
-    let _ = assert_equal popped_model popped_impl in
+    assert_equal popped_model popped_impl ~printer:show_slice_option;
     (mem, root_ptr), model
 
   | Get p ->
@@ -237,10 +238,10 @@ let suite =
             let applied = apply_op acc op in
             let impl, model = applied in
             let impl_elements, model_elements = get_all_elements impl model in
-            let _ = assert_equal
-                ~msg:"Items in implementation queue did not match items in model queue."
-                ~printer:show_liquidation_slice_list
-                model_elements impl_elements in
+            assert_equal
+              ~msg:"Items in implementation queue did not match items in model queue."
+              ~printer:show_liquidation_slice_list
+              model_elements impl_elements;
             let _ = Avl.assert_avl_invariants (fst impl) (snd impl) in
             applied
         ) acc ops in

--- a/tests/testAvlModel.ml
+++ b/tests/testAvlModel.ml
@@ -4,6 +4,7 @@
 open OUnit2
 open Core_kernel.Deque
 open LiquidationAuctionPrimitiveTypes
+open TestCommon
 
 type queue_op =
   (* Place new element in back *)
@@ -21,7 +22,6 @@ type queue_op =
 [@@deriving show]
 
 type slice_option = liquidation_slice option [@@deriving show]
-type liquidation_slice_list = liquidation_slice list [@@deriving show]
 
 (* ========================================================================= *)
 (* Random inputs for QCheck *)
@@ -38,7 +38,7 @@ let slice_gen = QCheck.Gen.(
     map (fun (tez, kit) ->
         let contents = {
           (* TODO: Use arbitrary addresses as well? *)
-          burrow=(TestCommon.alice_addr, Ligo.nat_from_literal "0n");
+          burrow=(alice_addr, Ligo.nat_from_literal "0n");
           tez=tez;
           min_kit_for_unwarranted=Some kit;
         } in
@@ -179,7 +179,7 @@ let apply_op ((impl: Mem.mem * avl_ptr), (model: model)) op =
       | None -> None
       | Some (_, slice) -> Some slice
     in
-    assert_equal popped_model popped_impl ~printer:show_slice_option;
+    assert_slice_option_equal ~expected:popped_model ~real:popped_impl;
     (mem, root_ptr), model
 
   | Get p ->
@@ -213,7 +213,7 @@ let apply_op ((impl: Mem.mem * avl_ptr), (model: model)) op =
     let new_mem, split_ptr = Avl.avl_take mem root_ptr tez_limit None in
     (* Take slices from front of implementation *)
     let slices_impl = avl_foldl (new_mem, split_ptr) [] (fun acc e -> List.append acc [e]) in
-    let _ = assert_equal slices_model slices_impl ~printer:show_liquidation_slice_list in
+    assert_liquidation_slice_list_equal ~expected:slices_model ~real:slices_impl;
     (new_mem, root_ptr), model
 
 let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
@@ -238,10 +238,10 @@ let suite =
             let applied = apply_op acc op in
             let impl, model = applied in
             let impl_elements, model_elements = get_all_elements impl model in
-            assert_equal
-              ~msg:"Items in implementation queue did not match items in model queue."
-              ~printer:show_liquidation_slice_list
-              model_elements impl_elements;
+            (* Items in implementation queue must match items in model queue. *)
+            assert_liquidation_slice_list_equal
+              ~expected:model_elements
+              ~real:impl_elements;
             let _ = Avl.assert_avl_invariants (fst impl) (snd impl) in
             applied
         ) acc ops in

--- a/tests/testBurrow.ml
+++ b/tests/testBurrow.ml
@@ -55,8 +55,8 @@ let suite =
            (kit_of_mukit (Ligo.nat_from_literal "1n"))
            burrow0 in
 
-       assert_equal ~printer:show_kit kit_zero (Burrow.burrow_outstanding_kit burrow);
-       assert_equal ~printer:show_kit kit_zero (Burrow.burrow_excess_kit burrow)
+       assert_kit_equal ~expected:kit_zero ~real:(Burrow.burrow_outstanding_kit burrow);
+       assert_kit_equal ~expected:kit_zero ~real:(Burrow.burrow_excess_kit burrow)
     );
 
     ("burrow_burn_kit - burning greater than outstanding_kit returns burrow with expected excess and outstanding kit" >::
@@ -71,8 +71,8 @@ let suite =
            (kit_of_mukit (Ligo.nat_from_literal "2n"))
            burrow0 in
 
-       assert_equal ~printer:show_kit kit_zero (Burrow.burrow_outstanding_kit burrow);
-       assert_equal ~printer:show_kit (kit_of_mukit (Ligo.nat_from_literal "1n")) (Burrow.burrow_excess_kit burrow)
+       assert_kit_equal ~expected:kit_zero ~real:(Burrow.burrow_outstanding_kit burrow);
+       assert_kit_equal ~expected:(kit_of_mukit (Ligo.nat_from_literal "1n")) ~real:(Burrow.burrow_excess_kit burrow)
     );
 
     ("burrow_burn_kit - burning less than outstanding_kit returns burrow with expected excess and outstanding kit" >::
@@ -87,8 +87,8 @@ let suite =
            (kit_of_mukit (Ligo.nat_from_literal "1n"))
            burrow0 in
 
-       assert_equal ~printer:show_kit (kit_of_mukit (Ligo.nat_from_literal "1n")) (Burrow.burrow_outstanding_kit burrow);
-       assert_equal ~printer:show_kit kit_zero (Burrow.burrow_excess_kit burrow)
+       assert_kit_equal ~expected:(kit_of_mukit (Ligo.nat_from_literal "1n")) ~real:(Burrow.burrow_outstanding_kit burrow);
+       assert_kit_equal ~expected:kit_zero ~real:(Burrow.burrow_excess_kit burrow)
     );
 
     ("burrow_burn_kit - burning zero kit returns burrow with expected excess and outstanding kit" >::
@@ -103,8 +103,8 @@ let suite =
            kit_zero
            burrow0 in
 
-       assert_equal ~printer:show_kit (kit_of_mukit (Ligo.nat_from_literal "1n")) (Burrow.burrow_outstanding_kit burrow);
-       assert_equal ~printer:show_kit kit_zero (Burrow.burrow_excess_kit burrow)
+       assert_kit_equal ~expected:(kit_of_mukit (Ligo.nat_from_literal "1n")) ~real:(Burrow.burrow_outstanding_kit burrow);
+       assert_kit_equal ~expected:kit_zero ~real:(Burrow.burrow_excess_kit burrow)
     );
 
     ("burrow_burn_kit - does not change burrow address" >::
@@ -116,10 +116,9 @@ let suite =
 
        let burrow = Burrow.burrow_burn_kit Parameters.initial_parameters (kit_of_mukit (Ligo.nat_from_literal "1n")) burrow0 in
 
-       assert_equal
-         ~printer:Ligo.string_of_address
-         (Burrow.burrow_address burrow0)
-         (Burrow.burrow_address burrow)
+       assert_address_equal
+         ~expected:(Burrow.burrow_address burrow0)
+         ~real:(Burrow.burrow_address burrow)
     );
 
     ("burrow_set_delegate - fails for a burrow which needs to be touched" >::
@@ -143,10 +142,9 @@ let suite =
 
        let burrow = Burrow.burrow_set_delegate Parameters.initial_parameters (Some charles_key_hash) burrow0 in
 
-       assert_equal
-         ~printer:Ligo.string_of_address
-         (Burrow.burrow_address burrow0)
-         (Burrow.burrow_address burrow)
+       assert_address_equal
+         ~expected:(Burrow.burrow_address burrow0)
+         ~real:(Burrow.burrow_address burrow)
     );
 
     ("burrow_is_overburrowed - fails for a burrow which needs to be touched" >::
@@ -184,14 +182,12 @@ let suite =
            (Ligo.tez_from_literal "1mutez")
            burrow0 in
 
-       assert_equal
-         ~printer:Ligo.string_of_tez
-         (Ligo.tez_from_literal "101mutez")
-         (Burrow.burrow_collateral burrow);
-       assert_equal
-         ~printer:show_kit
-         kit_zero
-         (Burrow.burrow_excess_kit burrow)
+       assert_tez_equal
+         ~expected:(Ligo.tez_from_literal "101mutez")
+         ~real:(Burrow.burrow_collateral burrow);
+       assert_kit_equal
+         ~expected:kit_zero
+         ~real:(Burrow.burrow_excess_kit burrow)
     );
 
     ("burrow_deposit_tez - does not change burrow address" >::
@@ -203,10 +199,9 @@ let suite =
 
        let burrow = Burrow.burrow_deposit_tez Parameters.initial_parameters (Ligo.tez_from_literal "1mutez") burrow0 in
 
-       assert_equal
-         ~printer:Ligo.string_of_address
-         (Burrow.burrow_address burrow0)
-         (Burrow.burrow_address  burrow)
+       assert_address_equal
+         ~expected:(Burrow.burrow_address burrow0)
+         ~real:(Burrow.burrow_address  burrow)
     );
 
     ("burrow_withdraw_tez - fails for a burrow which needs to be touched" >::
@@ -233,10 +228,9 @@ let suite =
            (Ligo.tez_from_literal "1mutez")
            burrow0 in
 
-       assert_equal
-         ~printer:Ligo.string_of_tez
-         (Ligo.tez_from_literal "99mutez")
-         (Burrow.burrow_collateral burrow)
+       assert_tez_equal
+         ~expected:(Ligo.tez_from_literal "99mutez")
+         ~real:(Burrow.burrow_collateral burrow)
     );
 
     ("burrow_withdraw_tez - does not change burrow address" >::
@@ -248,10 +242,9 @@ let suite =
 
        let burrow = Burrow.burrow_withdraw_tez Parameters.initial_parameters (Ligo.tez_from_literal "1mutez") burrow0 in
 
-       assert_equal
-         ~printer:Ligo.string_of_address
-         (Burrow.burrow_address burrow0)
-         (Burrow.burrow_address  burrow)
+       assert_address_equal
+         ~expected:(Burrow.burrow_address burrow0)
+         ~real:(Burrow.burrow_address  burrow)
     );
 
     ("burrow_mint_kit - burrow after successful minting has expected collateral" >::
@@ -266,10 +259,9 @@ let suite =
            (kit_of_mukit (Ligo.nat_from_literal "1n"))
            burrow0 in
 
-       assert_equal
-         ~printer:show_kit
-         (kit_of_mukit (Ligo.nat_from_literal "2n"))
-         (Burrow.burrow_outstanding_kit burrow)
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "2n"))
+         ~real:(Burrow.burrow_outstanding_kit burrow)
     );
 
     ("burrow_mint_kit - fails for a burrow which needs to be touched" >::
@@ -293,10 +285,9 @@ let suite =
 
        let burrow = Burrow.burrow_mint_kit Parameters.initial_parameters (kit_of_mukit (Ligo.nat_from_literal "1n")) burrow0 in
 
-       assert_equal
-         ~printer:Ligo.string_of_address
-         (Burrow.burrow_address burrow0)
-         (Burrow.burrow_address  burrow)
+       assert_address_equal
+         ~expected:(Burrow.burrow_address burrow0)
+         ~real:(Burrow.burrow_address  burrow)
     );
 
     ("burrow_mint_kit - minting burrow_max_mintable_kit succeeds" >::
@@ -309,10 +300,9 @@ let suite =
        let burrow_max_mintable_kit = Burrow.burrow_max_mintable_kit Parameters.initial_parameters burrow0 in
        let burrow = Burrow.burrow_mint_kit Parameters.initial_parameters burrow_max_mintable_kit burrow0 in
 
-       assert_equal
-         ~printer:show_kit
-         burrow_max_mintable_kit
-         (Burrow.burrow_outstanding_kit burrow)
+       assert_kit_equal
+         ~expected:burrow_max_mintable_kit
+         ~real:(Burrow.burrow_outstanding_kit burrow)
     );
 
     ("burrow_mint_kit - minting more than burrow_max_mintable_kit fails" >::
@@ -398,10 +388,9 @@ let suite =
 
        let burrow = Burrow.burrow_activate Parameters.initial_parameters Constants.creation_deposit burrow0 in
 
-       assert_equal
-         ~printer:Ligo.string_of_address
-         (Burrow.burrow_address burrow0)
-         (Burrow.burrow_address  burrow)
+       assert_address_equal
+         ~expected:(Burrow.burrow_address burrow0)
+         ~real:(Burrow.burrow_address  burrow)
     );
 
     ("burrow_deactivate - fails for a burrow which needs to be touched" >::
@@ -491,10 +480,9 @@ let suite =
 
        let burrow, _ = Burrow.burrow_deactivate Parameters.initial_parameters burrow0 in
 
-       assert_equal
-         ~printer:Ligo.string_of_address
-         (Burrow.burrow_address burrow0)
-         (Burrow.burrow_address  burrow)
+       assert_address_equal
+         ~expected:(Burrow.burrow_address burrow0)
+         ~real:(Burrow.burrow_address  burrow)
     );
 
     ("burrow_is_liquidatable - fails for a burrow which needs to be touched" >::
@@ -536,10 +524,9 @@ let suite =
      fun _ ->
        let burrow = Burrow.burrow_create Parameters.initial_parameters burrow_addr Constants.creation_deposit None in
 
-       assert_equal
-         ~printer:Ligo.string_of_address
-         burrow_addr
-         (Burrow.burrow_address burrow)
+       assert_address_equal
+         ~expected:burrow_addr
+         ~real:(Burrow.burrow_address burrow)
 
     );
 
@@ -556,10 +543,9 @@ let suite =
 
        let burrow = Burrow.burrow_touch parameters burrow0 in
 
-       assert_equal
-         ~printer:Ligo.string_of_address
-         (Burrow.burrow_address burrow0)
-         (Burrow.burrow_address  burrow)
+       assert_address_equal
+         ~expected:(Burrow.burrow_address burrow0)
+         ~real:(Burrow.burrow_address  burrow)
     );
 
     ("burrow_return_kit_from_auction - does not change burrow address" >::
@@ -582,10 +568,9 @@ let suite =
 
        let burrow = Burrow.burrow_return_kit_from_auction slice (kit_of_mukit (Ligo.nat_from_literal "1n")) burrow0 in
 
-       assert_equal
-         ~printer:Ligo.string_of_address
-         (Burrow.burrow_address burrow0)
-         (Burrow.burrow_address  burrow)
+       assert_address_equal
+         ~expected:(Burrow.burrow_address burrow0)
+         ~real:(Burrow.burrow_address  burrow)
     );
 
     ("burrow_return_slice_from_auction - does not change burrow address" >::
@@ -608,10 +593,9 @@ let suite =
 
        let burrow = Burrow.burrow_return_slice_from_auction slice burrow0 in
 
-       assert_equal
-         ~printer:Ligo.string_of_address
-         (Burrow.burrow_address burrow0)
-         (Burrow.burrow_address  burrow)
+       assert_address_equal
+         ~expected:(Burrow.burrow_address burrow0)
+         ~real:(Burrow.burrow_address  burrow)
     );
 
     (* This is a bit of an odd test but it ensures that the math in compute_tez_to_auction
@@ -769,10 +753,9 @@ let suite =
           tez_to_deposit
           burrow0 in
 
-      assert_equal
-        ~printer:Ligo.string_of_tez
-        (Ligo.add_tez_tez (Burrow.burrow_collateral burrow0) tez_to_deposit)
-        (Burrow.burrow_collateral burrow);
+      assert_tez_equal
+        ~expected:(Ligo.add_tez_tez (Burrow.burrow_collateral burrow0) tez_to_deposit)
+        ~real:(Burrow.burrow_collateral burrow);
       true
     );
 
@@ -792,14 +775,12 @@ let suite =
           Parameters.initial_parameters
           burrow0 in
 
-      assert_equal
-        ~printer:Ligo.string_of_tez
-        (Ligo.tez_from_literal ("0mutez"))
-        (Burrow.burrow_collateral burrow);
-      assert_equal
-        ~printer:Ligo.string_of_tez
-        (Ligo.add_tez_tez Constants.creation_deposit collateral_balance_tez)
-        returned_tez;
+      assert_tez_equal
+        ~expected:(Ligo.tez_from_literal ("0mutez"))
+        ~real:(Burrow.burrow_collateral burrow);
+      assert_tez_equal
+        ~expected:(Ligo.add_tez_tez Constants.creation_deposit collateral_balance_tez)
+        ~real:returned_tez;
       true
     );
 
@@ -822,10 +803,9 @@ let suite =
       (* Reactivate it with the tez returned from deactivating it *)
       let burrow = Burrow.burrow_activate Parameters.initial_parameters tez deactivated_burrow in
 
-      assert_equal
-        ~printer:Ligo.string_of_tez
-        starting_collateral
-        (Burrow.burrow_collateral burrow);
+      assert_tez_equal
+        ~expected:starting_collateral
+        ~real:(Burrow.burrow_collateral burrow);
       true
     );
 

--- a/tests/testCfmm.ml
+++ b/tests/testCfmm.ml
@@ -23,13 +23,6 @@ let cfmm_kit_times_ctez (u: cfmm) =
 (* Reveal the current number of liquidity tokens extant. *)
 let cfmm_liquidity_tokens_extant (u: cfmm) = u.lqt
 
-let eq_cfmm (u1: cfmm) (u2: cfmm) : bool =
-  ctez_compare u1.ctez u2.ctez = 0
-  && kit_compare u1.kit u2.kit = 0
-  && lqt_compare u1.lqt u2.lqt = 0
-  && eq_ratio_ratio u1.kit_in_ctez_in_prev_block u2.kit_in_ctez_in_prev_block
-  && Ligo.eq_nat_nat u1.last_level u2.last_level
-
 (* amount > 0xtz *)
 (* max_kit_deposited = CEIL{kit * amount / ctez} *)
 (* min_lqt_minted = FLOOR{lqt * amount / ctez} *)
@@ -230,8 +223,8 @@ let buy_kit_unit_test =
         (ctez_of_muctez (Ligo.nat_from_literal "1_000_000n"))
         (kit_of_mukit (Ligo.nat_from_literal "1n"))
         (Ligo.timestamp_from_seconds_literal 10) in
-    assert_equal ~printer:show_kit expected_returned_kit returned_kit;
-    assert_equal ~printer:show_cfmm ~cmp:eq_cfmm expected_updated_cfmm updated_cfmm;
+    assert_kit_equal ~expected:expected_returned_kit ~real:returned_kit;
+    assert_cfmm_equal ~expected:expected_updated_cfmm ~real:updated_cfmm;
 
     (* Low expectations and on time (tight): pass *)
     Ligo.Tezos.reset ();
@@ -242,8 +235,8 @@ let buy_kit_unit_test =
         (ctez_of_muctez (Ligo.nat_from_literal "1_000_000n"))
         (kit_of_mukit (Ligo.nat_from_literal "453_636n"))
         (Ligo.timestamp_from_seconds_literal 2) in
-    assert_equal ~printer:show_kit expected_returned_kit returned_kit;
-    assert_equal ~printer:show_cfmm ~cmp:eq_cfmm expected_updated_cfmm updated_cfmm;
+    assert_kit_equal ~expected:expected_returned_kit ~real:returned_kit;
+    assert_cfmm_equal ~expected:expected_updated_cfmm ~real:updated_cfmm;
 
     (* High expectations but on time (tight): fail *)
     Ligo.Tezos.reset ();
@@ -410,8 +403,8 @@ let sell_kit_unit_test =
         kit_one
         (ctez_of_muctez (Ligo.nat_from_literal "1n"))
         (Ligo.timestamp_from_seconds_literal 10) in
-    assert_equal ~printer:show_ctez expected_returned_ctez returned_ctez;
-    assert_equal ~printer:show_cfmm ~cmp:eq_cfmm expected_updated_cfmm updated_cfmm;
+    assert_ctez_equal ~expected:expected_returned_ctez ~real:returned_ctez;
+    assert_cfmm_equal ~expected:expected_updated_cfmm ~real:updated_cfmm;
 
     (* Low expectations and on time (tight): pass *)
     Ligo.Tezos.reset ();
@@ -422,8 +415,8 @@ let sell_kit_unit_test =
         kit_one
         (ctez_of_muctez (Ligo.nat_from_literal "1_663_333n"))
         (Ligo.timestamp_from_seconds_literal 2) in
-    assert_equal ~printer:show_ctez expected_returned_ctez returned_ctez;
-    assert_equal ~printer:show_cfmm ~cmp:eq_cfmm expected_updated_cfmm updated_cfmm;
+    assert_ctez_equal ~expected:expected_returned_ctez ~real:returned_ctez;
+    assert_cfmm_equal ~expected:expected_updated_cfmm ~real:updated_cfmm;
 
     (* High expectations but on time (tight): fail *)
     Ligo.Tezos.reset ();
@@ -595,7 +588,7 @@ let add_liquidity_unit_test =
         (Ligo.timestamp_from_seconds_literal 1) in
     assert_lqt_equal ~expected:expected_returned_liquidity ~real:returned_liquidity;
     assert_kit_equal ~expected:expected_returned_kit ~real:returned_kit;
-    assert_equal ~printer:show_cfmm ~cmp:eq_cfmm expected_updated_cfmm updated_cfmm
+    assert_cfmm_equal ~expected:expected_updated_cfmm ~real:updated_cfmm
 
 let test_add_liquidity_failures =
   "add liquidity failure conditions" >:: fun _ ->

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -857,6 +857,7 @@ let suite =
        assert_equal [] ops ~printer:show_operation_list;
 
        assert_equal
+         ~printer:Ligo.string_of_int
          (Ligo.int_from_literal "202_000_000") (* wow, high reward, many blocks have passed. *)
          touch_reward;
 
@@ -908,6 +909,7 @@ let suite =
          (Option.is_some checker.liquidation_auctions.current_auction);
 
        assert_equal
+         ~printer:Ligo.string_of_int
          (Ligo.int_from_literal "500_000")
          touch_reward;
 

--- a/tests/testCommon.ml
+++ b/tests/testCommon.ml
@@ -5,9 +5,49 @@ let charles_key_hash = Ligo.key_hash_from_literal "charles_key_hash"
 
 let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
 
-let assert_nat_equal ~expected:expected ~real:real = OUnit2.assert_equal ~printer:Ligo.string_of_nat expected real
-let assert_kit_equal ~expected:expected ~real:real = OUnit2.assert_equal ~printer:Kit.show_kit expected real
-let assert_lqt_equal ~expected:expected ~real:real = OUnit2.assert_equal ~printer:Lqt.show_lqt expected real
+let assert_stdlib_int_equal ~expected ~real = OUnit2.assert_equal ~printer:string_of_int expected real
+let assert_string_equal ~expected ~real = OUnit2.assert_equal ~printer:(fun x -> x) expected real
+
+let assert_tez_equal ~expected ~real = OUnit2.assert_equal ~printer:Ligo.string_of_tez expected real
+let assert_nat_equal ~expected ~real = OUnit2.assert_equal ~printer:Ligo.string_of_nat expected real
+let assert_int_equal ~expected ~real = OUnit2.assert_equal ~printer:Ligo.string_of_int expected real
+let assert_kit_equal ~expected ~real = OUnit2.assert_equal ~printer:Kit.show_kit expected real
+let assert_lqt_equal ~expected ~real = OUnit2.assert_equal ~printer:Lqt.show_lqt expected real
+let assert_ratio_equal ~expected ~real = OUnit2.assert_equal ~printer:Ratio.show_ratio ~cmp:Ratio.eq_ratio_ratio expected real
+let assert_address_equal ~expected ~real = OUnit2.assert_equal ~printer:Ligo.string_of_address expected real
+let assert_fixedpoint_equal ~expected ~real = OUnit2.assert_equal ~printer:FixedPoint.show_fixedpoint expected real
+let assert_liquidation_result_equal ~expected ~real = OUnit2.assert_equal ~printer:Burrow.show_liquidation_result expected real
+let assert_avl_ptr_equal ~expected ~real = OUnit2.assert_equal ~printer:LiquidationAuctionPrimitiveTypes.show_avl_ptr expected real
+let assert_ctez_equal ~expected ~real = OUnit2.assert_equal ~printer:Ctez.show_ctez expected real
+let assert_parameters_equal ~expected ~real = OUnit2.assert_equal ~printer:Parameters.show_parameters expected real (* FIXME: contains a ratio *)
+let assert_liquidation_slice_contents_equal ~expected ~real = OUnit2.assert_equal ~printer:LiquidationAuctionPrimitiveTypes.show_liquidation_slice_contents expected real
+
+type kit_option = Kit.kit option [@@deriving show]
+let assert_kit_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_kit_option expected real
+
+type tez_option = Ligo.tez option [@@deriving show]
+let assert_tez_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_tez_option expected real
+
+type slice_content_list = LiquidationAuctionPrimitiveTypes.liquidation_slice_contents list [@@deriving show]
+let assert_slice_content_list_equal ~expected ~real = OUnit2.assert_equal ~printer:show_slice_content_list expected real
+
+type liquidation_slice_list = LiquidationAuctionPrimitiveTypes.liquidation_slice list [@@deriving show]
+let assert_liquidation_slice_list_equal ~expected ~real = OUnit2.assert_equal ~printer:show_liquidation_slice_list expected real
+
+type operation_list = LigoOp.operation list [@@deriving show]
+let assert_operation_list_equal ~expected ~real = OUnit2.assert_equal ~printer:show_operation_list expected real
+
+type slice_option = LiquidationAuctionPrimitiveTypes.liquidation_slice option [@@deriving show]
+let assert_slice_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_slice_option expected real
+
+let eq_cfmm (u1: CfmmTypes.cfmm) (u2: CfmmTypes.cfmm) : bool =
+  Ctez.ctez_compare u1.ctez u2.ctez = 0
+  && Kit.kit_compare u1.kit u2.kit = 0
+  && Lqt.lqt_compare u1.lqt u2.lqt = 0
+  && Ratio.eq_ratio_ratio u1.kit_in_ctez_in_prev_block u2.kit_in_ctez_in_prev_block
+  && Ligo.eq_nat_nat u1.last_level u2.last_level
+
+let assert_cfmm_equal ~expected ~real = OUnit2.assert_equal ~printer:CfmmTypes.show_cfmm ~cmp:eq_cfmm expected real
 
 let cfmm_make_for_test ~ctez ~kit ~lqt ~kit_in_ctez_in_prev_block ~last_level =
   { CfmmTypes.ctez = ctez;

--- a/tests/testFixedPoint.ml
+++ b/tests/testFixedPoint.ml
@@ -2,8 +2,6 @@ open OUnit2
 open Ratio
 open FixedPoint
 
-type fp = fixedpoint[@@deriving show]
-
 let suite =
   "FixedPoint tests" >::: [
     "fixedpoint arithmetic" >::
@@ -13,23 +11,23 @@ let suite =
        let fp5 = fixedpoint_of_hex_string "-28" in
        let two = fixedpoint_of_hex_string "2" in
        assert_equal
-         ~printer:show_fp
+         ~printer:show_fixedpoint
          (fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "8")))
          (fixedpoint_add fp1 fp2);
        assert_equal
-         ~printer:show_fp
+         ~printer:show_fixedpoint
          (fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "2")))
          (fixedpoint_sub fp1 fp2);
        assert_equal
-         ~printer:show_fp
+         ~printer:show_fixedpoint
          (fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "4")))
          (fixedpoint_pow two (Ligo.nat_from_literal "2n"));
        assert_equal
-         ~printer:show_fp
+         ~printer:show_fixedpoint
          (fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "2")))
          (fixedpoint_pow two (Ligo.nat_from_literal "1n"));
        assert_equal
-         ~printer:show_fp
+         ~printer:show_fixedpoint
          (fixedpoint_one)
          (fixedpoint_pow fp5 (Ligo.nat_from_literal "0n"));
     );

--- a/tests/testFixedPoint.ml
+++ b/tests/testFixedPoint.ml
@@ -1,6 +1,7 @@
 open OUnit2
 open Ratio
 open FixedPoint
+open TestCommon
 
 let suite =
   "FixedPoint tests" >::: [
@@ -10,25 +11,20 @@ let suite =
        let fp2 = fixedpoint_of_hex_string "3" in
        let fp5 = fixedpoint_of_hex_string "-28" in
        let two = fixedpoint_of_hex_string "2" in
-       assert_equal
-         ~printer:show_fixedpoint
-         (fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "8")))
-         (fixedpoint_add fp1 fp2);
-       assert_equal
-         ~printer:show_fixedpoint
-         (fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "2")))
-         (fixedpoint_sub fp1 fp2);
-       assert_equal
-         ~printer:show_fixedpoint
-         (fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "4")))
-         (fixedpoint_pow two (Ligo.nat_from_literal "2n"));
-       assert_equal
-         ~printer:show_fixedpoint
-         (fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "2")))
-         (fixedpoint_pow two (Ligo.nat_from_literal "1n"));
-       assert_equal
-         ~printer:show_fixedpoint
-         (fixedpoint_one)
-         (fixedpoint_pow fp5 (Ligo.nat_from_literal "0n"));
+       assert_fixedpoint_equal
+         ~expected:(fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "8")))
+         ~real:(fixedpoint_add fp1 fp2);
+       assert_fixedpoint_equal
+         ~expected:(fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "2")))
+         ~real:(fixedpoint_sub fp1 fp2);
+       assert_fixedpoint_equal
+         ~expected:(fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "4")))
+         ~real:(fixedpoint_pow two (Ligo.nat_from_literal "2n"));
+       assert_fixedpoint_equal
+         ~expected:(fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "2")))
+         ~real:(fixedpoint_pow two (Ligo.nat_from_literal "1n"));
+       assert_fixedpoint_equal
+         ~expected:(fixedpoint_one)
+         ~real:(fixedpoint_pow fp5 (Ligo.nat_from_literal "0n"));
     );
   ]

--- a/tests/testKit.ml
+++ b/tests/testKit.ml
@@ -3,9 +3,6 @@ open Ratio
 open FixedPoint
 open Kit
 
-type kt = kit [@@deriving show]
-type fp = fixedpoint[@@deriving show]
-
 let suite =
   "KitTests" >::: [
     "kit arithmetic" >::
@@ -21,24 +18,24 @@ let suite =
          (Ligo.int kit_scaling_factor_nat);
 
        (* add *)
-       assert_equal ~printer:show_kt
+       assert_equal ~printer:show_kit
          (kit_of_mukit (Ligo.nat_from_literal "8_000_000n"))
          (kit_add (kit_of_mukit (Ligo.nat_from_literal "5_000_000n")) (kit_of_mukit (Ligo.nat_from_literal "3_000_000n")));
 
        (* subtract *)
-       assert_equal ~printer:show_kt
+       assert_equal ~printer:show_kit
          (kit_of_mukit (Ligo.nat_from_literal "2_000_000n"))
          (kit_sub (kit_of_mukit (Ligo.nat_from_literal "5_000_000n")) (kit_of_mukit (Ligo.nat_from_literal "3_000_000n")));
 
        (* scale *)
        assert_equal
-         ~printer:show_kt
+         ~printer:show_kit
          (kit_of_mukit (Ligo.nat_from_literal "15_370_401n"))
          (kit_scale (kit_of_mukit (Ligo.nat_from_literal "5_123_467n")) (fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "3"))));
 
        (* compare *)
        assert_equal
-         ~printer:show_kt
+         ~printer:show_kit
          (kit_of_mukit (Ligo.nat_from_literal "5_000_000n"))
          (max (kit_of_mukit (Ligo.nat_from_literal "5_000_000n")) (kit_of_mukit (Ligo.nat_from_literal "3_000_000n")));
 
@@ -46,6 +43,6 @@ let suite =
        assert_equal
          ~printer:(fun x -> x)
          "50309951mukit"
-         (show_kt (kit_of_mukit (Ligo.nat_from_literal "50_309_951n")));
+         (show_kit (kit_of_mukit (Ligo.nat_from_literal "50_309_951n")));
     )
   ]

--- a/tests/testKit.ml
+++ b/tests/testKit.ml
@@ -2,47 +2,45 @@ open OUnit2
 open Ratio
 open FixedPoint
 open Kit
+open TestCommon
 
 let suite =
   "KitTests" >::: [
     "kit arithmetic" >::
     (fun _ ->
        (* scaling factor (int) *)
-       assert_equal ~printer:Ligo.string_of_int
-         (Common.pow_int_nat (Ligo.int_from_literal "10") kit_decimal_digits)
-         kit_scaling_factor_int;
+       assert_int_equal
+         ~expected:kit_scaling_factor_int
+         ~real:(Common.pow_int_nat (Ligo.int_from_literal "10") kit_decimal_digits);
 
        (* scaling factor (nat) *)
-       assert_equal ~printer:Ligo.string_of_int
-         kit_scaling_factor_int
-         (Ligo.int kit_scaling_factor_nat);
+       assert_int_equal
+         ~expected:kit_scaling_factor_int
+         ~real:(Ligo.int kit_scaling_factor_nat);
 
        (* add *)
-       assert_equal ~printer:show_kit
-         (kit_of_mukit (Ligo.nat_from_literal "8_000_000n"))
-         (kit_add (kit_of_mukit (Ligo.nat_from_literal "5_000_000n")) (kit_of_mukit (Ligo.nat_from_literal "3_000_000n")));
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "8_000_000n"))
+         ~real:(kit_add (kit_of_mukit (Ligo.nat_from_literal "5_000_000n")) (kit_of_mukit (Ligo.nat_from_literal "3_000_000n")));
 
        (* subtract *)
-       assert_equal ~printer:show_kit
-         (kit_of_mukit (Ligo.nat_from_literal "2_000_000n"))
-         (kit_sub (kit_of_mukit (Ligo.nat_from_literal "5_000_000n")) (kit_of_mukit (Ligo.nat_from_literal "3_000_000n")));
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "2_000_000n"))
+         ~real:(kit_sub (kit_of_mukit (Ligo.nat_from_literal "5_000_000n")) (kit_of_mukit (Ligo.nat_from_literal "3_000_000n")));
 
        (* scale *)
-       assert_equal
-         ~printer:show_kit
-         (kit_of_mukit (Ligo.nat_from_literal "15_370_401n"))
-         (kit_scale (kit_of_mukit (Ligo.nat_from_literal "5_123_467n")) (fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "3"))));
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "15_370_401n"))
+         ~real:(kit_scale (kit_of_mukit (Ligo.nat_from_literal "5_123_467n")) (fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "3"))));
 
        (* compare *)
-       assert_equal
-         ~printer:show_kit
-         (kit_of_mukit (Ligo.nat_from_literal "5_000_000n"))
-         (max (kit_of_mukit (Ligo.nat_from_literal "5_000_000n")) (kit_of_mukit (Ligo.nat_from_literal "3_000_000n")));
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "5_000_000n"))
+         ~real:(max (kit_of_mukit (Ligo.nat_from_literal "5_000_000n")) (kit_of_mukit (Ligo.nat_from_literal "3_000_000n")));
 
        (* show *)
-       assert_equal
-         ~printer:(fun x -> x)
-         "50309951mukit"
-         (show_kit (kit_of_mukit (Ligo.nat_from_literal "50_309_951n")));
+       assert_string_equal
+         ~expected:"50309951mukit"
+         ~real:(show_kit (kit_of_mukit (Ligo.nat_from_literal "50_309_951n")));
     )
   ]

--- a/tests/testLiquidationAuction.ml
+++ b/tests/testLiquidationAuction.ml
@@ -14,6 +14,7 @@ let checker_address = Ligo.address_from_literal "checker"
 let checker_amount = Ligo.tez_from_literal "0mutez"
 let checker_sender = Ligo.address_from_literal "somebody"
 
+type tez_option = Ligo.tez option [@@deriving show]
 type slice_content_list = liquidation_slice_contents list [@@deriving show]
 
 (* ========================================================================= *)
@@ -207,7 +208,7 @@ let suite =
 
               assert_liquidation_auction_invariants auctions;
               assert_liquidation_auction_invariants auctions_out;
-              assert_equal popped_contents (List.nth slice_contents_list i_to_pop);
+              assert_equal popped_contents (List.nth slice_contents_list i_to_pop) ~printer:show_liquidation_slice_contents;
               assert_equal ((List.length expected_slices)) (List.length slices_out) ~printer:string_of_int;
               assert_equal expected_slices slices_out ~printer:show_slice_content_list
           )
@@ -283,7 +284,7 @@ let suite =
 
               assert_liquidation_auction_invariants auctions;
               assert_liquidation_auction_invariants auctions_out;
-              assert_equal popped_contents (List.nth slice_contents_list i_to_pop);
+              assert_equal popped_contents (List.nth slice_contents_list i_to_pop) ~printer:show_liquidation_slice_contents;
               assert_equal ((List.length expected_contents)) (List.length slices_out) ~printer:string_of_int;
               assert_equal expected_contents slices_out ~printer:show_slice_content_list
           )
@@ -307,6 +308,7 @@ let suite =
        let auctions = liquidation_auction_touch auctions start_price in
        let current = Option.get auctions.current_auction in
        assert_equal
+         ~printer:show_tez_option
          (Some (Ligo.tez_from_literal "2_000_000mutez"))
          (liquidation_auction_current_auction_tez auctions);
        assert_equal
@@ -364,7 +366,7 @@ let suite =
            } in
        let start_price = one_ratio in
        let auctions = liquidation_auction_touch auctions start_price in
-       assert_equal (Some (Ligo.tez_from_literal "10_000_000_000mutez")) (liquidation_auction_current_auction_tez auctions);
+       assert_equal (Some (Ligo.tez_from_literal "10_000_000_000mutez")) (liquidation_auction_current_auction_tez auctions) ~printer:show_tez_option;
     );
 
     ("test splits up auction lots to fit batch size" >::
@@ -391,7 +393,7 @@ let suite =
            } in
        let start_price = one_ratio in
        let auctions = liquidation_auction_touch auctions start_price in
-       assert_equal (Some (Ligo.tez_from_literal "10_000_000_000mutez")) (liquidation_auction_current_auction_tez auctions);
+       assert_equal (Some (Ligo.tez_from_literal "10_000_000_000mutez")) (liquidation_auction_current_auction_tez auctions) ~printer:show_tez_option;
     );
 
     ("test bidding" >::

--- a/tests/testLiquidationAuction.ml
+++ b/tests/testLiquidationAuction.ml
@@ -14,9 +14,6 @@ let checker_address = Ligo.address_from_literal "checker"
 let checker_amount = Ligo.tez_from_literal "0mutez"
 let checker_sender = Ligo.address_from_literal "somebody"
 
-type tez_option = Ligo.tez option [@@deriving show]
-type slice_content_list = liquidation_slice_contents list [@@deriving show]
-
 (* ========================================================================= *)
 (* QCheck arbitrary values *)
 (* ========================================================================= *)
@@ -140,10 +137,10 @@ let suite =
                assert_liquidation_auction_invariants auctions;
                assert_liquidation_auction_invariants auctions_out;
                (* We should have inserted one element into our original list *)
-               assert_equal ((List.length slices_in) + 1) (List.length slices_out) ~printer:string_of_int;
+               assert_stdlib_int_equal ~expected:((List.length slices_in) + 1) ~real:(List.length slices_out);
                (* Removing the new element from the list should produce the input list *)
                (* Note: comparing by content since the pointers will change when inserting *)
-               assert_equal slices_in slices_without_new_one ~printer:show_slice_content_list;
+               assert_slice_content_list_equal ~expected:slices_in ~real:slices_without_new_one;
                auctions_out
             )
             liquidation_auction_empty
@@ -208,9 +205,9 @@ let suite =
 
               assert_liquidation_auction_invariants auctions;
               assert_liquidation_auction_invariants auctions_out;
-              assert_equal popped_contents (List.nth slice_contents_list i_to_pop) ~printer:show_liquidation_slice_contents;
-              assert_equal ((List.length expected_slices)) (List.length slices_out) ~printer:string_of_int;
-              assert_equal expected_slices slices_out ~printer:show_slice_content_list
+              assert_liquidation_slice_contents_equal ~expected:popped_contents ~real:(List.nth slice_contents_list i_to_pop);
+              assert_stdlib_int_equal ~expected:((List.length expected_slices)) ~real:(List.length slices_out);
+              assert_slice_content_list_equal ~expected:expected_slices ~real:slices_out;
           )
             (Ligo.Big_map.bindings auctions_out.burrow_slices)
         in
@@ -284,9 +281,9 @@ let suite =
 
               assert_liquidation_auction_invariants auctions;
               assert_liquidation_auction_invariants auctions_out;
-              assert_equal popped_contents (List.nth slice_contents_list i_to_pop) ~printer:show_liquidation_slice_contents;
-              assert_equal ((List.length expected_contents)) (List.length slices_out) ~printer:string_of_int;
-              assert_equal expected_contents slices_out ~printer:show_slice_content_list
+              assert_liquidation_slice_contents_equal ~expected:popped_contents ~real:(List.nth slice_contents_list i_to_pop);
+              assert_stdlib_int_equal ~expected:((List.length expected_contents)) ~real:(List.length slices_out);
+              assert_slice_content_list_equal ~expected:expected_contents ~real:slices_out;
           )
             (Ligo.Big_map.bindings auctions_out.burrow_slices)
         in
@@ -307,39 +304,32 @@ let suite =
        let start_price = one_ratio in
        let auctions = liquidation_auction_touch auctions start_price in
        let current = Option.get auctions.current_auction in
-       assert_equal
-         ~printer:show_tez_option
-         (Some (Ligo.tez_from_literal "2_000_000mutez"))
-         (liquidation_auction_current_auction_tez auctions);
-       assert_equal
-         (kit_of_mukit (Ligo.nat_from_literal "2_000_000n"))
-         (liquidation_auction_current_auction_minimum_bid current)
-         ~printer:show_kit;
-       assert_equal
-         (kit_of_mukit (Ligo.nat_from_literal "2_000_000n"))
-         (liquidation_auction_current_auction_minimum_bid current)
-         ~printer:show_kit;
+       assert_tez_option_equal
+         ~expected:(Some (Ligo.tez_from_literal "2_000_000mutez"))
+         ~real:(liquidation_auction_current_auction_tez auctions);
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "2_000_000n"))
+         ~real:(liquidation_auction_current_auction_minimum_bid current);
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "2_000_000n"))
+         ~real:(liquidation_auction_current_auction_minimum_bid current);
        (* Price of descending auction should go down... *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       assert_equal
-         (kit_of_mukit (Ligo.nat_from_literal "1_999_666n"))
-         (liquidation_auction_current_auction_minimum_bid current)
-         ~printer:show_kit;
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "1_999_666n"))
+         ~real:(liquidation_auction_current_auction_minimum_bid current);
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       assert_equal
-         (kit_of_mukit (Ligo.nat_from_literal "1_999_333n"))
-         (liquidation_auction_current_auction_minimum_bid current)
-         ~printer:show_kit;
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "1_999_333n"))
+         ~real:(liquidation_auction_current_auction_minimum_bid current);
        Ligo.Tezos.new_transaction ~seconds_passed:58 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       assert_equal
-         (kit_of_mukit (Ligo.nat_from_literal "1_980_098n"))
-         (liquidation_auction_current_auction_minimum_bid current)
-         ~printer:show_kit;
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "1_980_098n"))
+         ~real:(liquidation_auction_current_auction_minimum_bid current);
        Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       assert_equal
-         (kit_of_mukit (Ligo.nat_from_literal "1_960_394n"))
-         (liquidation_auction_current_auction_minimum_bid current)
-         ~printer:show_kit;
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "1_960_394n"))
+         ~real:(liquidation_auction_current_auction_minimum_bid current);
     );
 
     ("test batches up auction lots" >::
@@ -366,7 +356,9 @@ let suite =
            } in
        let start_price = one_ratio in
        let auctions = liquidation_auction_touch auctions start_price in
-       assert_equal (Some (Ligo.tez_from_literal "10_000_000_000mutez")) (liquidation_auction_current_auction_tez auctions) ~printer:show_tez_option;
+       assert_tez_option_equal
+         ~expected:(Some (Ligo.tez_from_literal "10_000_000_000mutez"))
+         ~real:(liquidation_auction_current_auction_tez auctions);
     );
 
     ("test splits up auction lots to fit batch size" >::
@@ -393,7 +385,9 @@ let suite =
            } in
        let start_price = one_ratio in
        let auctions = liquidation_auction_touch auctions start_price in
-       assert_equal (Some (Ligo.tez_from_literal "10_000_000_000mutez")) (liquidation_auction_current_auction_tez auctions) ~printer:show_tez_option;
+       assert_tez_option_equal
+         ~expected:(Some (Ligo.tez_from_literal "10_000_000_000mutez"))
+         ~real:(liquidation_auction_current_auction_tez auctions);
     );
 
     ("test bidding" >::
@@ -421,10 +415,9 @@ let suite =
          (fun () -> liquidation_auction_place_bid current { address = bidder; kit = kit_of_mukit (Ligo.nat_from_literal "1_999_999n"); });
        (* On/Above minimum bid, we get a bid ticket and our bid plus 0.33 cNp becomes the new minimum bid *)
        let (current, _) = liquidation_auction_place_bid current { address = bidder; kit = kit_of_mukit (Ligo.nat_from_literal "2_000_000n"); } in
-       assert_equal
-         (kit_of_mukit (Ligo.nat_from_literal "2_006_599n"))
-         (liquidation_auction_current_auction_minimum_bid current)
-         ~printer:show_kit;
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "2_006_599n"))
+         ~real:(liquidation_auction_current_auction_minimum_bid current);
        (* Minimum bid does not drop over time *)
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        (* Can increase the bid.*)

--- a/tests/testLqt.ml
+++ b/tests/testLqt.ml
@@ -7,14 +7,14 @@ let suite =
     "lqt arithmetic" >::
     (fun _ ->
        (* scaling factor (int) *)
-       assert_equal ~printer:Ligo.string_of_int
-         (Common.pow_int_nat (Ligo.int_from_literal "10") lqt_decimal_digits)
-         lqt_scaling_factor_int;
+       assert_int_equal
+         ~expected:lqt_scaling_factor_int
+         ~real:(Common.pow_int_nat (Ligo.int_from_literal "10") lqt_decimal_digits);
 
        (* scaling factor (nat) *)
-       assert_equal ~printer:Ligo.string_of_int
-         lqt_scaling_factor_int
-         (Ligo.int lqt_scaling_factor_nat);
+       assert_int_equal
+         ~expected:lqt_scaling_factor_int
+         ~real:(Ligo.int lqt_scaling_factor_nat);
 
        (* add *)
        assert_lqt_equal
@@ -32,9 +32,8 @@ let suite =
          ~real:(max (lqt_of_denomination (Ligo.nat_from_literal "5_000_000n")) (lqt_of_denomination (Ligo.nat_from_literal "3_000_000n")));
 
        (* show *)
-       assert_equal
-         ~printer:(fun x -> x)
-         "50.309951lqt"
-         (show_lqt (lqt_of_denomination (Ligo.nat_from_literal "50_309_951n")));
+       assert_string_equal
+         ~expected:"50.309951lqt"
+         ~real:(show_lqt (lqt_of_denomination (Ligo.nat_from_literal "50_309_951n")));
     )
   ]

--- a/tests/testParameters.ml
+++ b/tests/testParameters.ml
@@ -42,74 +42,65 @@ let test_compute_drift_derivative_no_acceleration =
   "test_compute_drift_derivative_no_acceleration" >:: fun _ ->
     (* exp( 0 ): 1 *)
     let target = fixedpoint_one in
-    assert_equal
-      ~printer:show_fixedpoint
-      fixedpoint_zero
-      (compute_drift_derivative target);
+    assert_fixedpoint_equal
+      ~expected:fixedpoint_zero
+      ~real:(compute_drift_derivative target);
 
     (* exp( low ): 201/200 = 1.005 (rounded DOWN) *)
     let target = fixedpoint_of_hex_string "1.0147AE147AE147AE" in
-    assert_equal
-      ~printer:show_fixedpoint
-      fixedpoint_zero
-      (compute_drift_derivative target);
+    assert_fixedpoint_equal
+      ~expected:fixedpoint_zero
+      ~real:(compute_drift_derivative target);
 
     (* exp(-low ): 199/200 = 0.995 (rounded UP) *)
     let target = fixedpoint_of_hex_string "0.FEB851EB851EB852" in
-    assert_equal
-      ~printer:show_fixedpoint
-      fixedpoint_zero
-      (compute_drift_derivative target)
+    assert_fixedpoint_equal
+      ~expected:fixedpoint_zero
+      ~real:(compute_drift_derivative target)
 
 let test_compute_drift_derivative_low_positive_acceleration =
   "test_compute_drift_derivative_low_positive_acceleration" >:: fun _ ->
     (* exp( low ): 201/200 = 1.005 (rounded UP) *)
     let target = fixedpoint_of_hex_string "1.0147AE147AE147AF" in
-    assert_equal
-      ~printer:show_fixedpoint
-      (fixedpoint_of_hex_string "0.000000000003C547")
-      (compute_drift_derivative target);
+    assert_fixedpoint_equal
+      ~expected:(fixedpoint_of_hex_string "0.000000000003C547")
+      ~real:(compute_drift_derivative target);
 
     (* exp( high): 21/20   = 1.05 (rounded DOWN) *)
     let target = fixedpoint_of_hex_string "1.0CCCCCCCCCCCCCCC" in
-    assert_equal
-      ~printer:show_fixedpoint
-      (fixedpoint_of_hex_string "0.000000000003C547")
-      (compute_drift_derivative target)
+    assert_fixedpoint_equal
+      ~expected:(fixedpoint_of_hex_string "0.000000000003C547")
+      ~real:(compute_drift_derivative target)
 
 let test_compute_drift_derivative_low_negative_acceleration =
   "test_compute_drift_derivative_low_negative_acceleration" >:: fun _ ->
     (* exp(-low ): 199/200 = 0.995 (rounded DOWN) *)
     let target = fixedpoint_of_hex_string "0.FEB851EB851EB851" in
-    assert_equal
-      ~printer:show_fixedpoint
-      (fixedpoint_of_hex_string "-0.000000000003C547")
-      (compute_drift_derivative target);
+    assert_fixedpoint_equal
+      ~expected:(fixedpoint_of_hex_string "-0.000000000003C547")
+      ~real:(compute_drift_derivative target);
 
     (* exp(-high): 19/20   = 0.95 (rounded UP) *)
     let target = fixedpoint_of_hex_string "0.F333333333333334" in
-    assert_equal
-      ~printer:show_fixedpoint
-      (fixedpoint_of_hex_string "-0.000000000003C547")
-      (compute_drift_derivative target)
+    assert_fixedpoint_equal
+      ~expected:(fixedpoint_of_hex_string "-0.000000000003C547")
+      ~real:(compute_drift_derivative target)
 
 let test_compute_drift_derivative_high_positive_acceleration =
   "test_compute_drift_derivative_high_positive_acceleration" >:: fun _ ->
     (* exp( high): 21/20   = 1.05 (rounded UP) *)
     let target = fixedpoint_of_hex_string "1.0CCCCCCCCCCCCCCD" in
-    assert_equal
-      ~printer:show_fixedpoint
-      (fixedpoint_of_hex_string "0.000000000012DA63")
-      (compute_drift_derivative target)
+    assert_fixedpoint_equal
+      ~expected:(fixedpoint_of_hex_string "0.000000000012DA63")
+      ~real:(compute_drift_derivative target)
 
 let test_compute_drift_derivative_high_negative_acceleration =
   "test_compute_drift_derivative_high_negative_acceleration" >:: fun _ ->
     (* exp(-high): 19/20   = 0.95 (rounded DOWN) *)
     let target = fixedpoint_of_hex_string "0.F333333333333333" in
-    assert_equal
-      ~printer:show_fixedpoint
-      (fixedpoint_of_hex_string "-0.000000000012DA63")
-      (compute_drift_derivative target)
+    assert_fixedpoint_equal
+      ~expected:(fixedpoint_of_hex_string "-0.000000000012DA63")
+      ~real:(compute_drift_derivative target)
 
 (* ************************************************************************* *)
 (*                     compute_imbalance (unit tests)                        *)
@@ -119,101 +110,81 @@ let test_compute_imbalance_all_zero =
   "test_compute_imbalance_all_zero" >:: fun _ ->
     let outstanding = kit_zero in
     let circulating = kit_zero in
-    assert_equal
-      ~printer:show_ratio
-      ~cmp:eq_ratio_ratio
-      zero_ratio
-      (compute_imbalance outstanding circulating)
+    assert_ratio_equal
+      ~expected:zero_ratio
+      ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_zero_outstanding =
   "test_compute_imbalance_zero_outstanding" >:: fun _ ->
     let outstanding = kit_zero in
     let circulating = kit_one in
-    assert_equal
-      ~printer:show_ratio
-      ~cmp:eq_ratio_ratio
-      (make_ratio (Ligo.int_from_literal "5") (Ligo.int_from_literal "100"))
-      (compute_imbalance outstanding circulating)
+    assert_ratio_equal
+      ~expected:(make_ratio (Ligo.int_from_literal "5") (Ligo.int_from_literal "100"))
+      ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_zero_circulating =
   "test_compute_imbalance_zero_circulating" >:: fun _ ->
     let outstanding = kit_one in
     let circulating = kit_zero in
-    assert_equal
-      ~printer:show_ratio
-      ~cmp:eq_ratio_ratio
-      (make_ratio (Ligo.int_from_literal "-5") (Ligo.int_from_literal "100"))
-      (compute_imbalance outstanding circulating)
+    assert_ratio_equal
+      ~expected:(make_ratio (Ligo.int_from_literal "-5") (Ligo.int_from_literal "100"))
+      ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_equal =
   "test_compute_imbalance_equal" >:: fun _ ->
     let outstanding = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
     let circulating = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
-    assert_equal
-      ~printer:show_ratio
-      ~cmp:eq_ratio_ratio
-      zero_ratio
-      (compute_imbalance outstanding circulating)
+    assert_ratio_equal
+      ~expected:zero_ratio
+      ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_negative_small =
   "test_compute_imbalance_negative_small" >:: fun _ ->
     let outstanding = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
     let circulating = kit_of_mukit (Ligo.nat_from_literal   "937_500_001n") in
-    assert_equal
-      ~printer:show_ratio
-      ~cmp:eq_ratio_ratio
-      (make_ratio (Ligo.int_from_literal "-187499997") (Ligo.int_from_literal "3750000004")) (* JUST BELOW SATURATION *)
-      (compute_imbalance outstanding circulating)
+    assert_ratio_equal
+      ~expected:(make_ratio (Ligo.int_from_literal "-187499997") (Ligo.int_from_literal "3750000004")) (* JUST BELOW SATURATION *)
+      ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_negative_big =
   "test_compute_imbalance_negative_big" >:: fun _ ->
     let outstanding = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
     let circulating = kit_of_mukit (Ligo.nat_from_literal   "937_500_000n") in
-    assert_equal
-      ~printer:show_ratio
-      ~cmp:eq_ratio_ratio
-      (make_ratio (Ligo.int_from_literal "-5") (Ligo.int_from_literal "100")) (* JUST ABOVE SATURATION *)
-      (compute_imbalance outstanding circulating)
+    assert_ratio_equal
+      ~expected:(make_ratio (Ligo.int_from_literal "-5") (Ligo.int_from_literal "100")) (* JUST ABOVE SATURATION *)
+      ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_negative_capped =
   "test_compute_imbalance_negative_capped" >:: fun _ ->
     let outstanding = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
     let circulating = kit_of_mukit (Ligo.nat_from_literal             "1n") in
-    assert_equal
-      ~printer:show_ratio
-      ~cmp:eq_ratio_ratio
-      (make_ratio (Ligo.int_from_literal "-5") (Ligo.int_from_literal "100")) (* SATURATED *)
-      (compute_imbalance outstanding circulating)
+    assert_ratio_equal
+      ~expected:(make_ratio (Ligo.int_from_literal "-5") (Ligo.int_from_literal "100")) (* SATURATED *)
+      ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_positive_small =
   "test_compute_imbalance_positive_small" >:: fun _ ->
     let outstanding = kit_of_mukit (Ligo.nat_from_literal   "933_333_334n") in
     let circulating = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
-    assert_equal
-      ~printer:show_ratio
-      ~cmp:eq_ratio_ratio
-      (make_ratio (Ligo.int_from_literal "199999998") (Ligo.int_from_literal "4000000000")) (* JUST BELOW SATURATION *)
-      (compute_imbalance outstanding circulating)
+    assert_ratio_equal
+      ~expected:(make_ratio (Ligo.int_from_literal "199999998") (Ligo.int_from_literal "4000000000")) (* JUST BELOW SATURATION *)
+      ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_positive_big =
   "test_compute_imbalance_positive_big" >:: fun _ ->
     let outstanding = kit_of_mukit (Ligo.nat_from_literal   "933_333_333n") in
     let circulating = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
-    assert_equal
-      ~printer:show_ratio
-      ~cmp:eq_ratio_ratio
-      (make_ratio (Ligo.int_from_literal "5") (Ligo.int_from_literal "100")) (* JUST ABOVE SATURATION *)
-      (compute_imbalance outstanding circulating)
+    assert_ratio_equal
+      ~expected:(make_ratio (Ligo.int_from_literal "5") (Ligo.int_from_literal "100")) (* JUST ABOVE SATURATION *)
+      ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_positive_capped =
   "test_compute_imbalance_positive_capped" >:: fun _ ->
     let outstanding = kit_of_mukit (Ligo.nat_from_literal             "1n") in
     let circulating = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
-    assert_equal
-      ~printer:show_ratio
-      ~cmp:eq_ratio_ratio
-      (make_ratio (Ligo.int_from_literal "5") (Ligo.int_from_literal "100")) (* SATURATED *)
-      (compute_imbalance outstanding circulating)
+    assert_ratio_equal
+      ~expected:(make_ratio (Ligo.int_from_literal "5") (Ligo.int_from_literal "100")) (* SATURATED *)
+      ~real:(compute_imbalance outstanding circulating)
 
 (* ************************************************************************* *)
 (*                compute_imbalance (property-based tests)                   *)
@@ -338,10 +309,9 @@ let test_protected_index_follows_index =
 
   let _total_accrual_to_cfmm, new_params = parameters_touch index kit_in_tez params in
 
-  assert_equal
-    (compare new_params.index params.index)
-    (compare new_params.protected_index params.protected_index)
-    ~printer:string_of_int;
+  assert_stdlib_int_equal
+    ~expected:(compare new_params.index params.index)
+    ~real:(compare new_params.protected_index params.protected_index);
   true
 
 (* The protected index should not follow the tendency of the given index "too
@@ -365,13 +335,13 @@ let test_protected_index_pace =
     (* Final   : 1.030420 (=103.0420% of initial; slightly over 3%) *)
     Ligo.Tezos.reset();
     let new_params = call_touch_times very_high_index kit_in_tez (60 (* 60 blocks ~ 1h *)) params in
-    assert_equal ~printer:Ligo.string_of_tez (Ligo.tez_from_literal "1_030_420mutez") new_params.protected_index;
+    assert_tez_equal ~expected:(Ligo.tez_from_literal "1_030_420mutez") ~real:new_params.protected_index;
     (* One day, upward move, touched in every block *)
     (* Initial : 1.000000 *)
     (* Final   : 2.053031 (=205.3031% of initial; slightly over double) *)
     Ligo.Tezos.reset();
     let new_params = call_touch_times very_high_index kit_in_tez (60 * 24 (* 60 blocks ~ 1h *)) params in
-    assert_equal ~printer:Ligo.string_of_tez (Ligo.tez_from_literal "2_053_031mutez") new_params.protected_index;
+    assert_tez_equal ~expected:(Ligo.tez_from_literal "2_053_031mutez") ~real:new_params.protected_index;
 
     (* DOWNWARD MOVES *)
     let very_low_index =
@@ -382,13 +352,13 @@ let test_protected_index_pace =
     (* Final   : 0.970407 (=2.9593% less than initial; slightly under 3% *)
     Ligo.Tezos.reset();
     let new_params = call_touch_times very_low_index kit_in_tez (60 (* 60 blocks ~ 1h *)) params in
-    assert_equal ~printer:Ligo.string_of_tez (Ligo.tez_from_literal "970_407mutez") new_params.protected_index;
+    assert_tez_equal ~expected:(Ligo.tez_from_literal "970_407mutez") ~real:new_params.protected_index;
     (* One day, downward move, touched in every block *)
     (* Initial : 1.000000 *)
     (* Final   : 0.486151 (=51.3849% less than initial; slightly more than halved) *)
     Ligo.Tezos.reset();
     let new_params = call_touch_times very_low_index kit_in_tez (60 * 24 (* 60 blocks ~ 1h *)) params in
-    assert_equal ~printer:Ligo.string_of_tez (Ligo.tez_from_literal "486_151mutez") new_params.protected_index
+    assert_tez_equal ~expected:(Ligo.tez_from_literal "486_151mutez") ~real:new_params.protected_index
 
 (* ************************************************************************* *)
 (*                                 Prices                                    *)
@@ -440,10 +410,9 @@ let test_minting_index_high_unbounded =
   Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
   let _total_accrual_to_cfmm, new_params = parameters_touch index kit_in_tez params in
-  assert_equal
-    index
-    (tz_minting new_params)
-    ~printer:Ligo.string_of_tez;
+  assert_tez_equal
+    ~expected:index
+    ~real:(tz_minting new_params);
   true
 
 (* The pace of change of the liquidation index is bounded on the high side.
@@ -492,10 +461,9 @@ let test_liquidation_index_low_unbounded =
   Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
   let _total_accrual_to_cfmm, new_params = parameters_touch index kit_in_tez params in
-  assert_equal
-    index
-    (tz_liquidation new_params)
-    ~printer:Ligo.string_of_tez;
+  assert_tez_equal
+    ~expected:index
+    ~real:(tz_liquidation new_params);
   true
 
 (* ************************************************************************* *)
@@ -524,8 +492,9 @@ let test_touch_1 =
     let new_index = Ligo.tez_from_literal "340_000mutez" in
     let kit_in_tez = make_ratio (Ligo.int_from_literal "305") (Ligo.int_from_literal "1000") in
     let total_accrual_to_cfmm, new_parameters = parameters_touch new_index kit_in_tez initial_parameters in
-    assert_equal
-      { q = fixedpoint_of_hex_string "0.E6666895A3EC8BA5"; (* 0.90000013020828555983 *)
+    assert_parameters_equal
+      ~expected:{
+        q = fixedpoint_of_hex_string "0.E6666895A3EC8BA5"; (* 0.90000013020828555983 *)
         index = Ligo.tez_from_literal "340_000mutez";
         protected_index = Ligo.tez_from_literal "340_000mutez";
         target = fixedpoint_of_hex_string "1.00D6E1B366FF4BEE"; (* 1.00327883367481013224 *)
@@ -537,12 +506,8 @@ let test_touch_1 =
         circulating_kit = kit_of_mukit (Ligo.nat_from_literal "0_000_000n"); (* NOTE that it ends up being identical to the one we started with *)
         last_touched = !Ligo.Tezos.now;
       }
-      new_parameters
-      ~printer:show_parameters;
-    assert_equal
-      kit_zero (* NOTE: I'd expect this to be higher I think. *)
-      total_accrual_to_cfmm
-      ~printer:show_kit
+      ~real:new_parameters;
+    assert_kit_equal ~expected:kit_zero ~real:total_accrual_to_cfmm (* NOTE: I'd expect this to be higher I think. *)
 
 (* Just a simple unit test, testing nothing specific, really. *)
 let test_touch_2 =
@@ -566,8 +531,9 @@ let test_touch_2 =
     let new_index = Ligo.tez_from_literal "340_000mutez" in
     let kit_in_tez = make_ratio (Ligo.int_from_literal "305") (Ligo.int_from_literal "1000") in
     let total_accrual_to_cfmm, new_parameters = parameters_touch new_index kit_in_tez initial_parameters in
-    assert_equal
-      { q = fixedpoint_of_hex_string "0.E6666895A3EC8BA5";
+    assert_parameters_equal
+      ~expected:{
+        q = fixedpoint_of_hex_string "0.E6666895A3EC8BA5";
         index = Ligo.tez_from_literal "340000mutez";
         protected_index = Ligo.tez_from_literal "340000mutez";
         target = fixedpoint_of_hex_string "1.00D6E1B366FF4BEE";
@@ -579,12 +545,10 @@ let test_touch_2 =
         circulating_kit = kit_of_mukit (Ligo.nat_from_literal "1_000_001n");
         last_touched = !Ligo.Tezos.now;
       }
-      new_parameters
-      ~printer:show_parameters;
-    assert_equal
-      (kit_of_mukit (Ligo.nat_from_literal "1n"))
-      total_accrual_to_cfmm
-      ~printer:show_kit
+      ~real:new_parameters;
+    assert_kit_equal
+      ~expected:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+      ~real:total_accrual_to_cfmm
 
 let suite =
   "Parameters tests" >::: [

--- a/tests/testTez.ml
+++ b/tests/testTez.ml
@@ -1,26 +1,22 @@
 open OUnit2
-open FixedPoint
-
-type tz = Ligo.tez [@@deriving show]
-type fp = fixedpoint[@@deriving show]
 
 let suite =
   "TezTests" >::: [
     "tez arithmetic" >::
     (fun _ ->
-       assert_equal ~printer:show_tz
+       assert_equal ~printer:Ligo.string_of_tez
          (Ligo.tez_from_literal "8_000_000mutez")
          (Ligo.add_tez_tez (Ligo.tez_from_literal "5_000_000mutez") (Ligo.tez_from_literal "3_000_000mutez"));
-       assert_equal ~printer:show_tz
+       assert_equal ~printer:Ligo.string_of_tez
          (Ligo.tez_from_literal "2_000_000mutez")
          (Ligo.sub_tez_tez (Ligo.tez_from_literal "5_000_000mutez") (Ligo.tez_from_literal "3_000_000mutez"));
        assert_equal
-         ~printer:show_tz
+         ~printer:Ligo.string_of_tez
          (Ligo.tez_from_literal "5_000_000mutez")
          (max (Ligo.tez_from_literal "5_000_000mutez") (Ligo.tez_from_literal "3_000_000mutez"));
        assert_equal
          ~printer:(fun x -> x)
          "50309951mutez"
-         (show_tz (Ligo.tez_from_literal "50_309_951mutez"));
+         (Ligo.string_of_tez (Ligo.tez_from_literal "50_309_951mutez"));
     )
   ]

--- a/tests/testTez.ml
+++ b/tests/testTez.ml
@@ -1,22 +1,21 @@
 open OUnit2
+open TestCommon
 
 let suite =
   "TezTests" >::: [
     "tez arithmetic" >::
     (fun _ ->
-       assert_equal ~printer:Ligo.string_of_tez
-         (Ligo.tez_from_literal "8_000_000mutez")
-         (Ligo.add_tez_tez (Ligo.tez_from_literal "5_000_000mutez") (Ligo.tez_from_literal "3_000_000mutez"));
-       assert_equal ~printer:Ligo.string_of_tez
-         (Ligo.tez_from_literal "2_000_000mutez")
-         (Ligo.sub_tez_tez (Ligo.tez_from_literal "5_000_000mutez") (Ligo.tez_from_literal "3_000_000mutez"));
-       assert_equal
-         ~printer:Ligo.string_of_tez
-         (Ligo.tez_from_literal "5_000_000mutez")
-         (max (Ligo.tez_from_literal "5_000_000mutez") (Ligo.tez_from_literal "3_000_000mutez"));
-       assert_equal
-         ~printer:(fun x -> x)
-         "50309951mutez"
-         (Ligo.string_of_tez (Ligo.tez_from_literal "50_309_951mutez"));
+       assert_tez_equal
+         ~expected:(Ligo.tez_from_literal "8_000_000mutez")
+         ~real:(Ligo.add_tez_tez (Ligo.tez_from_literal "5_000_000mutez") (Ligo.tez_from_literal "3_000_000mutez"));
+       assert_tez_equal
+         ~expected:(Ligo.tez_from_literal "2_000_000mutez")
+         ~real:(Ligo.sub_tez_tez (Ligo.tez_from_literal "5_000_000mutez") (Ligo.tez_from_literal "3_000_000mutez"));
+       assert_tez_equal
+         ~expected:(Ligo.tez_from_literal "5_000_000mutez")
+         ~real:(max (Ligo.tez_from_literal "5_000_000mutez") (Ligo.tez_from_literal "3_000_000mutez"));
+       assert_string_equal
+         ~expected:"50309951mutez"
+         ~real:(Ligo.string_of_tez (Ligo.tez_from_literal "50_309_951mutez"));
     )
   ]


### PR DESCRIPTION
I guess this PR is a little bikesheddy, but I've been wanting to perform these changes for a while now, and every now and then I come across these issues. Changes:

* Ensure that all calls to `assert_equal` get the optional `printer` argument, so that when there is a failure we can actually see what went wrong. Exception to this rule is the call to `assert_equal` in `test_all_permutations`, because it's very tight and it timeouts if we do.
* Instead of replicating the `assert_equal ~printer:(...) ~cmp:(...) expected real` pattern, define separate functions per type, like this:
  ```
  let assert_ratio_equal ~expected ~real = OUnit2.assert_equal ~printer:Ratio.show_ratio ~cmp:Ratio.eq_ratio_ratio expected real
  ```
  This has several advantages:
  - The code is shorter (this PR takes ~100 LOC away)
  - The order of `real` and `expected` cannot be gotten wrong (we had several instances where the arguments were flipped, giving misleading errors).
  - The use of the default `(=)` is avoided. If we don't pass the `cmp` parameter explicitly, `(=)` is implicitly used, which is wrong for several of our types, such as bigmaps, ratios, and every type that includes them. In fact, there are a few cases in the codebase were `(=)` is still used while it shouldn't, but I'll fix that in a separate PR.