### PR TITLE
Add support for integer literal mutations

### DIFF
--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -43,6 +43,7 @@ MODULES = ["burrow.ml", "checker.ml", "parameters.ml", "cfmm.ml"]  #
 MUTATION_GROUPS = [
     ## MATH
     # KIT
+    {"kit_zero", "kit_one"},
     {"kit_add", "kit_sub", "kit_min", "kit_max"},
     {"gt_kit_kit", "geq_kit_kit", "eq_kit_kit", "lt_kit_kit"},
     # INT

--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -74,6 +74,8 @@ MUTATION_GROUPS = [
         "gt_ratio_ratio",
         "eq_ratio_ratio",
     },
+    # BOOL
+    {"true", "false"},
 ]
 
 MUTATION_MAPPINGS = []

--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -17,13 +17,26 @@ import os
 import random
 import re
 import subprocess
+from enum import Enum, auto
 from contextlib import contextmanager
 from pprint import pprint
 from typing import Optional, Tuple
+from typing import Callable
 
 random.seed(42)
 
-MODULES = ["burrow.ml", "checker.ml", "parameters.ml", "cfmm.ml"]
+# Custom type aliases can go here
+MutationFormatter = Callable[[str], str]
+
+
+class MutationType(Enum):
+    # Swap out a function for another one with the same type
+    SWAP_FUNCTION = auto()
+    # Update an integer literal value
+    INTEGER_LITERAL = auto()
+
+
+MODULES = ["burrow.ml", "checker.ml", "parameters.ml", "cfmm.ml"]  #
 
 # Each group contains functions with the same type signature which can be swapped
 # and still allow the program to compile.
@@ -63,18 +76,79 @@ MUTATION_GROUPS = [
 ]
 
 MUTATION_MAPPINGS = []
+
+# Mappings for function swap mutations
 for group in MUTATION_GROUPS:
     for from_mutation in group:
         # Might need other escapes here as well
         escaped = from_mutation.replace(".", "\.")
         from_regex = re.compile(f"^.*(?:\.|\s|=)({from_mutation}).*$")
         to_mutations = {m for m in group if m != from_mutation}
-        MUTATION_MAPPINGS += [(from_mutation, from_regex, m) for m in to_mutations]
+        MUTATION_MAPPINGS += [
+            (MutationType.SWAP_FUNCTION, (from_mutation, from_regex, m))
+            for m in to_mutations
+        ]
+
+## Add mapping for integer (tez, nat, int) mutations
+# How much to weight integer mutations relative to other mutations
+_INTEGER_LITERAL_MUTATION_WEIGHT = 0.5
+_INTEGER_LITERAL_REGEX = re.compile('^.*"([\d_]+[a-zA-Z]*)".*$')
+for _ in range(0, round(_INTEGER_LITERAL_MUTATION_WEIGHT * len(MUTATION_MAPPINGS))):
+    MUTATION_MAPPINGS.append((MutationType.INTEGER_LITERAL, _INTEGER_LITERAL_REGEX))
+
+
+def mutate_integer_literal(value_src: str) -> str:
+    """Mutates an integer literal value from OCaml to a random value
+
+    Works with Ligo.int, Ligo.nat, and Ligo.tez values.
+
+    Args:
+        value_src (str): The input value string (e.g. 4mutez or 1_000_000n)
+
+    Returns:
+        str: The mutated value string
+
+    >>> mutate_integer_literal("1_000_000mutez")
+    "0mutez"
+    """
+    # Drop known suffixes
+    if value_src.endswith("mutez"):
+        suffix = "mutez"
+    elif value_src.endswith("n"):
+        suffix = "n"
+    else:
+        suffix = ""
+    prefix = value_src.rstrip(suffix)
+
+    # Attempt to parse to an int
+    value = int(prefix)
+
+    if value_src.endswith("mutez") or value_src.endswith("n"):
+        # We're dealing with numbers which are bounded [0, inf)
+        if value == 0:
+            mutated_value = 1
+        else:
+            mutated_value = random.choice([0, 1, value + 1, value - 1])
+    else:
+        mutated_value = random.choice([-1, 0, 1, value + 1, value - 1])
+
+    return f"{mutated_value:_}{suffix}"
 
 
 def mutate(
-    src: str, before_regex: re.Pattern, after: str
-) -> Tuple[bool, Optional[int]]:
+    src: str, before_regex: re.Pattern, formatter: MutationFormatter
+) -> Tuple[bool, Optional[int], Optional[str], Optional[str]]:
+    """Mutates an OCaml src file
+
+    Args:
+        src (str): The path to the OCaml src file
+        before_regex (re.Pattern): Regex with a single capturing group which identifies the mutation site
+        formatter (MutationFormatter): A function which generates a mutation for a given source
+
+    Returns:
+        A tuple containing a flag indicating whether a mutation was performed, the line mutated, the
+        original statement, and the corresponding mutated statement.
+    """
     with open(src) as f:
         lines = [l.rstrip("\n") for l in f.readlines()]
     matching_lines = []
