### PR TITLE
Add missing tests for view_total_supply and view_all_tokens

### DIFF
--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -829,6 +829,29 @@ let suite =
        ()
     );
 
+    ("view_total_supply (FA2) - initial kit supply" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let total_mukit_amount = Checker.view_total_supply (Fa2Interface.kit_token_id, empty_checker) in
+       assert_nat_equal ~expected:(Ligo.nat_from_literal "0n") ~real:total_mukit_amount;
+       ()
+    );
+
+    ("view_total_supply (FA2) - initial lqt supply" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let total_mulqt_amount = Checker.view_total_supply (Fa2Interface.lqt_token_id, empty_checker) in
+       assert_nat_equal ~expected:(Ligo.nat_from_literal "0n") ~real:total_mulqt_amount;
+       ()
+    );
+
+    ("view_total_supply (FA2) - undefined token id" >::
+     fun _ ->
+       assert_raises
+         (Failure "FA2_TOKEN_UNDEFINED")
+         (fun () -> Checker.view_total_supply (Ligo.nat_from_literal "3n", empty_checker))
+    );
+
     (* ************************************************************************* *)
     (**                      LiquidationAuctions                                 *)
     (* ************************************************************************* *)

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -852,6 +852,16 @@ let suite =
          (fun () -> Checker.view_total_supply (Ligo.nat_from_literal "3n", empty_checker))
     );
 
+    ("view_all_tokens (FA2)" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let all_tokens = Checker.view_all_tokens ((), empty_checker) in
+       assert_nat_list_equal
+         ~expected:[ Fa2Interface.kit_token_id; Fa2Interface.lqt_token_id ]
+         ~real:all_tokens;
+       ()
+    );
+
     (* ************************************************************************* *)
     (**                      LiquidationAuctions                                 *)
     (* ************************************************************************* *)

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -40,6 +40,9 @@ let assert_operation_list_equal ~expected ~real = OUnit2.assert_equal ~printer:s
 type slice_option = LiquidationAuctionPrimitiveTypes.liquidation_slice option [@@deriving show]
 let assert_slice_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_slice_option expected real
 
+type nat_list = Ligo.nat list [@@deriving show]
+let assert_nat_list_equal ~expected ~real = OUnit2.assert_equal ~printer:show_nat_list expected real
+
 let eq_cfmm (u1: CfmmTypes.cfmm) (u2: CfmmTypes.cfmm) : bool =
   Ctez.ctez_compare u1.ctez u2.ctez = 0
   && Kit.kit_compare u1.kit u2.kit = 0


### PR DESCRIPTION
Test coverage also slightly increases (from 84.32% to 84.82%).