### PR TITLE
Touch burrows before operating on/accessing them

### DIFF
--- a/src/checker.ml
+++ b/src/checker.ml
@@ -319,6 +319,7 @@ let entrypoint_cancel_liquidation_slice (state, leaf_ptr: checker * leaf_ptr) : 
   let (cancelled, auctions) = liquidation_auctions_cancel_slice state.liquidation_auctions leaf_ptr in
   let (burrow_owner, _) = cancelled.burrow in
   let burrow = find_burrow state.burrows cancelled.burrow in
+  let burrow = burrow_touch state.parameters burrow in
   let _ =
     if burrow_is_cancellation_warranted state.parameters burrow cancelled.tez
     then ()
@@ -903,15 +904,21 @@ let view_remove_liquidity_min_kit_withdrawn (lqt, state: lqt * checker) : kit =
 
 let view_burrow_max_mintable_kit (burrow_id, state: burrow_id * checker) : kit =
   assert_checker_invariants state;
-  burrow_max_mintable_kit state.parameters (find_burrow state.burrows burrow_id)
+  let burrow = find_burrow state.burrows burrow_id in
+  let burrow = burrow_touch state.parameters burrow in
+  burrow_max_mintable_kit state.parameters burrow
 
 let view_is_burrow_overburrowed (burrow_id, state: burrow_id * checker) : bool =
   assert_checker_invariants state;
-  burrow_is_overburrowed state.parameters (find_burrow state.burrows burrow_id)
+  let burrow = find_burrow state.burrows burrow_id in
+  let burrow = burrow_touch state.parameters burrow in
+  burrow_is_overburrowed state.parameters burrow
 
 let view_is_burrow_liquidatable (burrow_id, state: burrow_id * checker) : bool =
   assert_checker_invariants state;
-  burrow_is_liquidatable state.parameters (find_burrow state.burrows burrow_id)
+  let burrow = find_burrow state.burrows burrow_id in
+  let burrow = burrow_touch state.parameters burrow in
+  burrow_is_liquidatable state.parameters burrow
 
 (* ************************************************************************* *)
 (**                            FA2_VIEWS                                     *)

--- a/src/error.ml
+++ b/src/error.ml
@@ -68,7 +68,5 @@ let[@inline] error_GetEntrypointOptFailureReceivePrice             : Ligo.int = 
 let[@inline] error_GetEntrypointOptFailureOracleEntrypoint         : Ligo.int = Ligo.int_from_literal "113"
 let[@inline] error_GetEntrypointOptFailureFA12Transfer             : Ligo.int = Ligo.int_from_literal "114"
 
-let[@inline] error_OperationOnUntouchedBurrow                      : Ligo.int = Ligo.int_from_literal "120"
-
 let[@inline] error_ContractNotDeployed                             : Ligo.int = Ligo.int_from_literal "134"
 let[@inline] error_ContractAlreadyDeployed                         : Ligo.int = Ligo.int_from_literal "135"

