### PR TITLE
Initial stress test for liquidation auction

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ doCheck ? false }:
+{ doCheck ? false, e2eTestsHack ? false }:
 
 let
   sources = import ./nix/sources.nix { };
@@ -69,6 +69,11 @@ rec
       name = "checker-michelson";
       buildInputs = [ ligoBinary ] ++ (with pkgs; [ ruby ]) ++ ocamlDeps pkgs;
       src = checkerSource;
+      patchPhase = pkgs.lib.optional e2eTestsHack ''
+        set -x
+        cat ${./patches/e2e-tests-hack.patch} | patch -p1
+        set +x
+      '';
       buildPhase = ''
         export HOME=$(mktemp -d)
         make build-ligo

--- a/default.nix
+++ b/default.nix
@@ -69,6 +69,9 @@ rec
       name = "checker-michelson";
       buildInputs = [ ligoBinary ] ++ (with pkgs; [ ruby ]) ++ ocamlDeps pkgs;
       src = checkerSource;
+      # On E2E tests, we are using a patched version of checker to be able to experiment
+      # with index changes without having to wait for the protected index to catch up.
+      # It's a hack, and shouldn't be used for anything else than the tests.
       patchPhase = pkgs.lib.optional e2eTestsHack ''
         set -x
         cat ${./patches/e2e-tests-hack.patch} | patch -p1

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -255,10 +255,9 @@ class LiquidationsStressTest(SandboxedTestCase):
             (self.client.key.public_key_hash(), 1)
         ).storage_view()
 
-
         call_bulk(
-          [checker.mint_kit(burrow_no, max_mintable_kit) for burrow_no in burrows],
-          batch_size=100
+            [checker.mint_kit(burrow_no, max_mintable_kit) for burrow_no in burrows],
+            batch_size=100,
         )
 
         # Change the index (kits are 100x valuable)
@@ -277,8 +276,13 @@ class LiquidationsStressTest(SandboxedTestCase):
         #
         # This should use the push_back method of the AVL tree.
         call_bulk(
-          [checker.mark_for_liquidation((self.client.key.public_key_hash(), burrow_no)) for burrow_no in burrows],
-          batch_size=40
+            [
+                checker.mark_for_liquidation(
+                    (self.client.key.public_key_hash(), burrow_no)
+                )
+                for burrow_no in burrows
+            ],
+            batch_size=40,
         )
 
         # This touch starts a liquidation auction

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -10,6 +10,10 @@ from pytezos.contract.interface import ContractInterface
 from pytezos.operation import MAX_OPERATIONS_TTL
 
 PROJECT_ROOT = os.path.join(os.path.dirname(__file__), "../")
+CHECKER_DIR = os.environ.get(
+  "CHECKER_DIR",
+  os.path.join(PROJECT_ROOT, "generated/michelson")
+)
 
 from checker_client.checker import *
 