@@ -82,18 +156,21 @@ def mutate(
         match = before_regex.match(l)
         if match:
             assert len(match.regs) == 2
-            matching_lines.append((i, match.span(1)))
+            matching_lines.append((i, match.groups(1)[0], match.span(1)))
 
     if not matching_lines:
-        return False, None
-    i_match, (start, stop) = matching_lines[random.randint(0, len(matching_lines) - 1)]
+        return False, None, None, None
+    i_match, before, (start, stop) = matching_lines[
+        random.randint(0, len(matching_lines) - 1)
+    ]
+    after = formatter(before)
     old_line = lines[i_match]
     new_line = old_line[:start] + after + old_line[stop:]
     lines[i_match] = new_line
     with open(src, "w") as f:
         for line in lines:
             print(line, file=f)
-    return True, i_match
+    return True, i_match, before, after
 
 
 def restore(src: str):
@@ -137,9 +214,22 @@ def do_mutation():
         print(f"Attempting to mutate {src}...")
         possible_mutations = [m for m in MUTATION_MAPPINGS]
         random.shuffle(possible_mutations)
-        for mutation_from, mutation_from_regex, mutation_to in possible_mutations:
+        for mutation_type, mutation_meta in possible_mutations:
+            if mutation_type == MutationType.SWAP_FUNCTION:
+                mutation_from, mutation_from_regex, mutation_to = mutation_meta
+                formatter = lambda x: mutation_to
+            elif mutation_type == MutationType.INTEGER_LITERAL:
+                mutation_from_regex = mutation_meta
+                mutation_from = "literal_number"
+                mutation_to = "literal_number"
+                formatter = mutate_integer_literal
+            else:
+                raise Exception(f"Unknown mutation type {mutation_type}")
+
             print(f"  Trying mutation: {mutation_from} -> {mutation_to}")
-            found_site_to_mutate, line = mutate(src, mutation_from_regex, mutation_to)
+            found_site_to_mutate, line, before, after = mutate(
+                src, mutation_from_regex, formatter
+            )
             if found_site_to_mutate:
                 "Successfully mutated source."
                 break
@@ -155,39 +245,45 @@ def do_mutation():
             "Tried all possible combinations of modules and mutations and could not find a matching name"
         )
     tests_failed = test_mutated_src()
-    yield (src, mutation_from, mutation_to, line), tests_failed
+    yield (src, mutation_type, before, after, line), tests_failed
     restore(src)
 
 
 if __name__ == "__main__":
-    n_mutations = 500
+    n_mutations = 25
     report = {}
     for i in range(n_mutations):
         # Using a context manager here as a quick and dirty way to ensure that mutations are removed
         # when the script exits.
         with do_mutation() as mutation_result:
-            (src, mutation_from, mutation_to, line), tests_failed = mutation_result
+            (
+                src,
+                mutation_type,
+                mutation_from,
+                mutation_to,
+                line,
+            ), tests_failed = mutation_result
         if src not in report:
             report[src] = {}
-        report[src][(mutation_from, mutation_to, line)] = tests_failed
+        report[src][(mutation_type, mutation_from, mutation_to, line)] = tests_failed
         srcs = list(report.keys())
         srcs.sort()
 
     pprint(report)
 
     print_lines = [
-        "==============================================================",
+        "==================================================================================",
         "CASES NOT CAUGHT BY TESTS:",
-        "==============================================================",
-        "SRC                    MUTATION_FROM -> MUTATION_TO    LINE_NO",
+        "==================================================================================",
+        f"{'SRC':<20} {'TYPE':<20} {'MUTATION_FROM':<15} -> {'MUTATION_TO':15} L{'LINE':<5}",
     ]
     for src in srcs:
         mutations = report[src]
         for (mutation_details, tests_failed) in mutations.items():
-            mutation_from, mutation_to, line_number = mutation_details
+            mutation_type, mutation_from, mutation_to, line_number = mutation_details
             if not tests_failed:
                 print_lines.append(
-                    f"{src:<24} {mutation_from:>0} -> {mutation_to} L{line_number}"
+                    f"{src:<20} {mutation_type.name:<20} {mutation_from:<15} -> {mutation_to:15} L{line_number:<5}"
                 )
     for l in print_lines:
         print(l)

--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -156,6 +156,12 @@ def mutate(
         lines = [l.rstrip("\n") for l in f.readlines()]
     matching_lines = []
     for i, l in enumerate(lines):
+        stripped = l.lstrip()
+        # Note: this is not super precise and could skip lines with
+        # actual code which start with the * operator. This doesn't
+        # seem to happen in the checker codebase though...
+        if stripped.startswith("(*") or stripped.startswith("*"):
+            continue
         match = before_regex.match(l)
         if match:
             assert len(match.regs) == 2


### PR DESCRIPTION
Updates our quick and dirty mutation testing script to add support for mutating integer literals like `"1_000_000mutez"` or `"42"`. Additionally updates it to:
  * Add mutations for swapping boolean values
  * Add mutations for swapping `kit_zero` and `kit_one` constants.
  * Ignore comment lines to reduce false positives
  * Improve report formatting
