### PR TITLE
Increase test coverage for checkerMain.ml

### DIFF
--- a/src/checkerMain.ml
+++ b/src/checkerMain.ml
@@ -51,8 +51,9 @@ let main (op, state: params * wrapper): LigoOp.operation list * wrapper =
 
   let ops, lazy_functions, metadata, deployment_state = match deployment_state with
     | Unsealed deployer ->
-      if !Ligo.Tezos.sender = deployer
-      then match op with
+      begin match !Ligo.Tezos.sender = deployer with
+      | true ->
+        begin match op with
         | DeployFunction p ->
           let lfi, bs = p in
           let lazy_functions =
@@ -88,9 +89,10 @@ let main (op, state: params * wrapper): LigoOp.operation list * wrapper =
           let metadata = Ligo.Big_map.add "" metadata_url metadata in
 
           ([touchOp], lazy_functions, metadata, Sealed checker)
-        | CheckerEntrypoint _ ->
-          (Ligo.failwith error_ContractNotDeployed: LigoOp.operation list * lazy_function_map * (string, Ligo.bytes) Ligo.big_map * deployment_state)
-      else (Ligo.failwith error_UnauthorisedCaller: LigoOp.operation list * lazy_function_map * (string, Ligo.bytes) Ligo.big_map * deployment_state)
+        | CheckerEntrypoint _ -> (Ligo.failwith error_ContractNotDeployed: LigoOp.operation list * lazy_function_map * (string, Ligo.bytes) Ligo.big_map * deployment_state)
+        end
+      | false -> (Ligo.failwith error_UnauthorisedCaller: LigoOp.operation list * lazy_function_map * (string, Ligo.bytes) Ligo.big_map * deployment_state)
+      end
     | Sealed checker ->
       let ops, checker =
         match op with

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -120,60 +120,60 @@ let suite =
     ("If checker is sealed, users should be able to call CheckerEntrypoint/StrictParams/Transfer" >::
      with_sealed_wrapper
        (fun sealed_wrapper ->
-         let op = CheckerMain.(CheckerEntrypoint (StrictParams (Transfer []))) in
-         (* This call should succeed *)
-         Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-         let _ops, _wrapper = CheckerMain.main (op, sealed_wrapper) in
-         ()
-      )
+          let op = CheckerMain.(CheckerEntrypoint (StrictParams (Transfer []))) in
+          (* This call should succeed *)
+          Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          let _ops, _wrapper = CheckerMain.main (op, sealed_wrapper) in
+          ()
+       )
     );
 
     ("If checker is sealed, users should be able to call CheckerEntrypoint/LazyParams" >::
      with_sealed_wrapper
        (fun sealed_wrapper ->
-         let op = CheckerMain.(CheckerEntrypoint (LazyParams (Receive_price (Ligo.nat_from_literal "756n")))) in
-         (* This call should succeed *)
-         Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:oracle_addr ~amount:(Ligo.tez_from_literal "0mutez");
-         let _ops, _wrapper = CheckerMain.main (op, sealed_wrapper) in
-         (* But if the call does not come from the oracle it should fail. *)
-         assert_raises
-           (Failure (Ligo.string_of_int error_UnauthorisedCaller))
-           (fun () ->
-             Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-             CheckerMain.main (op, sealed_wrapper)
-           )
-      )
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Receive_price (Ligo.nat_from_literal "756n")))) in
+          (* This call should succeed *)
+          Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:oracle_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          let _ops, _wrapper = CheckerMain.main (op, sealed_wrapper) in
+          (* But if the call does not come from the oracle it should fail. *)
+          assert_raises
+            (Failure (Ligo.string_of_int error_UnauthorisedCaller))
+            (fun () ->
+               Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+               CheckerMain.main (op, sealed_wrapper)
+            )
+       )
     );
 
     (* Failing cases when checker is already sealed *)
     ("DeployFunction - should fail if the contract is already sealed" >::
      with_sealed_wrapper
        (fun sealed_wrapper ->
-         let fn_id, fn_bytes = CheckerEntrypoints.lazyParamsToLazyFunctionId (CheckerEntrypoints.Touch ()) in
-         let op = CheckerMain.DeployFunction (fn_id, fn_bytes) in
-         assert_raises
-           (Failure (Ligo.string_of_int error_ContractAlreadyDeployed))
-           (fun () -> CheckerMain.main (op, sealed_wrapper))
+          let fn_id, fn_bytes = CheckerEntrypoints.lazyParamsToLazyFunctionId (CheckerEntrypoints.Touch ()) in
+          let op = CheckerMain.DeployFunction (fn_id, fn_bytes) in
+          assert_raises
+            (Failure (Ligo.string_of_int error_ContractAlreadyDeployed))
+            (fun () -> CheckerMain.main (op, sealed_wrapper))
        )
     );
 
     ("SealContract - should fail if the contract is already sealed" >::
      with_sealed_wrapper
        (fun sealed_wrapper ->
-         let op = CheckerMain.SealContract (oracle_addr, ctez_addr) in
-         assert_raises
-           (Failure (Ligo.string_of_int error_ContractAlreadyDeployed))
-           (fun () -> CheckerMain.main (op, sealed_wrapper))
+          let op = CheckerMain.SealContract (oracle_addr, ctez_addr) in
+          assert_raises
+            (Failure (Ligo.string_of_int error_ContractAlreadyDeployed))
+            (fun () -> CheckerMain.main (op, sealed_wrapper))
        )
     );
 
     ("DeployMetadata - should fail if the contract is already sealed" >::
      with_sealed_wrapper
        (fun sealed_wrapper ->
-         let op = CheckerMain.DeployMetadata (Ligo.bytes_from_literal "0x0123456789ABCDEF") in
-         assert_raises
-           (Failure (Ligo.string_of_int error_ContractAlreadyDeployed))
-           (fun () -> CheckerMain.main (op, sealed_wrapper))
+          let op = CheckerMain.DeployMetadata (Ligo.bytes_from_literal "0x0123456789ABCDEF") in
+          assert_raises
+            (Failure (Ligo.string_of_int error_ContractAlreadyDeployed))
+            (fun () -> CheckerMain.main (op, sealed_wrapper))
        )
     );
 

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -7,7 +7,7 @@ let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
 
 let suite =
   "CheckerMainTests" >::: [
-
+    (* initial_wrapper *)
     (
       qcheck_to_ounit
       @@ QCheck.Test.make
@@ -31,6 +31,23 @@ let suite =
        assert_bool
          "initial metadata bigmap must be empty"
          (List.length (Ligo.Big_map.bindings (initial_wrapper bob_addr).metadata) = 0)
+    );
+
+
+    ("SealContract - no deployments" >::
+     fun _ ->
+       let checker_deployer = leena_addr in
+       Ligo.Tezos.reset ();
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:leena_addr ~amount:(Ligo.tez_from_literal "0mutez");
+
+       let wrapper = CheckerMain.initial_wrapper checker_deployer in (* unsealed *)
+       let ctez_addr = Ligo.address_of_string "ctez_addr" in
+       let oracle_addr = Ligo.address_of_string "oracle_addr" in
+       let op = CheckerMain.SealContract (oracle_addr, ctez_addr) in
+       let _ops, _wrapper = CheckerMain.main (op, wrapper) in (* sealed *)
+       assert_bool "yay!" true;
+
+       ()
     );
 
     (* Add tests here *)

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -1,9 +1,24 @@
 open OUnit2
 open TestLib
 open CheckerMain
+open Error
 
 let property_test_count = 100
 let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
+
+let with_sealed_wrapper f =
+  fun _ ->
+
+  let checker_deployer = leena_addr in
+  Ligo.Tezos.reset ();
+  Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:checker_deployer ~amount:(Ligo.tez_from_literal "0mutez");
+
+  let wrapper = CheckerMain.initial_wrapper checker_deployer in (* unsealed *)
+  let ctez_addr = Ligo.address_of_string "ctez_addr" in
+  let oracle_addr = Ligo.address_of_string "oracle_addr" in
+  let op = CheckerMain.SealContract (oracle_addr, ctez_addr) in
+  let _ops, wrapper = CheckerMain.main (op, wrapper) in (* sealed *)
+  f wrapper
 
 let suite =
   "CheckerMainTests" >::: [
@@ -33,21 +48,67 @@ let suite =
          (List.length (Ligo.Big_map.bindings (initial_wrapper bob_addr).metadata) = 0)
     );
 
-
-    ("SealContract - no deployments" >::
+    (* Failing cases when checker is not sealed yet *)
+    ("If checker is not sealed, only the deployer should be able to work with it" >::
      fun _ ->
-       let checker_deployer = leena_addr in
        Ligo.Tezos.reset ();
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:leena_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
-       let wrapper = CheckerMain.initial_wrapper checker_deployer in (* unsealed *)
+       let wrapper = CheckerMain.initial_wrapper leena_addr in (* unsealed *)
        let ctez_addr = Ligo.address_of_string "ctez_addr" in
        let oracle_addr = Ligo.address_of_string "oracle_addr" in
-       let op = CheckerMain.SealContract (oracle_addr, ctez_addr) in
-       let _ops, _wrapper = CheckerMain.main (op, wrapper) in (* sealed *)
-       assert_bool "yay!" true;
 
-       ()
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let op = CheckerMain.SealContract (oracle_addr, ctez_addr) in
+       assert_raises
+         (Failure (Ligo.string_of_int error_UnauthorisedCaller))
+         (fun () -> CheckerMain.main (op, wrapper))
+    );
+
+    ("If checker is not sealed, we shouldn't be able to invoke entrypoints" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:leena_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let wrapper = CheckerMain.initial_wrapper leena_addr in (* unsealed *)
+       let op = CheckerMain.(CheckerEntrypoint (StrictParams (Transfer []))) in
+       assert_raises
+         (Failure (Ligo.string_of_int error_ContractNotDeployed))
+         (fun () -> CheckerMain.main (op, wrapper))
+    );
+
+    (* Failing cases when checker is already sealed *)
+    ("DeployFunction - should fail if the contract is already sealed" >::
+     with_sealed_wrapper
+       (fun sealed_wrapper ->
+         let fn_id, fn_bytes = CheckerEntrypoints.lazyParamsToLazyFunctionId (CheckerEntrypoints.Touch ()) in
+         let op = CheckerMain.DeployFunction (fn_id, fn_bytes) in
+         assert_raises
+           (Failure (Ligo.string_of_int error_ContractAlreadyDeployed))
+           (fun () -> CheckerMain.main (op, sealed_wrapper))
+       )
+    );
+
+    ("SealContract - should fail if the contract is already sealed" >::
+     with_sealed_wrapper
+       (fun sealed_wrapper ->
+         let op =
+           let ctez_addr = Ligo.address_of_string "ctez_addr" in
+           let oracle_addr = Ligo.address_of_string "oracle_addr" in
+           CheckerMain.SealContract (oracle_addr, ctez_addr) in
+         assert_raises
+           (Failure (Ligo.string_of_int error_ContractAlreadyDeployed))
+           (fun () -> CheckerMain.main (op, sealed_wrapper))
+       )
+    );
+
+    ("DeployMetadata - should fail if the contract is already sealed" >::
+     with_sealed_wrapper
+       (fun sealed_wrapper ->
+         let op = CheckerMain.DeployMetadata (Ligo.bytes_from_literal "0x0123456789ABCDEF") in
+         assert_raises
+           (Failure (Ligo.string_of_int error_ContractAlreadyDeployed))
+           (fun () -> CheckerMain.main (op, sealed_wrapper))
+       )
     );
 
     (* Add tests here *)


### PR DESCRIPTION
These unit tests primarily go through different execution
paths and ensure that calls to entrypoints fail/succeed,
depending on whether checker is sealed/unsealed.
However, the values themselves are not inspected.

At this high a level most of the actual code to be run is
wrapped in `{BEGIN,END}_LIGO`, so I think e2e tests
are much more appropriate for testing the behavior of
main.

Test coverage goes from 86.40% to 88.52%.