@@ -60,7 +64,7 @@ class E2ETest(SandboxedTestCase):
         print("Deploying Checker.")
         checker = deploy_checker(
             self.client,
-            checker_dir=os.path.join(PROJECT_ROOT, "generated/michelson"),
+            checker_dir=CHECKER_DIR,
             oracle=oracle.context.address,
             ctez=ctez["fa12_ctez"].context.address,
             ttl=MAX_OPERATIONS_TTL,
@@ -176,7 +180,7 @@ class LiquidationsStressTest(SandboxedTestCase):
         print("Deploying Checker.")
         checker = deploy_checker(
             self.client,
-            checker_dir=os.path.join(PROJECT_ROOT, "generated/michelson"),
+            checker_dir=CHECKER_DIR,
             oracle=oracle.context.address,
             ctez=ctez["fa12_ctez"].context.address,
             ttl=MAX_OPERATIONS_TTL,

--- a/patches/e2e-tests-hack.patch
+++ b/patches/e2e-tests-hack.patch
@@ -1,0 +1,12 @@
+diff --git a/src/parameters.ml b/src/parameters.ml
+index 395ecd1..4907c90 100644
+--- a/src/parameters.ml
++++ b/src/parameters.ml
+@@ -211,6 +211,7 @@ let[@inline] compute_current_burrow_fee_index (last_burrow_fee_index: fixedpoint
+ *)
+ let[@inline] compute_current_protected_index (last_protected_index: Ligo.tez) (current_index: Ligo.tez) (duration_in_seconds: Ligo.int) : Ligo.tez =
+   assert (Ligo.gt_tez_tez last_protected_index (Ligo.tez_from_literal "0mutez"));
++  let duration_in_seconds = Ligo.mul_int_int duration_in_seconds (Ligo.int_from_literal "1000") in
+   let last_protected_index = tez_to_mutez last_protected_index in
+   fraction_to_tez_floor
+     (clamp_int

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -18,7 +18,6 @@ open Error
 open Fa12Interface
 open Fa2Interface
 open Mem
-open Ptr
 
 (* BEGIN_OCAML *)
 let assert_checker_invariants (state: checker) : unit =
@@ -616,13 +615,13 @@ let entrypoint_remove_liquidity (state, p: checker * (lqt * ctez * kit * Ligo.ti
 (**                          LIQUIDATION AUCTIONS                            *)
 (* ************************************************************************* *)
 
-let entrypoint_liquidation_auction_place_bid (state, (auction_id, kit): checker * (Ligo.nat * kit)) : LigoOp.operation list * checker =
+let entrypoint_liquidation_auction_place_bid (state, (auction_id, kit): checker * (liquidation_auction_id * kit)) : LigoOp.operation list * checker =
   assert_checker_invariants state;
   let _ = ensure_no_tez_given () in
 
   let bid = { address=(!Ligo.Tezos.sender); kit=kit; } in
   let current_auction = liquidation_auction_get_current_auction state.liquidation_auctions in
-  let () = if nat_of_ptr (ptr_of_avl_ptr current_auction.contents) = auction_id
+  let () = if current_auction.contents = auction_id
     then ()
     else Ligo.failwith error_InvalidLiquidationAuction in
 
@@ -927,7 +926,7 @@ let view_is_burrow_liquidatable (burrow_id, state: burrow_id * checker) : bool =
 let view_current_liquidation_auction_minimum_bid ((), state: unit * checker) : view_current_liquidation_auction_minimum_bid_result =
   assert_checker_invariants state;
   let auction = liquidation_auction_get_current_auction state.liquidation_auctions in
-  { auction_id = nat_of_ptr (ptr_of_avl_ptr auction.contents)
+  { auction_id = auction.contents
   ; minimum_bid = liquidation_auction_current_auction_minimum_bid auction
   }
 

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -924,6 +924,13 @@ let view_is_burrow_liquidatable (burrow_id, state: burrow_id * checker) : bool =
   let burrow = burrow_touch state.parameters burrow in
   burrow_is_liquidatable state.parameters burrow
 
+let view_current_liquidation_auction_minimum_bid ((), state: unit * checker) : view_current_liquidation_auction_minimum_bid_result =
+  assert_checker_invariants state;
+  let auction = liquidation_auction_get_current_auction state.liquidation_auctions in
+  { auction_id = nat_of_ptr (ptr_of_avl_ptr auction.contents)
+  ; minimum_bid = liquidation_auction_current_auction_minimum_bid auction
+  }
+
 (* ************************************************************************* *)
 (**                            FA2_VIEWS                                     *)
 (* ************************************************************************* *)

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -205,9 +205,10 @@ val entrypoint_remove_liquidity : checker * (lqt * ctez * kit * Ligo.timestamp) 
     auction, or if the bid is too low.
 
     Parameters:
+    - identifier of the current liquidation auction
     - The amount of kit to be bid
 *)
-val entrypoint_liquidation_auction_place_bid : checker * kit -> LigoOp.operation list * checker
+val entrypoint_liquidation_auction_place_bid : checker * (Ligo.nat * kit) -> LigoOp.operation list * checker
 
 (** Claim the rewards of a completed liquidation auction. Fails if the sender
     is not the auction winner, if the auction is still ongoing, or if the

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -258,6 +258,8 @@ val view_add_liquidity_min_lqt_minted : (ctez * checker) -> lqt
 val view_remove_liquidity_min_ctez_withdrawn : (lqt * checker) -> ctez
 val view_remove_liquidity_min_kit_withdrawn : (lqt * checker) -> kit
 
+val view_current_liquidation_auction_minimum_bid: (unit * checker) -> view_current_liquidation_auction_minimum_bid_result
+
 val view_burrow_max_mintable_kit : (burrow_id * checker) -> kit
 val view_is_burrow_overburrowed : (burrow_id * checker) -> bool
 val view_is_burrow_liquidatable : (burrow_id * checker) -> bool

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -208,7 +208,7 @@ val entrypoint_remove_liquidity : checker * (lqt * ctez * kit * Ligo.timestamp) 
     - identifier of the current liquidation auction
     - The amount of kit to be bid
 *)
-val entrypoint_liquidation_auction_place_bid : checker * (Ligo.nat * kit) -> LigoOp.operation list * checker
+val entrypoint_liquidation_auction_place_bid : checker * (liquidation_auction_id * kit) -> LigoOp.operation list * checker
 
 (** Claim the rewards of a completed liquidation auction. Fails if the sender
     is not the auction winner, if the auction is still ongoing, or if the

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -3,6 +3,7 @@ open Burrow
 open CfmmTypes
 open Parameters
 open LiquidationAuctionTypes
+open LiquidationAuctionPrimitiveTypes
 open Fa2Interface
 
 type burrow_map = (burrow_id, burrow) Ligo.big_map
@@ -48,6 +49,6 @@ type wrapper =
   }
 
 type view_current_liquidation_auction_minimum_bid_result =
-  { auction_id: Ligo.nat
+  { auction_id: liquidation_auction_id
   ; minimum_bid: kit
   }

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -1,3 +1,4 @@
+open Kit
 open Burrow
 open CfmmTypes
 open Parameters
@@ -44,4 +45,9 @@ type wrapper =
   { lazy_functions : lazy_function_map
   ; metadata: (string, Ligo.bytes) Ligo.big_map
   ; deployment_state : deployment_state
+  }
+
+type view_current_liquidation_auction_minimum_bid_result =
+  { auction_id: Ligo.nat
+  ; minimum_bid: kit
   }

--- a/src/error.ml
+++ b/src/error.ml
@@ -55,6 +55,7 @@ let[@inline] error_NotACompletedSlice                              : Ligo.int = 
 let[@inline] error_InvalidAvlPtr                                   : Ligo.int = Ligo.int_from_literal "88"
 let[@inline] error_InvalidLeafPtr                                  : Ligo.int = Ligo.int_from_literal "89"
 let[@inline] error_BurrowAlreadyExists                             : Ligo.int = Ligo.int_from_literal "90"
+let[@inline] error_InvalidLiquidationAuction                       : Ligo.int = Ligo.int_from_literal "91"
 
 let[@inline] error_GetContractOptFailure                           : Ligo.int = Ligo.int_from_literal "95"
 

--- a/src/ligo.ml
+++ b/src/ligo.ml
@@ -143,6 +143,10 @@ let int_from_literal s =
   with exc -> failwith ("Ligo.int_from_literal: " ^ Printexc.to_string exc)
 
 let int_from_int64 = Z.of_int64
+let nat_from_int64 (t: Int64.t) =
+  let r = Z.of_int64 t in
+  assert (r > Z.zero);
+  r
 
 let add_int_int = Z.add
 

--- a/src/ligo.ml
+++ b/src/ligo.ml
@@ -142,10 +142,9 @@ let int_from_literal s =
   try parse_int_with_suffix "" s
   with exc -> failwith ("Ligo.int_from_literal: " ^ Printexc.to_string exc)
 
-let int_from_int64 = Z.of_int64
 let nat_from_int64 (t: Int64.t) =
   let r = Z.of_int64 t in
-  assert (r > Z.zero);
+  assert (r >= Z.zero);
   r
 
 let add_int_int = Z.add

--- a/src/ligo.mli
+++ b/src/ligo.mli
@@ -172,7 +172,6 @@ val address_from_literal : String.t -> address (* IN LIGO: type-annotate with "a
 val key_hash_from_literal : String.t -> key_hash (* IN LIGO: type-annotate with "key_hash". *)
 val bytes_from_literal : String.t -> bytes     (* IN LIGO: replace the double quotes with parens *)
 
-val int_from_int64: Int64.t -> int                      (* NON-LIGO, temporary*)
 val nat_from_int64: Int64.t -> nat                      (* NON-LIGO, temporary*)
 val timestamp_from_seconds_literal : Int.t -> timestamp (* NON-LIGO: in LIGO they come from strings, or Tezos.now *)
 

--- a/src/ligo.mli
+++ b/src/ligo.mli
@@ -173,6 +173,7 @@ val key_hash_from_literal : String.t -> key_hash (* IN LIGO: type-annotate with 
 val bytes_from_literal : String.t -> bytes     (* IN LIGO: replace the double quotes with parens *)
 
 val int_from_int64: Int64.t -> int                      (* NON-LIGO, temporary*)
+val nat_from_int64: Int64.t -> nat                      (* NON-LIGO, temporary*)
 val timestamp_from_seconds_literal : Int.t -> timestamp (* NON-LIGO: in LIGO they come from strings, or Tezos.now *)
 
 (* OPERATIONS ON int *)

--- a/src/ptr.ml
+++ b/src/ptr.ml
@@ -1,11 +1,12 @@
-type ptr = Ligo.int
+type ptr = Ligo.nat
 (* BEGIN_OCAML *) [@@deriving show] (* END_OCAML *)
 
-let[@inline] ptr_null = Ligo.int_from_literal "0"
-let[@inline] ptr_init = Ligo.int_from_literal "1"
-let[@inline] ptr_next (t: ptr) = Ligo.add_int_int t (Ligo.int_from_literal "1")
+let[@inline] nat_of_ptr (t: ptr) = t
+let[@inline] ptr_null = Ligo.nat_from_literal "0n"
+let[@inline] ptr_init = Ligo.nat_from_literal "1n"
+let[@inline] ptr_next (t: ptr) = Ligo.add_nat_nat t (Ligo.nat_from_literal "1n")
 
 (* BEGIN_OCAML *)
-let compare_ptr = Common.compare_int
-let random_ptr () = Ligo.int_from_int64 (Random.int64 Int64.max_int)
+let compare_ptr = Common.compare_nat
+let random_ptr () = Ligo.nat_from_int64 (Random.int64 Int64.max_int)
 (* END_OCAML *)

--- a/src/ptr.ml
+++ b/src/ptr.ml
@@ -1,7 +1,6 @@
 type ptr = Ligo.nat
 (* BEGIN_OCAML *) [@@deriving show] (* END_OCAML *)
 
-let[@inline] nat_of_ptr (t: ptr) = t
 let[@inline] ptr_null = Ligo.nat_from_literal "0n"
 let[@inline] ptr_init = Ligo.nat_from_literal "1n"
 let[@inline] ptr_next (t: ptr) = Ligo.add_nat_nat t (Ligo.nat_from_literal "1n")

--- a/src/ptr.mli
+++ b/src/ptr.mli
@@ -1,5 +1,6 @@
 type ptr (* George: perhaps I'd prefer a phantom parameter to not mix up pointers. *)
 
+val nat_of_ptr : ptr -> Ligo.nat
 val ptr_null : ptr
 val ptr_init : ptr
 val ptr_next : ptr -> ptr

--- a/src/ptr.mli
+++ b/src/ptr.mli
@@ -1,6 +1,5 @@
 type ptr (* George: perhaps I'd prefer a phantom parameter to not mix up pointers. *)
 
-val nat_of_ptr : ptr -> Ligo.nat
 val ptr_null : ptr
 val ptr_init : ptr
 val ptr_next : ptr -> ptr

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -895,12 +895,7 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:(5*60) ~blocks_passed:5 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
        assert_raises
          (Failure (Ligo.string_of_int error_NoOpenAuction))
-         (fun () ->
-            Checker.entrypoint_liquidation_auction_place_bid
-              ( checker
-              , (kit_of_mukit (Ligo.nat_from_literal "1_000n"))
-              )
-         );
+         (fun () ->Checker.view_current_liquidation_auction_minimum_bid ((), checker));
 
        let kit_before_reward = get_balance_of checker bob_addr kit_token_id in
        let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_200_000mutez") in
@@ -922,11 +917,12 @@ let suite =
        let kit_after_reward = get_balance_of checker alice_addr kit_token_id in
 
        let touch_reward = Ligo.sub_nat_nat kit_after_reward kit_before_reward in
+       let auction_id = (Checker.view_current_liquidation_auction_minimum_bid ((), checker)).auction_id in
 
        let (ops, checker) =
          Checker.entrypoint_liquidation_auction_place_bid
            ( checker
-           , (kit_of_mukit (Ligo.nat_from_literal "4_200_000n"))
+           , (auction_id, kit_of_mukit (Ligo.nat_from_literal "4_200_000n"))
            ) in
 
        let auction_id =

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -736,6 +736,39 @@ let suite =
          (fun () -> Checker.entrypoint_update_operators (empty_checker, []))
     );
 
+    ("entrypoint_liquidation_auction_place_bid: should only allow the current auction" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let checker = { empty_checker with last_price = Some (Ligo.nat_from_literal "1_000_000n") } in
+
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let _, checker = Checker.entrypoint_touch (checker, ()) in
+
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "200_000_000mutez");
+       let _, checker = Checker.entrypoint_create_burrow (checker, (Ligo.nat_from_literal "0n", None)) in
+       let max_kit = Checker.view_burrow_max_mintable_kit ((alice_addr, Ligo.nat_from_literal "0n"), checker) in
+
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let _, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", max_kit)) in
+       let checker = { checker with last_price = Some (Ligo.nat_from_literal "10_000_000n") } in
+       let _, checker = Checker.entrypoint_touch (checker, ()) in
+
+       Ligo.Tezos.new_transaction ~seconds_passed:1_000_000 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let _, checker = Checker.entrypoint_touch (checker, ()) in
+
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let _, checker = Checker.entrypoint_touch_burrow (checker, (alice_addr, Ligo.nat_from_literal "0n")) in
+       let _, checker = Checker.entrypoint_mark_for_liquidation (checker, (alice_addr, Ligo.nat_from_literal "0n")) in
+       let _, checker = Checker.entrypoint_touch (checker, ()) in
+
+       let res = Checker.view_current_liquidation_auction_minimum_bid ((), checker) in
+       let other_ptr = match res.auction_id with AVLPtr i -> Ptr.ptr_next i in
+
+       assert_raises
+         (Failure (Ligo.string_of_int error_InvalidLiquidationAuction))
+         (fun () -> Checker.entrypoint_liquidation_auction_place_bid (checker, (AVLPtr other_ptr, res.minimum_bid)));
+    );
+
     ("can complete a liquidation auction" >::
      fun _ ->
        Ligo.Tezos.reset ();

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -895,7 +895,7 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:(5*60) ~blocks_passed:5 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
        assert_raises
          (Failure (Ligo.string_of_int error_NoOpenAuction))
-         (fun () ->Checker.view_current_liquidation_auction_minimum_bid ((), checker));
+         (fun () -> Checker.view_current_liquidation_auction_minimum_bid ((), checker));
 
        let kit_before_reward = get_balance_of checker bob_addr kit_token_id in
        let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_200_000mutez") in


### PR DESCRIPTION
This PR adds a new e2e test called `LiquidationsStressTest` which creates a thousand liquidation slices.

It mainly tests the `push_back` function, and it seems to be well below the gas limit since we're triggering 40 liquidations as a bulk operation. We should add similar tests for other AVL functions too (`split` and `del` comes to mind).

While doing that, I had to implement a few other minor changes:

* On this test, we are running a patch version of Checker on which the protected index tracks the actual index much more closely, in order to be able to trigger liquidations quickly. To use this:

```
CHECKER_DIR=$(nix-build -A michelson --arg e2eTestsHack true) python e2e/main.py LiquidationsStressTest
```

When we end up in a state where our E2E tests run reliably, we should add this to the CI.

* Our 'ptr' type is now a 'nat' instead of an 'int'. I just felt like it suits more since it always is positive.
* Our 'liquidation_auction_place_bid' function now expects an 'auction_id'
* We have a 'current_liquidation_auction_minimum_bid' view, which also returns the auction id.