--- a/tests/testBurrow.ml
+++ b/tests/testBurrow.ml
@@ -31,16 +31,49 @@ let burrow_for_needs_touch_tests = make_test_burrow
 
 let suite =
   "Burrow tests" >::: [
-    ("burrow_burn_kit - fails for a burrow which needs to be touched" >::
+    ("burrow_is_optimistically_overburrowed - fails for a burrow which needs to be touched" >::
      fun _ ->
        assert_raises
          (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
          (fun () ->
-            Burrow.burrow_burn_kit
+            Burrow.burrow_is_optimistically_overburrowed
               {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              (kit_of_mukit (Ligo.nat_from_literal "1n"))
               burrow_for_needs_touch_tests
          )
+    );
+
+    ("burrow_is_cancellation_warranted - fails for a burrow which needs to be touched" >::
+     fun _ ->
+       assert_raises
+         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
+         (fun () ->
+            Burrow.burrow_is_cancellation_warranted
+              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
+              burrow_for_needs_touch_tests
+              (Ligo.tez_from_literal "0mutez")
+         )
+    );
+
+    ("compute_min_kit_for_unwarranted - fails for a burrow which needs to be touched" >::
+     fun _ ->
+       assert_raises
+         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
+         (fun () ->
+            Burrow.compute_min_kit_for_unwarranted
+              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
+              burrow_for_needs_touch_tests
+              (Ligo.tez_from_literal "0mutez")
+         )
+    );
+
+    ("burrow_burn_kit - does not fail for a burrow which needs to be touched" >::
+     fun _ ->
+       let _ =
+         Burrow.burrow_burn_kit
+           {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
+           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           burrow_for_needs_touch_tests
+       in ()
     );
 
     ("burrow_burn_kit - burning exactly outstanding_kit returns burrow with expected excess and outstanding kit" >::
@@ -121,16 +154,14 @@ let suite =
          ~real:(Burrow.burrow_address burrow)
     );
 
-    ("burrow_set_delegate - fails for a burrow which needs to be touched" >::
+    ("burrow_set_delegate - does not fail for a burrow which needs to be touched" >::
      fun _ ->
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () ->
-            Burrow.burrow_set_delegate
-              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              (Some charles_key_hash)
-              burrow_for_needs_touch_tests
-         )
+       let _ =
+         Burrow.burrow_set_delegate
+           {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
+           (Some charles_key_hash)
+           burrow_for_needs_touch_tests
+       in ()
     );
 
     ("burrow_set_delegate - does not change burrow address" >::
@@ -158,16 +189,14 @@ let suite =
          )
     );
 
-    ("burrow_deposit_tez - fails for a burrow which needs to be touched" >::
+    ("burrow_deposit_tez - does not fail for a burrow which needs to be touched" >::
      fun _ ->
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () ->
-            Burrow.burrow_deposit_tez
-              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              (Ligo.tez_from_literal "1mutez")
-              burrow_for_needs_touch_tests
-         )
+       let _ =
+         Burrow.burrow_deposit_tez
+           {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
+           (Ligo.tez_from_literal "1mutez")
+           burrow_for_needs_touch_tests
+       in ()
     );
 
     ("burrow_deposit_tez - burrow after successful deposit has expected collateral and excess" >::
@@ -204,16 +233,14 @@ let suite =
          ~real:(Burrow.burrow_address  burrow)
     );
 
-    ("burrow_withdraw_tez - fails for a burrow which needs to be touched" >::
+    ("burrow_withdraw_tez - does not fail for a burrow which needs to be touched" >::
      fun _ ->
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () ->
-            Burrow.burrow_withdraw_tez
-              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              (Ligo.tez_from_literal "1mutez")
-              burrow_for_needs_touch_tests
-         )
+       let _ =
+         Burrow.burrow_withdraw_tez
+           {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
+           (Ligo.tez_from_literal "0mutez")
+           burrow_for_needs_touch_tests
+       in ()
     );
 
     ("burrow_withdraw_tez - burrow after successful withdrawal has expected collateral" >::
@@ -264,16 +291,14 @@ let suite =
          ~real:(Burrow.burrow_outstanding_kit burrow)
     );
 
-    ("burrow_mint_kit - fails for a burrow which needs to be touched" >::
+    ("burrow_mint_kit - does not fail for a burrow which needs to be touched" >::
      fun _ ->
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () ->
-            Burrow.burrow_mint_kit
-              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              (kit_of_mukit (Ligo.nat_from_literal "1n"))
-              burrow_for_needs_touch_tests
-         )
+       let _ =
+         Burrow.burrow_mint_kit
+           {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
+           (kit_of_mukit (Ligo.nat_from_literal "0n"))
+           burrow_for_needs_touch_tests
+       in ()
     );
 
     ("burrow_mint_kit - does not change burrow address" >::
@@ -321,16 +346,16 @@ let suite =
          )
     );
 
-    ("burrow_activate - fails for a burrow which needs to be touched" >::
+    ("burrow_activate - does not fail for a burrow which needs to be touched" >::
      fun _ ->
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () ->
-            Burrow.burrow_activate
-              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              Constants.creation_deposit
-              burrow_for_needs_touch_tests
-         )
+       let burrow, _ =
+         Burrow.burrow_deactivate Parameters.initial_parameters burrow_for_needs_touch_tests in
+       let _ =
+         Burrow.burrow_activate
+           {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
+           Constants.creation_deposit
+           burrow
+       in ()
     );
 
     ("burrow_activate - fails for a burrow which is already active" >::
@@ -393,15 +418,13 @@ let suite =
          ~real:(Burrow.burrow_address  burrow)
     );
 
-    ("burrow_deactivate - fails for a burrow which needs to be touched" >::
+    ("burrow_deactivate - does not fail for a burrow which needs to be touched" >::
      fun _ ->
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () ->
-            Burrow.burrow_deactivate
-              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              burrow_for_needs_touch_tests
-         )
+       let _ =
+         Burrow.burrow_deactivate
+           {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
+           burrow_for_needs_touch_tests
+       in ()
     );
 
     ("burrow_deactivate - fails for a burrow which is already inactive" >::
@@ -508,15 +531,13 @@ let suite =
          )
     );
 
-    ("burrow_request_liquidation - fails for a burrow which needs to be touched" >::
+    ("burrow_request_liquidation - does not fail for a burrow which needs to be touched" >::
      fun _ ->
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () ->
-            Burrow.burrow_request_liquidation
-              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              burrow_for_needs_touch_tests
-         )
+       let _ =
+         Burrow.burrow_request_liquidation
+           {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
+           burrow_for_needs_touch_tests
+       in ()
     );
 
     (* Note: this is a bit overkill but testing anyways since the address field is extremely important *)

--- a/tests/testBurrow.ml
+++ b/tests/testBurrow.ml
@@ -31,41 +31,6 @@ let burrow_for_needs_touch_tests = make_test_burrow
 
 let suite =
   "Burrow tests" >::: [
-    ("burrow_is_optimistically_overburrowed - fails for a burrow which needs to be touched" >::
-     fun _ ->
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () ->
-            Burrow.burrow_is_optimistically_overburrowed
-              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              burrow_for_needs_touch_tests
-         )
-    );
-
-    ("burrow_is_cancellation_warranted - fails for a burrow which needs to be touched" >::
-     fun _ ->
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () ->
-            Burrow.burrow_is_cancellation_warranted
-              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              burrow_for_needs_touch_tests
-              (Ligo.tez_from_literal "0mutez")
-         )
-    );
-
-    ("compute_min_kit_for_unwarranted - fails for a burrow which needs to be touched" >::
-     fun _ ->
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () ->
-            Burrow.compute_min_kit_for_unwarranted
-              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              burrow_for_needs_touch_tests
-              (Ligo.tez_from_literal "0mutez")
-         )
-    );
-
     ("burrow_burn_kit - does not fail for a burrow which needs to be touched" >::
      fun _ ->
        let _ =
@@ -176,17 +141,6 @@ let suite =
        assert_address_equal
          ~expected:(Burrow.burrow_address burrow0)
          ~real:(Burrow.burrow_address burrow)
-    );
-
-    ("burrow_is_overburrowed - fails for a burrow which needs to be touched" >::
-     fun _ ->
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () ->
-            Burrow.burrow_is_overburrowed
-              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              burrow_for_needs_touch_tests
-         )
     );
 
     ("burrow_deposit_tez - does not fail for a burrow which needs to be touched" >::
@@ -506,29 +460,6 @@ let suite =
        assert_address_equal
          ~expected:(Burrow.burrow_address burrow0)
          ~real:(Burrow.burrow_address  burrow)
-    );
-
-    ("burrow_is_liquidatable - fails for a burrow which needs to be touched" >::
-     fun _ ->
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () ->
-            Burrow.burrow_is_liquidatable
-              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              burrow_for_needs_touch_tests
-         )
-    );
-
-    ("compute_min_kit_for_unwarranted - fails for a burrow which needs to be touched" >::
-     fun _ ->
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () ->
-            Burrow.compute_min_kit_for_unwarranted
-              {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-              burrow_for_needs_touch_tests
-              (Ligo.tez_from_literal "1mutez")
-         )
     );
 
     ("burrow_request_liquidation - does not fail for a burrow which needs to be touched" >::

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -984,7 +984,7 @@ let suite =
        let (ops, checker) = Checker.entrypoint_liquidation_auction_claim_win (checker, auction_id) in
 
        assert_operation_list_equal
-         ~expected:[LigoOp.Tezos.unit_transaction () (Ligo.tez_from_literal "3_156_451mutez") (Option.get (LigoOp.Tezos.get_contract_opt alice_addr))]
+         ~expected:[LigoOp.Tezos.unit_transaction () (Ligo.tez_from_literal "3_156_446mutez") (Option.get (LigoOp.Tezos.get_contract_opt alice_addr))]
          ~real:ops;
 
        (* This should fail; shouldn't be able to claim the win twice. *)
@@ -1046,7 +1046,7 @@ let suite =
        ()
     );
 
-    ("deposit_tez - fails on untouched burrows" >::
+    ("deposit_tez - does not fail on untouched burrows" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let amount = Constants.creation_deposit in
@@ -1058,12 +1058,11 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
        (* Try to deposit some tez to the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:amount;
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () -> Checker.entrypoint_deposit_tez (checker, Ligo.nat_from_literal "0n"))
+       let _ = Checker.entrypoint_deposit_tez (checker, Ligo.nat_from_literal "0n") in
+       ()
     );
 
-    ("entrypoint_withdraw_tez - fails on untouched burrows" >::
+    ("entrypoint_withdraw_tez - does not fail on untouched burrows" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let amount = Ligo.add_tez_tez Constants.creation_deposit Constants.creation_deposit in
@@ -1075,12 +1074,11 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
        (* Try to withdraw some tez from the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () -> Checker.entrypoint_withdraw_tez (checker, (Constants.creation_deposit, Ligo.nat_from_literal "0n")))
+       let _ = Checker.entrypoint_withdraw_tez (checker, (Constants.creation_deposit, Ligo.nat_from_literal "0n")) in
+       ()
     );
 
-    ("entrypoint_mint_kit - fails on untouched burrows" >::
+    ("entrypoint_mint_kit - does not fail on untouched burrows" >::
      fun _ ->
        Ligo.Tezos.reset ();
        (* Create a burrow *)
@@ -1092,12 +1090,11 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
        (* Try to mint some kit out of the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () -> Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "1n"))))
+       let _ = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "1n"))) in
+       ()
     );
 
-    ("entrypoint_burn_kit - fails on untouched burrows" >::
+    ("entrypoint_burn_kit - does not fail on untouched burrows" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let amount = Ligo.add_tez_tez Constants.creation_deposit Constants.creation_deposit in
@@ -1112,12 +1109,11 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
        (* Try to burn some kit into the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () -> Checker.entrypoint_burn_kit (checker, (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "1n"))))
+       let _ = Checker.entrypoint_burn_kit (checker, (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "1n"))) in
+       ()
     );
 
-    ("entrypoint_activate_burrow - fails on untouched burrows" >::
+    ("entrypoint_activate_burrow - does not fail on untouched burrows" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let amount = Constants.creation_deposit in
@@ -1132,12 +1128,11 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
        (* Try to activate the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:amount;
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () -> Checker.entrypoint_activate_burrow (checker, Ligo.nat_from_literal "0n"))
+       let _ = Checker.entrypoint_activate_burrow (checker, Ligo.nat_from_literal "0n") in
+       ()
     );
 
-    ("entrypoint_deactivate_burrow - fails on untouched burrows" >::
+    ("entrypoint_deactivate_burrow - does not fail on untouched burrows" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let amount = Constants.creation_deposit in
@@ -1149,12 +1144,11 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
        (* Try to deactivate the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () -> Checker.entrypoint_deactivate_burrow (checker, (Ligo.nat_from_literal "0n", !Ligo.Tezos.sender)))
+       let _ = Checker.entrypoint_deactivate_burrow (checker, (Ligo.nat_from_literal "0n", !Ligo.Tezos.sender)) in
+       ()
     );
 
-    ("entrypoint_mark_for_liquidation - fails on untouched burrows" >::
+    ("entrypoint_mark_for_liquidation - does not fail on untouched burrows" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let amount = Constants.creation_deposit in
@@ -1167,14 +1161,16 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
        (* Try to mark the untouched burrow for liquidation *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       (* TODO: Would be nice to create the conditions for entrypoint_mark_for_liquidation
+        * to really succeed instead of failing for another reason. *)
        assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () -> Checker.entrypoint_mark_for_liquidation (checker, burrow_id))
+         (Failure (Ligo.string_of_int error_NotLiquidationCandidate))
+         (fun () -> Checker.entrypoint_mark_for_liquidation (checker, burrow_id));
     );
 
     (* TODO: Add test "entrypoint_cancel_liquidation_slice - fails on untouched burrows" *)
 
-    ("entrypoint_set_burrow_delegate - fails on untouched burrows" >::
+    ("entrypoint_set_burrow_delegate - does not fail on untouched burrows" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let amount = Constants.creation_deposit in
@@ -1186,12 +1182,11 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
        (* Try to set the delegate of the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () -> Checker.entrypoint_set_burrow_delegate (checker, (Ligo.nat_from_literal "0n", None)))
+       let _ = Checker.entrypoint_set_burrow_delegate (checker, (Ligo.nat_from_literal "0n", None)) in
+       ()
     );
 
-    ("view_burrow_max_mintable_kit - fails on untouched burrows" >::
+    ("view_burrow_max_mintable_kit - does not fail on untouched burrows" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let amount = Constants.creation_deposit in
@@ -1204,12 +1199,11 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
        (* Try to view the max mintable kit from the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () -> Checker.view_burrow_max_mintable_kit (burrow_id, checker))
+       let _ = Checker.view_burrow_max_mintable_kit (burrow_id, checker) in
+       ()
     );
 
-    ("view_is_burrow_overburrowed - fails on untouched burrows" >::
+    ("view_is_burrow_overburrowed - does not fail on untouched burrows" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let amount = Constants.creation_deposit in
@@ -1222,12 +1216,11 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
        (* Try to view whether the untouched burrow is overburrowed *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () -> Checker.view_is_burrow_overburrowed (burrow_id, checker))
+       let _ = Checker.view_is_burrow_overburrowed (burrow_id, checker) in
+       ()
     );
 
-    ("view_is_burrow_liquidatable - fails on untouched burrows" >::
+    ("view_is_burrow_liquidatable - does not fail on untouched burrows" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let amount = Constants.creation_deposit in
@@ -1240,8 +1233,7 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
        (* Try to view whether the untouched burrow is liquidatable *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       assert_raises
-         (Failure (Ligo.string_of_int error_OperationOnUntouchedBurrow))
-         (fun () -> Checker.view_is_burrow_liquidatable (burrow_id, checker))
+       let _ = Checker.view_is_burrow_liquidatable (burrow_id, checker) in
+       ()
     );
   ]


### PR DESCRIPTION
Closes #126.

This pertains to the entrypoints operating on burrows
- deposit_tez / withdraw_tez
- mint_kit / burn_kit
- activate / deactivate
- set_delegate
- request_liquidation
- cancel_liquidation_slice

and the views accessing burrow data
- view_burrow_max_mintable_kit
- view_is_burrow_overburrowed
- view_is_burrow_liquidatable

but NOT the predicates/utility functions (since these
are internally called multiple times so this change
would incur unnecessary gas costs and bloat the size
of the contract)
- burrow_is_overburrowed
- burrow_max_mintable_kit
- burrow_is_liquidatable
- burrow_is_cancellation_warranted
- compute_min_kit_for_unwarranted
- burrow_is_optimistically_overburrowed

Additionally, this PR
- complements the tests to ensure that operating on
  untouched burrows indeed does not fail, and
- changes burrow_touch to floor when updating the
  outstanding kit. This aligns better with the global
  calculation of outstanding kit, and does not penalize
  users for frequently interacting with their burrow.

Bytecount updates (adds ~500B per affected entrypoint):
- burn_kit: ~1368 bytes => ~1872 bytes
- mint_kit: ~1673 bytes => ~2130 bytes
- deposit_tez: ~770 bytes => ~1269 bytes
- touch_burrow: ~827 bytes => ~754 bytes
- withdraw_tez: ~1227 bytes => ~1690 bytes
- activate_burrow: ~902 bytes => ~1391 bytes
- deactivate_burrow: ~1439 bytes => ~1902 bytes
- set_burrow_delegate: ~782 bytes => ~1291 bytes
- mark_for_liquidation: ~19365 bytes => ~19838 bytes
- cancel_liquidation_slice: ~13690 bytes => ~14229 bytes