### PR TITLE
Add additional unit tests for burrow.ml

### DIFF
--- a/tests/testBurrow.ml
+++ b/tests/testBurrow.ml
@@ -644,6 +644,85 @@ let suite =
             (Ligo.mul_int_int lp_den f_den))
     );
 
+    (
+      "burrow_return_kit_from_auction - expected value for burrow with outstanding kit" >::
+      fun _ -> (
+          let burrow = Burrow.make_burrow_for_test
+              ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10n"))
+              ~excess_kit:kit_zero
+              ~active:true
+              ~address:alice_addr
+              ~delegate:None
+              ~collateral:(Ligo.tez_from_literal "0mutez")
+              ~adjustment_index:fixedpoint_one
+              ~collateral_at_auction:(Ligo.tez_from_literal "3mutez")
+              ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+
+          let slice = let open LiquidationAuctionPrimitiveTypes in
+            {
+              burrow=(alice_addr, Ligo.nat_from_literal "0n");
+              tez=(Ligo.tez_from_literal "2mutez");
+              min_kit_for_unwarranted=None;
+            }
+          in
+
+          let burrow_out = Burrow.burrow_return_kit_from_auction slice (kit_of_mukit (Ligo.nat_from_literal "9n")) burrow in
+          let burrow_expected = Burrow.make_burrow_for_test
+              ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+              ~excess_kit:kit_zero
+              ~active:true
+              ~address:alice_addr
+              ~delegate:None
+              ~collateral:(Ligo.tez_from_literal "0mutez")
+              ~adjustment_index:fixedpoint_one
+              ~collateral_at_auction:(Ligo.tez_from_literal "1mutez")
+              ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+
+          assert_burrow_equal
+            ~expected:burrow_expected
+            ~real:burrow_out
+        ));
+
+    (
+      "burrow_return_kit_from_auction - expected value for burrow with excess kit" >::
+      fun _ -> (
+          let burrow = Burrow.make_burrow_for_test
+              ~outstanding_kit:kit_zero
+              ~excess_kit:(kit_of_mukit (Ligo.nat_from_literal "10n"))
+              ~active:true
+              ~address:alice_addr
+              ~delegate:None
+              ~collateral:(Ligo.tez_from_literal "0mutez")
+              ~adjustment_index:fixedpoint_one
+              ~collateral_at_auction:(Ligo.tez_from_literal "3mutez")
+              ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+
+          let slice = let open LiquidationAuctionPrimitiveTypes in
+            {
+              burrow=(alice_addr, Ligo.nat_from_literal "0n");
+              tez=(Ligo.tez_from_literal "2mutez");
+              min_kit_for_unwarranted=None;
+            }
+          in
+
+          let burrow_out = Burrow.burrow_return_kit_from_auction slice (kit_of_mukit (Ligo.nat_from_literal "9n")) burrow in
+          let burrow_expected = Burrow.make_burrow_for_test
+              ~outstanding_kit:kit_zero
+              ~excess_kit:(kit_of_mukit (Ligo.nat_from_literal "19n"))
+              ~active:true
+              ~address:alice_addr
+              ~delegate:None
+              ~collateral:(Ligo.tez_from_literal "0mutez")
+              ~adjustment_index:fixedpoint_one
+              ~collateral_at_auction:(Ligo.tez_from_literal "1mutez")
+              ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+
+          assert_burrow_equal
+            ~expected:burrow_expected
+            ~real:burrow_out
+        ));
+
+
     (* =========================================================================================== *)
     (* Property tests for ensuring methods don't allow a burrow to become overburrowed *)
     (* =========================================================================================== *)

--- a/tests/testBurrow.ml
+++ b/tests/testBurrow.ml
@@ -722,7 +722,25 @@ let suite =
             ~real:burrow_out
         ));
 
+    (
+      "burrow_is_cancellation_warranted - warranted cancellation" >::
+      fun _ -> (
+          let burrow = Burrow.make_burrow_for_test
+              ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "4_657_142n"))
+              ~excess_kit:kit_zero
+              ~active:true
+              ~address:alice_addr
+              ~delegate:None
+              ~collateral:(Ligo.tez_from_literal "5_000_000mutez")
+              ~adjustment_index:fixedpoint_one
+              ~collateral_at_auction:(Ligo.tez_from_literal "3_000_000mutez")
+              ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+          let cancelled_slice_tez = Ligo.tez_from_literal "1_000_000mutez" in
 
+          assert_bool
+            "burrow_is_cancellation_warranted returned false, but the cancellation is expected to be warranted"
+            (Burrow.burrow_is_cancellation_warranted Parameters.initial_parameters burrow cancelled_slice_tez))
+    );
     (* =========================================================================================== *)
     (* Property tests for ensuring methods don't allow a burrow to become overburrowed *)
     (* =========================================================================================== *)

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -28,6 +28,7 @@ let assert_kit_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_
 type tez_option = Ligo.tez option [@@deriving show]
 let assert_tez_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_tez_option expected real
 
+let assert_burrow_equal ~expected ~real = OUnit2.assert_equal ~printer:Burrow.show_burrow expected real
 type slice_content_list = LiquidationAuctionPrimitiveTypes.liquidation_slice_contents list [@@deriving show]
 let assert_slice_content_list_equal ~expected ~real = OUnit2.assert_equal ~printer:show_slice_content_list expected real
 


### PR DESCRIPTION
Adds unit tests which address the following mutations which failed (i.e. did not break the current test suite) during mutation testing:

```
burrow_return_kit_from_auction    kit_add -> kit_max (L193)
burrow_is_cancellation_warranted  sub_int_int -> add_int_int (L445)
```
