### PR TITLE
Increase coverage for cfmm.ml

### DIFF
--- a/src/cfmm.ml
+++ b/src/cfmm.ml
@@ -247,19 +247,20 @@ let cfmm_view_min_ctez_withdrawn_min_kit_withdrawn_cfmm_remove_liquidity
         (Ligo.mul_int_int (kit_to_mukit_int cfmm.kit) (lqt_to_denomination_int lqt_burned))
         (Ligo.mul_int_int kit_scaling_factor_int (lqt_to_denomination_int cfmm.lqt))
     in
-    if gt_ctez_ctez ctez_withdrawn cfmm.ctez then
-      (Ligo.failwith error_RemoveLiquidityTooMuchTezWithdrawn : (ctez * kit * cfmm))
-    else if gt_kit_kit kit_withdrawn cfmm.kit then
-      (Ligo.failwith error_RemoveLiquidityTooMuchKitWithdrawn : (ctez * kit * cfmm))
-    else
-      let remaining_ctez = ctez_sub cfmm.ctez ctez_withdrawn in
-      let remaining_lqt = lqt_sub cfmm.lqt lqt_burned in
-      let remaining_kit = kit_sub cfmm.kit kit_withdrawn in
-      let updated = { cfmm with
-                      ctez = remaining_ctez;
-                      kit = remaining_kit;
-                      lqt = remaining_lqt } in
-      (ctez_withdrawn, kit_withdrawn, updated)
+    (* Since (a) 0 < lqt_burned < cfmm.lqt, and (b) we floor for both the kit
+     * and the ctez withdrawn, it should be impossible to trigger the following
+     * assertions. *)
+    assert (lt_ctez_ctez ctez_withdrawn cfmm.ctez);
+    assert (lt_kit_kit kit_withdrawn cfmm.kit);
+
+    let remaining_ctez = ctez_sub cfmm.ctez ctez_withdrawn in
+    let remaining_lqt = lqt_sub cfmm.lqt lqt_burned in
+    let remaining_kit = kit_sub cfmm.kit kit_withdrawn in
+    let updated = { cfmm with
+                    ctez = remaining_ctez;
+                    kit = remaining_kit;
+                    lqt = remaining_lqt } in
+    (ctez_withdrawn, kit_withdrawn, updated)
 
 (* Selling liquidity always succeeds, but might leave the contract
  * without ctez and kit if everybody sells their liquidity. I think

--- a/src/cfmm.ml
+++ b/src/cfmm.ml
@@ -66,15 +66,18 @@ let cfmm_view_min_kit_expected_buy_kit
         kit_scaling_factor_int
         (Ligo.mul_int_int (ctez_to_muctez_int new_cfmm_ctez) den_uf) in
     let bought_kit = kit_of_fraction_floor numerator denominator in
-    if gt_kit_kit bought_kit cfmm.kit then
-      (Ligo.failwith error_BuyKitTooMuchKitBought : (kit * cfmm))
-    else
-      ( bought_kit,
-        { cfmm with
-          kit = kit_sub cfmm.kit bought_kit;
-          ctez = new_cfmm_ctez;
-        }
-      )
+    (* Due to (a) the constant-factor calculation (which means that to deplete
+     * the one amount the other would in effect have to become infinite), (b)
+     * the fact that checker owns 1mu of each token, and (c) the fact that we
+     * always floor in our calculations, it should be impossible to trigger the
+     * following assertion. *)
+    assert (lt_kit_kit bought_kit cfmm.kit);
+    ( bought_kit,
+      { cfmm with
+        kit = kit_sub cfmm.kit bought_kit;
+        ctez = new_cfmm_ctez;
+      }
+    )
 
 let cfmm_buy_kit
     (cfmm: cfmm)

--- a/src/cfmm.ml
+++ b/src/cfmm.ml
@@ -123,15 +123,19 @@ let cfmm_view_min_ctez_expected_cfmm_sell_kit
         (Ligo.int_from_literal "1_000_000")
         (Ligo.mul_int_int (kit_to_mukit_int new_cfmm_kit) den_uf) in
     let bought_ctez = ctez_of_fraction_floor numerator denominator in
-    if gt_ctez_ctez bought_ctez cfmm.ctez then
-      (Ligo.failwith error_SellKitTooMuchTezBought : (ctez * cfmm))
-    else
-      ( bought_ctez,
-        { cfmm with
-          kit = new_cfmm_kit;
-          ctez = ctez_sub cfmm.ctez bought_ctez;
-        }
-      )
+
+    (* Due to (a) the constant-factor calculation (which means that to deplete
+     * the one amount the other would in effect have to become infinite), (b)
+     * the fact that checker owns 1mu of each token, and (c) the fact that we
+     * always floor in our calculations, it should be impossible to trigger the
+     * following assertion. *)
+    assert (lt_ctez_ctez bought_ctez cfmm.ctez);
+    ( bought_ctez,
+      { cfmm with
+        kit = new_cfmm_kit;
+        ctez = ctez_sub cfmm.ctez bought_ctez;
+      }
+    )
 
 let cfmm_sell_kit
     (cfmm: cfmm)

--- a/src/cfmm.ml
+++ b/src/cfmm.ml
@@ -29,10 +29,11 @@ let cfmm_kit_in_ctez_in_prev_block (cfmm: cfmm) =
  * cfmm contract was touched. *)
 let cfmm_sync_last_observed (cfmm: cfmm) : cfmm =
   assert (Ligo.geq_nat_nat !Ligo.Tezos.level cfmm.last_level);
-  if Ligo.leq_nat_nat !Ligo.Tezos.level cfmm.last_level then
+  match Ligo.leq_nat_nat !Ligo.Tezos.level cfmm.last_level with
+  | true ->
     (* do nothing if it's been touched already in this block *)
     cfmm
-  else
+  | false ->
     { cfmm with
       kit_in_ctez_in_prev_block =
         make_ratio
@@ -47,9 +48,9 @@ let cfmm_view_min_kit_expected_buy_kit
   : (kit (* min_kit_expected *) * cfmm) =
   let cfmm = cfmm_sync_last_observed cfmm in
   let cfmm = cfmm_assert_initialized cfmm in
-  if (ctez_amount = ctez_zero) then
-    (Ligo.failwith error_BuyKitNoTezGiven : (kit * cfmm))
-  else
+  match (ctez_amount = ctez_zero) with
+  | true -> (Ligo.failwith error_BuyKitNoTezGiven : (kit * cfmm))
+  | false ->
     (* db = da * (b / a) * (a / (a + da)) * (1 - fee) or
      * db = da * b / (a + da) * (1 - fee) *)
     let { num = num_uf; den = den_uf; } =
@@ -85,18 +86,19 @@ let cfmm_buy_kit
     (min_kit_expected: kit)
     (deadline: Ligo.timestamp)
   : (kit * cfmm) =
-  if (ctez_amount = ctez_zero) then
-    (Ligo.failwith error_BuyKitNoTezGiven : (kit * cfmm))
-  else if (Ligo.geq_timestamp_timestamp !Ligo.Tezos.now deadline) then
-    (Ligo.failwith error_CfmmTooLate : (kit * cfmm))
-  else if (min_kit_expected = kit_zero) then
-    (Ligo.failwith error_BuyKitTooLowExpectedKit : (kit * cfmm))
-  else
-    let (bought_kit, cfmm) = cfmm_view_min_kit_expected_buy_kit cfmm ctez_amount in
-    if lt_kit_kit bought_kit min_kit_expected then
-      (Ligo.failwith error_BuyKitPriceFailure : (kit * cfmm))
-    else
-      (bought_kit, cfmm)
+  match (ctez_amount = ctez_zero) with
+  | true -> (Ligo.failwith error_BuyKitNoTezGiven : (kit * cfmm))
+  | false ->
+    match (Ligo.geq_timestamp_timestamp !Ligo.Tezos.now deadline) with
+    | true -> (Ligo.failwith error_CfmmTooLate : (kit * cfmm))
+    | false ->
+      match (min_kit_expected = kit_zero) with
+      | true -> (Ligo.failwith error_BuyKitTooLowExpectedKit : (kit * cfmm))
+      | false ->
+        let (bought_kit, cfmm) = cfmm_view_min_kit_expected_buy_kit cfmm ctez_amount in
+        match lt_kit_kit bought_kit min_kit_expected with
+        | true -> (Ligo.failwith error_BuyKitPriceFailure : (kit * cfmm))
+        | false -> (bought_kit, cfmm)
 
 let cfmm_view_min_ctez_expected_cfmm_sell_kit
     (cfmm: cfmm)
@@ -104,9 +106,9 @@ let cfmm_view_min_ctez_expected_cfmm_sell_kit
   : (ctez * cfmm) =
   let cfmm = cfmm_sync_last_observed cfmm in
   let cfmm = cfmm_assert_initialized cfmm in
-  if (kit_amount = kit_zero) then
-    (Ligo.failwith error_SellKitNoKitGiven : (ctez * cfmm))
-  else
+  match (kit_amount = kit_zero) with
+  | true -> (Ligo.failwith error_SellKitNoKitGiven : (ctez * cfmm))
+  | false ->
     (* db = da * (b / a) * (a / (a + da)) * (1 - fee) or
      * db = da * b / (a + da) * (1 - fee) *)
     let { num = num_uf; den = den_uf; } =
@@ -123,9 +125,9 @@ let cfmm_view_min_ctez_expected_cfmm_sell_kit
         (Ligo.int_from_literal "1_000_000")
         (Ligo.mul_int_int (kit_to_mukit_int new_cfmm_kit) den_uf) in
     let bought_ctez = ctez_of_fraction_floor numerator denominator in
-    if gt_ctez_ctez bought_ctez cfmm.ctez then
-      (Ligo.failwith error_SellKitTooMuchTezBought : (ctez * cfmm))
-    else
+    match gt_ctez_ctez bought_ctez cfmm.ctez with
+    | true -> (Ligo.failwith error_SellKitTooMuchTezBought : (ctez * cfmm))
+    | false ->
       ( bought_ctez,
         { cfmm with
           kit = new_cfmm_kit;
@@ -139,18 +141,19 @@ let cfmm_sell_kit
     (min_ctez_expected: ctez)
     (deadline: Ligo.timestamp)
   : (ctez * cfmm) =
-  if (kit_amount = kit_zero) then
-    (Ligo.failwith error_SellKitNoKitGiven : (ctez * cfmm))
-  else if Ligo.geq_timestamp_timestamp !Ligo.Tezos.now deadline then
-    (Ligo.failwith error_CfmmTooLate : (ctez * cfmm))
-  else if (min_ctez_expected = ctez_zero) then
-    (Ligo.failwith error_SellKitTooLowExpectedTez : (ctez * cfmm))
-  else
-    let (bought_ctez, cfmm) = cfmm_view_min_ctez_expected_cfmm_sell_kit cfmm kit_amount in
-    if lt_ctez_ctez bought_ctez min_ctez_expected then
-      (Ligo.failwith error_SellKitPriceFailure : (ctez * cfmm))
-    else
-      (bought_ctez, cfmm)
+  match (kit_amount = kit_zero) with
+  | true -> (Ligo.failwith error_SellKitNoKitGiven : (ctez * cfmm))
+  | false ->
+    match Ligo.geq_timestamp_timestamp !Ligo.Tezos.now deadline with
+    | true -> (Ligo.failwith error_CfmmTooLate : (ctez * cfmm))
+    | false ->
+      match (min_ctez_expected = ctez_zero) with
+      | true -> (Ligo.failwith error_SellKitTooLowExpectedTez : (ctez * cfmm))
+      | false ->
+        let (bought_ctez, cfmm) = cfmm_view_min_ctez_expected_cfmm_sell_kit cfmm kit_amount in
+        match lt_ctez_ctez bought_ctez min_ctez_expected with
+        | true -> (Ligo.failwith error_SellKitPriceFailure : (ctez * cfmm))
+        | false -> (bought_ctez, cfmm)
 
 let cfmm_view_max_kit_deposited_min_lqt_minted_cfmm_add_liquidity
     (cfmm: cfmm)
@@ -158,9 +161,9 @@ let cfmm_view_max_kit_deposited_min_lqt_minted_cfmm_add_liquidity
   : (lqt * kit * cfmm) =
   let cfmm = cfmm_sync_last_observed cfmm in
   let cfmm = cfmm_assert_initialized cfmm in
-  if ctez_amount = ctez_zero then
-    (Ligo.failwith error_AddLiquidityNoTezGiven : (lqt * kit * cfmm))
-  else
+  match ctez_amount = ctez_zero with
+  | true -> (Ligo.failwith error_AddLiquidityNoTezGiven : (lqt * kit * cfmm))
+  | false ->
     let cfmm_ctez = ctez_to_muctez_int cfmm.ctez in
     let lqt_minted =
       lqt_of_fraction_floor
@@ -196,31 +199,36 @@ let cfmm_add_liquidity
     (min_lqt_minted: lqt)
     (deadline: Ligo.timestamp)
   : (lqt * kit * cfmm) =
-  if Ligo.geq_timestamp_timestamp !Ligo.Tezos.now deadline then
-    (Ligo.failwith error_CfmmTooLate : (lqt * kit * cfmm))
-  else if ctez_amount = ctez_zero then
-    (Ligo.failwith error_AddLiquidityNoTezGiven : (lqt * kit * cfmm))
-  else if max_kit_deposited = kit_zero then
-    (Ligo.failwith error_AddLiquidityNoKitGiven : (lqt * kit * cfmm))
-  else if min_lqt_minted = lqt_zero then
-    (Ligo.failwith error_AddLiquidityNoLiquidityToBeAdded : (lqt * kit * cfmm))
-  else
-    let (lqt_minted, kit_deposited, cfmm) =
-      cfmm_view_max_kit_deposited_min_lqt_minted_cfmm_add_liquidity cfmm ctez_amount in
-    if lt_lqt_lqt lqt_minted min_lqt_minted then
-      (Ligo.failwith error_AddLiquidityTooLowLiquidityMinted : (lqt * kit * cfmm))
-    else if lt_kit_kit max_kit_deposited kit_deposited then
-      (Ligo.failwith error_AddLiquidityTooMuchKitRequired : (lqt * kit * cfmm))
-    else if kit_deposited = kit_zero then
-      (Ligo.failwith error_AddLiquidityZeroKitDeposited : (lqt * kit * cfmm))
-    else
-      let kit_to_return = kit_sub max_kit_deposited kit_deposited in
-      (* EXPECTED PROPERTY: kit_to_return + final_cfmm_kit = max_kit_deposited + initial_cfmm_kit
-       * which follows from the definitions:
-       *  kit_to_return  = max_kit_deposited - kit_deposited
-       *  final_cfmm_kit = initial_cfmm_kit  + kit_deposited
-      *)
-      (lqt_minted, kit_to_return, cfmm)
+  match Ligo.geq_timestamp_timestamp !Ligo.Tezos.now deadline with
+  | true -> (Ligo.failwith error_CfmmTooLate : (lqt * kit * cfmm))
+  | false ->
+    match ctez_amount = ctez_zero with
+    | true -> (Ligo.failwith error_AddLiquidityNoTezGiven : (lqt * kit * cfmm))
+    | false ->
+      match max_kit_deposited = kit_zero with
+      | true -> (Ligo.failwith error_AddLiquidityNoKitGiven : (lqt * kit * cfmm))
+      | false ->
+        match min_lqt_minted = lqt_zero with
+        | true -> (Ligo.failwith error_AddLiquidityNoLiquidityToBeAdded : (lqt * kit * cfmm))
+        | false ->
+          let (lqt_minted, kit_deposited, cfmm) =
+            cfmm_view_max_kit_deposited_min_lqt_minted_cfmm_add_liquidity cfmm ctez_amount in
+          match lt_lqt_lqt lqt_minted min_lqt_minted with
+          | true -> (Ligo.failwith error_AddLiquidityTooLowLiquidityMinted : (lqt * kit * cfmm))
+          | false ->
+            match lt_kit_kit max_kit_deposited kit_deposited with
+            | true -> (Ligo.failwith error_AddLiquidityTooMuchKitRequired : (lqt * kit * cfmm))
+            | false ->
+              match kit_deposited = kit_zero with
+              | true -> (Ligo.failwith error_AddLiquidityZeroKitDeposited : (lqt * kit * cfmm))
+              | false ->
+                let kit_to_return = kit_sub max_kit_deposited kit_deposited in
+                (* EXPECTED PROPERTY: kit_to_return + final_cfmm_kit = max_kit_deposited + initial_cfmm_kit
+                 * which follows from the definitions:
+                 *  kit_to_return  = max_kit_deposited - kit_deposited
+                 *  final_cfmm_kit = initial_cfmm_kit  + kit_deposited
+                *)
+                (lqt_minted, kit_to_return, cfmm)
 
 let cfmm_view_min_ctez_withdrawn_min_kit_withdrawn_cfmm_remove_liquidity
     (cfmm: cfmm)
@@ -228,34 +236,36 @@ let cfmm_view_min_ctez_withdrawn_min_kit_withdrawn_cfmm_remove_liquidity
   : (ctez * kit * cfmm) =
   let cfmm = cfmm_sync_last_observed cfmm in
   let cfmm = cfmm_assert_initialized cfmm in
-  if lqt_burned = lqt_zero then
-    (Ligo.failwith error_RemoveLiquidityNoLiquidityBurned : (ctez * kit * cfmm))
-  else if geq_lqt_lqt lqt_burned cfmm.lqt then
-    (Ligo.failwith error_RemoveLiquidityTooMuchLiquidityWithdrawn : (ctez * kit * cfmm))
-  else
-    let ctez_withdrawn =
-      ctez_of_fraction_floor
-        (Ligo.mul_int_int (ctez_to_muctez_int cfmm.ctez) (lqt_to_denomination_int lqt_burned))
-        (Ligo.mul_int_int (Ligo.int_from_literal "1_000_000") (lqt_to_denomination_int cfmm.lqt))
-    in
-    let kit_withdrawn =
-      kit_of_fraction_floor
-        (Ligo.mul_int_int (kit_to_mukit_int cfmm.kit) (lqt_to_denomination_int lqt_burned))
-        (Ligo.mul_int_int kit_scaling_factor_int (lqt_to_denomination_int cfmm.lqt))
-    in
-    if gt_ctez_ctez ctez_withdrawn cfmm.ctez then
-      (Ligo.failwith error_RemoveLiquidityTooMuchTezWithdrawn : (ctez * kit * cfmm))
-    else if gt_kit_kit kit_withdrawn cfmm.kit then
-      (Ligo.failwith error_RemoveLiquidityTooMuchKitWithdrawn : (ctez * kit * cfmm))
-    else
-      let remaining_ctez = ctez_sub cfmm.ctez ctez_withdrawn in
-      let remaining_lqt = lqt_sub cfmm.lqt lqt_burned in
-      let remaining_kit = kit_sub cfmm.kit kit_withdrawn in
-      let updated = { cfmm with
-                      ctez = remaining_ctez;
-                      kit = remaining_kit;
-                      lqt = remaining_lqt } in
-      (ctez_withdrawn, kit_withdrawn, updated)
+  match lqt_burned = lqt_zero with
+  | true -> (Ligo.failwith error_RemoveLiquidityNoLiquidityBurned : (ctez * kit * cfmm))
+  | false ->
+    match geq_lqt_lqt lqt_burned cfmm.lqt with
+    | true -> (Ligo.failwith error_RemoveLiquidityTooMuchLiquidityWithdrawn : (ctez * kit * cfmm))
+    | false ->
+      let ctez_withdrawn =
+        ctez_of_fraction_floor
+          (Ligo.mul_int_int (ctez_to_muctez_int cfmm.ctez) (lqt_to_denomination_int lqt_burned))
+          (Ligo.mul_int_int (Ligo.int_from_literal "1_000_000") (lqt_to_denomination_int cfmm.lqt))
+      in
+      let kit_withdrawn =
+        kit_of_fraction_floor
+          (Ligo.mul_int_int (kit_to_mukit_int cfmm.kit) (lqt_to_denomination_int lqt_burned))
+          (Ligo.mul_int_int kit_scaling_factor_int (lqt_to_denomination_int cfmm.lqt))
+      in
+      match gt_ctez_ctez ctez_withdrawn cfmm.ctez with
+      | true -> (Ligo.failwith error_RemoveLiquidityTooMuchTezWithdrawn : (ctez * kit * cfmm))
+      | false ->
+        match gt_kit_kit kit_withdrawn cfmm.kit with
+        | true -> (Ligo.failwith error_RemoveLiquidityTooMuchKitWithdrawn : (ctez * kit * cfmm))
+        | false ->
+          let remaining_ctez = ctez_sub cfmm.ctez ctez_withdrawn in
+          let remaining_lqt = lqt_sub cfmm.lqt lqt_burned in
+          let remaining_kit = kit_sub cfmm.kit kit_withdrawn in
+          let updated = { cfmm with
+                          ctez = remaining_ctez;
+                          kit = remaining_kit;
+                          lqt = remaining_lqt } in
+          (ctez_withdrawn, kit_withdrawn, updated)
 
 (* Selling liquidity always succeeds, but might leave the contract
  * without ctez and kit if everybody sells their liquidity. I think
@@ -268,25 +278,29 @@ let cfmm_remove_liquidity
     (min_kit_withdrawn: kit)
     (deadline: Ligo.timestamp)
   : (ctez * kit * cfmm) =
-  if Ligo.geq_timestamp_timestamp !Ligo.Tezos.now deadline then
-    (Ligo.failwith error_CfmmTooLate : (ctez * kit * cfmm))
-  else if lqt_burned = lqt_zero then
-    (Ligo.failwith error_RemoveLiquidityNoLiquidityBurned : (ctez * kit * cfmm))
-  else if geq_lqt_lqt lqt_burned cfmm.lqt then
-    (Ligo.failwith error_RemoveLiquidityTooMuchLiquidityWithdrawn : (ctez * kit * cfmm))
-  else if min_ctez_withdrawn = ctez_zero then
-    (Ligo.failwith error_RemoveLiquidityNoTezWithdrawnExpected : (ctez * kit * cfmm))
-  else if min_kit_withdrawn = kit_zero then
-    (Ligo.failwith error_RemoveLiquidityNoKitWithdrawnExpected : (ctez * kit * cfmm))
-  else
-    let (ctez_withdrawn, kit_withdrawn, cfmm) =
-      cfmm_view_min_ctez_withdrawn_min_kit_withdrawn_cfmm_remove_liquidity cfmm lqt_burned in
-    if lt_ctez_ctez ctez_withdrawn min_ctez_withdrawn then
-      (Ligo.failwith error_RemoveLiquidityCantWithdrawEnoughTez : (ctez * kit * cfmm))
-    else if lt_kit_kit kit_withdrawn min_kit_withdrawn then
-      (Ligo.failwith error_RemoveLiquidityCantWithdrawEnoughKit : (ctez * kit * cfmm))
-    else
-      (ctez_withdrawn, kit_withdrawn, cfmm)
+  match Ligo.geq_timestamp_timestamp !Ligo.Tezos.now deadline with
+  | true -> (Ligo.failwith error_CfmmTooLate : (ctez * kit * cfmm))
+  | false ->
+    match lqt_burned = lqt_zero with
+    | true -> (Ligo.failwith error_RemoveLiquidityNoLiquidityBurned : (ctez * kit * cfmm))
+    | false ->
+      match geq_lqt_lqt lqt_burned cfmm.lqt with
+      | true -> (Ligo.failwith error_RemoveLiquidityTooMuchLiquidityWithdrawn : (ctez * kit * cfmm))
+      | false ->
+        match min_ctez_withdrawn = ctez_zero with
+        | true -> (Ligo.failwith error_RemoveLiquidityNoTezWithdrawnExpected : (ctez * kit * cfmm))
+        | false ->
+          match min_kit_withdrawn = kit_zero with
+          | true -> (Ligo.failwith error_RemoveLiquidityNoKitWithdrawnExpected : (ctez * kit * cfmm))
+          | false ->
+            let (ctez_withdrawn, kit_withdrawn, cfmm) =
+              cfmm_view_min_ctez_withdrawn_min_kit_withdrawn_cfmm_remove_liquidity cfmm lqt_burned in
+            match lt_ctez_ctez ctez_withdrawn min_ctez_withdrawn with
+            | true -> (Ligo.failwith error_RemoveLiquidityCantWithdrawEnoughTez : (ctez * kit * cfmm))
+            | false ->
+              match lt_kit_kit kit_withdrawn min_kit_withdrawn with
+              | true -> (Ligo.failwith error_RemoveLiquidityCantWithdrawEnoughKit : (ctez * kit * cfmm))
+              | false -> (ctez_withdrawn, kit_withdrawn, cfmm)
 
 let cfmm_add_accrued_kit (cfmm: cfmm) (accrual: kit) : cfmm =
   let cfmm = cfmm_sync_last_observed cfmm in

--- a/src/cfmm.ml
+++ b/src/cfmm.ml
@@ -174,6 +174,10 @@ let cfmm_view_max_kit_deposited_min_lqt_minted_cfmm_add_liquidity
       kit_of_fraction_ceil
         (Ligo.mul_int_int (kit_to_mukit_int cfmm.kit) (ctez_to_muctez_int ctez_amount))
         (Ligo.mul_int_int kit_scaling_factor_int cfmm_ctez) in
+    (* Since (a) ctez_amount > 0, (b) cfmm.kit > 0, and (c) we ceil when
+     * computing kit_deposited, it should be impossible to trigger the
+     * following assertion. *)
+    assert (gt_kit_kit kit_deposited kit_zero);
     ( lqt_minted,
       kit_deposited,
       { cfmm with
@@ -215,8 +219,6 @@ let cfmm_add_liquidity
       (Ligo.failwith error_AddLiquidityTooLowLiquidityMinted : (lqt * kit * cfmm))
     else if lt_kit_kit max_kit_deposited kit_deposited then
       (Ligo.failwith error_AddLiquidityTooMuchKitRequired : (lqt * kit * cfmm))
-    else if kit_deposited = kit_zero then
-      (Ligo.failwith error_AddLiquidityZeroKitDeposited : (lqt * kit * cfmm))
     else
       let kit_to_return = kit_sub max_kit_deposited kit_deposited in
       (* EXPECTED PROPERTY: kit_to_return + final_cfmm_kit = max_kit_deposited + initial_cfmm_kit

--- a/src/error.ml
+++ b/src/error.ml
@@ -13,7 +13,6 @@ let[@inline] error_AddLiquidityNoKitGiven                          : Ligo.int = 
 let[@inline] error_AddLiquidityNoLiquidityToBeAdded                : Ligo.int = Ligo.int_from_literal "32"
 let[@inline] error_AddLiquidityTooLowLiquidityMinted               : Ligo.int = Ligo.int_from_literal "33"
 let[@inline] error_AddLiquidityTooMuchKitRequired                  : Ligo.int = Ligo.int_from_literal "34"
-let[@inline] error_AddLiquidityZeroKitDeposited                    : Ligo.int = Ligo.int_from_literal "35"
 
 let[@inline] error_RemoveLiquidityNoLiquidityBurned                : Ligo.int = Ligo.int_from_literal "41"
 let[@inline] error_RemoveLiquidityNoTezWithdrawnExpected           : Ligo.int = Ligo.int_from_literal "42"

--- a/src/error.ml
+++ b/src/error.ml
@@ -19,9 +19,7 @@ let[@inline] error_RemoveLiquidityNoLiquidityBurned                : Ligo.int = 
 let[@inline] error_RemoveLiquidityNoTezWithdrawnExpected           : Ligo.int = Ligo.int_from_literal "42"
 let[@inline] error_RemoveLiquidityNoKitWithdrawnExpected           : Ligo.int = Ligo.int_from_literal "43"
 let[@inline] error_RemoveLiquidityCantWithdrawEnoughTez            : Ligo.int = Ligo.int_from_literal "44"
-let[@inline] error_RemoveLiquidityTooMuchTezWithdrawn              : Ligo.int = Ligo.int_from_literal "45"
 let[@inline] error_RemoveLiquidityCantWithdrawEnoughKit            : Ligo.int = Ligo.int_from_literal "46"
-let[@inline] error_RemoveLiquidityTooMuchKitWithdrawn              : Ligo.int = Ligo.int_from_literal "47"
 let[@inline] error_RemoveLiquidityTooMuchLiquidityWithdrawn        : Ligo.int = Ligo.int_from_literal "48"
 
 let[@inline] error_LiquidationQueueTooLong                         : Ligo.int = Ligo.int_from_literal "50"

--- a/src/error.ml
+++ b/src/error.ml
@@ -2,7 +2,6 @@ let[@inline] error_CfmmTooLate                                  : Ligo.int = Lig
 
 let[@inline] error_BuyKitTooLowExpectedKit                         : Ligo.int = Ligo.int_from_literal "10"
 let[@inline] error_BuyKitPriceFailure                              : Ligo.int = Ligo.int_from_literal "11"
-let[@inline] error_BuyKitTooMuchKitBought                          : Ligo.int = Ligo.int_from_literal "12"
 let[@inline] error_BuyKitNoTezGiven                                : Ligo.int = Ligo.int_from_literal "13"
 
 let[@inline] error_SellKitTooLowExpectedTez                        : Ligo.int = Ligo.int_from_literal "21"

--- a/src/error.ml
+++ b/src/error.ml
@@ -6,7 +6,6 @@ let[@inline] error_BuyKitNoTezGiven                                : Ligo.int = 
 
 let[@inline] error_SellKitTooLowExpectedTez                        : Ligo.int = Ligo.int_from_literal "21"
 let[@inline] error_SellKitPriceFailure                             : Ligo.int = Ligo.int_from_literal "22"
-let[@inline] error_SellKitTooMuchTezBought                         : Ligo.int = Ligo.int_from_literal "23"
 let[@inline] error_SellKitNoKitGiven                               : Ligo.int = Ligo.int_from_literal "24"
 
 let[@inline] error_AddLiquidityNoTezGiven                          : Ligo.int = Ligo.int_from_literal "30"

--- a/tests/testCfmm.ml
+++ b/tests/testCfmm.ml
@@ -629,6 +629,31 @@ let test_add_liquidity_failures =
            (kit_of_mukit (Ligo.nat_from_literal "1n"))
            lqt_zero
            (Ligo.timestamp_from_seconds_literal 1)
+      );
+    assert_raises
+      (Failure (Ligo.string_of_int error_CfmmTooLate))
+      (fun () ->
+         Ligo.Tezos.reset ();
+         let deadline = Ligo.add_timestamp_int !Ligo.Tezos.now (Ligo.int_from_literal "0") in (* No time passed; failure (tests equality) *)
+         cfmm_add_liquidity
+           cfmm
+           (ctez_of_muctez (Ligo.nat_from_literal "1n"))
+           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           lqt_zero
+           deadline
+      );
+    assert_raises
+      (Failure (Ligo.string_of_int error_CfmmTooLate))
+      (fun () ->
+         Ligo.Tezos.reset ();
+         let deadline = Ligo.add_timestamp_int !Ligo.Tezos.now (Ligo.int_from_literal "1") in (* One second passed; failure (tests inequality) *)
+         Ligo.Tezos.new_transaction ~seconds_passed:2 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+         cfmm_add_liquidity
+           cfmm
+           (ctez_of_muctez (Ligo.nat_from_literal "1n"))
+           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           lqt_zero
+           deadline
       )
 
 (* ************************************************************************* *)

--- a/tests/testCfmm.ml
+++ b/tests/testCfmm.ml
@@ -814,6 +814,32 @@ let test_remove_liquidity_failures =
            (ctez_of_muctez (Ligo.nat_from_literal "1n"))
            (kit_of_mukit (Ligo.nat_from_literal "1n"))
            deadline
+      );
+    assert_raises
+      (Failure (Ligo.string_of_int error_RemoveLiquidityTooMuchLiquidityWithdrawn))
+      (fun () ->
+         Ligo.Tezos.reset ();
+         let deadline = Ligo.add_timestamp_int !Ligo.Tezos.now (Ligo.int_from_literal "1") in
+         let liq = cfmm.lqt in (* too much (equal) *)
+         cfmm_remove_liquidity
+           cfmm
+           liq
+           (ctez_of_muctez (Ligo.nat_from_literal "1n"))
+           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           deadline
+      );
+    assert_raises
+      (Failure (Ligo.string_of_int error_RemoveLiquidityTooMuchLiquidityWithdrawn))
+      (fun () ->
+         Ligo.Tezos.reset ();
+         let deadline = Ligo.add_timestamp_int !Ligo.Tezos.now (Ligo.int_from_literal "1") in
+         let liq = Lqt.lqt_add cfmm.lqt (Lqt.lqt_of_denomination (Ligo.nat_from_literal "1n")) in (* too much (unequal) *)
+         cfmm_remove_liquidity
+           cfmm
+           liq
+           (ctez_of_muctez (Ligo.nat_from_literal "1n"))
+           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           deadline
       )
 
 let suite =

--- a/tests/testCfmm.ml
+++ b/tests/testCfmm.ml
@@ -789,6 +789,31 @@ let test_remove_liquidity_failures =
            (ctez_of_muctez (Ligo.nat_from_literal "1n"))
            (kit_of_mukit (Ligo.nat_from_literal "0n"))
            (Ligo.timestamp_from_seconds_literal 100)
+      );
+    assert_raises
+      (Failure (Ligo.string_of_int error_CfmmTooLate))
+      (fun () ->
+         Ligo.Tezos.reset ();
+         let deadline = Ligo.add_timestamp_int !Ligo.Tezos.now (Ligo.int_from_literal "0") in (* No time passed; failure (tests equality) *)
+         cfmm_remove_liquidity
+           cfmm
+           liq
+           (ctez_of_muctez (Ligo.nat_from_literal "1n"))
+           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           deadline
+      );
+    assert_raises
+      (Failure (Ligo.string_of_int error_CfmmTooLate))
+      (fun () ->
+         Ligo.Tezos.reset ();
+         let deadline = Ligo.add_timestamp_int !Ligo.Tezos.now (Ligo.int_from_literal "1") in (* One second passed; failure (tests inequality) *)
+         Ligo.Tezos.new_transaction ~seconds_passed:2 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+         cfmm_remove_liquidity
+           cfmm
+           liq
+           (ctez_of_muctez (Ligo.nat_from_literal "1n"))
+           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           deadline
       )
 
 let suite =

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -1429,11 +1429,43 @@ let suite =
               (fun () -> Checker.view_remove_liquidity_min_ctez_withdrawn (Lqt.lqt_zero, checker))
          );
 
+       "view_remove_liquidity_min_ctez_withdrawn - too much lqt withdrawn (equal)" >:: with_cfmm_setup
+         (fun checker ->
+            let lqt_to_withdraw = checker.cfmm.lqt in
+            assert_raises
+              (Failure (Ligo.string_of_int error_RemoveLiquidityTooMuchLiquidityWithdrawn))
+              (fun () -> Checker.view_remove_liquidity_min_ctez_withdrawn (lqt_to_withdraw, checker))
+         );
+
+       "view_remove_liquidity_min_ctez_withdrawn - too much lqt withdrawn (more than)" >:: with_cfmm_setup
+         (fun checker ->
+            let lqt_to_withdraw = Lqt.lqt_add checker.cfmm.lqt (Lqt.lqt_of_denomination (Ligo.nat_from_literal "1n")) in
+            assert_raises
+              (Failure (Ligo.string_of_int error_RemoveLiquidityTooMuchLiquidityWithdrawn))
+              (fun () -> Checker.view_remove_liquidity_min_ctez_withdrawn (lqt_to_withdraw, checker))
+         );
+
        "view_remove_liquidity_min_kit_withdrawn - fail if no liquidity is given" >:: with_cfmm_setup
          (fun checker ->
             assert_raises
               (Failure (Ligo.string_of_int error_RemoveLiquidityNoLiquidityBurned))
               (fun () -> Checker.view_remove_liquidity_min_kit_withdrawn (Lqt.lqt_zero, checker))
+         );
+
+       "view_remove_liquidity_min_kit_withdrawn - too much lqt withdrawn (equal)" >:: with_cfmm_setup
+         (fun checker ->
+            let lqt_to_withdraw = checker.cfmm.lqt in
+            assert_raises
+              (Failure (Ligo.string_of_int error_RemoveLiquidityTooMuchLiquidityWithdrawn))
+              (fun () -> Checker.view_remove_liquidity_min_kit_withdrawn (lqt_to_withdraw, checker))
+         );
+
+       "view_remove_liquidity_min_kit_withdrawn - too much lqt withdrawn (more than)" >:: with_cfmm_setup
+         (fun checker ->
+            let lqt_to_withdraw = Lqt.lqt_add checker.cfmm.lqt (Lqt.lqt_of_denomination (Ligo.nat_from_literal "1n")) in
+            assert_raises
+              (Failure (Ligo.string_of_int error_RemoveLiquidityTooMuchLiquidityWithdrawn))
+              (fun () -> Checker.view_remove_liquidity_min_kit_withdrawn (lqt_to_withdraw, checker))
          );
      ]
     );

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -1369,7 +1369,6 @@ let suite =
          let _ = f checker in ()
      in
      [
-
        "view_buy_kit_min_kit_expected" >:: with_cfmm_setup
          (fun checker ->
             let ctez_to_sell = Ctez.ctez_of_muctez (Ligo.nat_from_literal "100_000n") in
@@ -1378,6 +1377,13 @@ let suite =
             (* must succeed, otherwise view_buy_kit_min_kit_expected overapproximated *)
             Checker.entrypoint_buy_kit (checker, (ctez_to_sell, min_kit_to_buy, deadline)));
 
+       "view_buy_kit_min_kit_expected - fail if no ctez is given" >:: with_cfmm_setup
+         (fun checker ->
+            assert_raises
+              (Failure (Ligo.string_of_int error_BuyKitNoTezGiven))
+              (fun () -> Checker.view_buy_kit_min_kit_expected (Ctez.ctez_zero, checker))
+         );
+
        "view_sell_kit_min_ctez_expected" >:: with_cfmm_setup
          (fun checker ->
             let kit_to_sell = Kit.kit_of_mukit (Ligo.nat_from_literal "100_000n") in
@@ -1385,6 +1391,13 @@ let suite =
             let deadline = Ligo.add_timestamp_int !Ligo.Tezos.now (Ligo.int_from_literal "20") in
             (* must succeed, otherwise view_sell_kit_min_ctez_expected overapproximated *)
             Checker.entrypoint_sell_kit (checker, (kit_to_sell, min_ctez_to_buy, deadline)));
+
+       "view_sell_kit_min_ctez_expected - fail if no kit is given" >:: with_cfmm_setup
+         (fun checker ->
+            assert_raises
+              (Failure (Ligo.string_of_int error_SellKitNoKitGiven))
+              (fun () -> Checker.view_sell_kit_min_ctez_expected (Kit.kit_zero, checker))
+         );
 
        "view_add_liquidity_max_kit_deposited / view_add_liquidity_min_lqt_minted" >:: with_cfmm_setup
          (fun checker ->

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -1397,6 +1397,20 @@ let suite =
              * view_add_liquidity_min_lqt_minted overapproximated (or both of them did) *)
             Checker.entrypoint_add_liquidity (checker, (ctez_to_sell, max_kit_to_sell, min_lqt_to_buy, deadline)));
 
+       "view_add_liquidity_max_kit_deposited - fail if no ctez is given" >:: with_cfmm_setup
+         (fun checker ->
+            assert_raises
+              (Failure (Ligo.string_of_int error_AddLiquidityNoTezGiven))
+              (fun () -> Checker.view_add_liquidity_max_kit_deposited (Ctez.ctez_zero, checker))
+         );
+
+       "view_add_liquidity_min_lqt_minted - fail if no ctez is given" >:: with_cfmm_setup
+         (fun checker ->
+            assert_raises
+              (Failure (Ligo.string_of_int error_AddLiquidityNoTezGiven))
+              (fun () -> Checker.view_add_liquidity_min_lqt_minted (Ctez.ctez_zero, checker))
+         );
+
        "view_remove_liquidity_min_ctez_withdrawn / view_remove_liquidity_min_kit_withdrawn" >:: with_cfmm_setup
          (fun checker ->
             let lqt_to_sell = Lqt.lqt_of_denomination (Ligo.nat_from_literal "5n") in

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -1421,6 +1421,20 @@ let suite =
              * view_remove_liquidity_min_ctez_withdrawn overapproximated or
              * view_remove_liquidity_min_kit_withdrawn overapproximated (or both of them did) *)
             Checker.entrypoint_remove_liquidity (checker, (lqt_to_sell, min_ctez_to_buy, min_kit_to_buy, deadline)));
+
+       "view_remove_liquidity_min_ctez_withdrawn - fail if no liquidity is given" >:: with_cfmm_setup
+         (fun checker ->
+            assert_raises
+              (Failure (Ligo.string_of_int error_RemoveLiquidityNoLiquidityBurned))
+              (fun () -> Checker.view_remove_liquidity_min_ctez_withdrawn (Lqt.lqt_zero, checker))
+         );
+
+       "view_remove_liquidity_min_kit_withdrawn - fail if no liquidity is given" >:: with_cfmm_setup
+         (fun checker ->
+            assert_raises
+              (Failure (Ligo.string_of_int error_RemoveLiquidityNoLiquidityBurned))
+              (fun () -> Checker.view_remove_liquidity_min_kit_withdrawn (Lqt.lqt_zero, checker))
+         );
      ]
     );
 


### PR DESCRIPTION
Coverage increases

1. due to the addition of the following new tests:
   * cfmm_remove_liquidity - too much lqt withdrawn (equal)
   * cfmm_remove_liquidity - too much lqt withdrawn (more than)
   * cfmm_remove_liquidity - error_CfmmTooLate - barely (equal)
   * cfmm_remove_liquidity - error_CfmmTooLate - over (unequal)
   * view_buy_kit_min_kit_expected   - fail if no ctez is given
   * view_sell_kit_min_ctez_expected - fail if no kit is given
   * view_remove_liquidity_min_ctez_withdrawn - too much lqt withdrawn (equal)
   * view_remove_liquidity_min_ctez_withdrawn - too much lqt withdrawn (more than)
   * view_remove_liquidity_min_kit_withdrawn  - too much lqt withdrawn (equal)
   * view_remove_liquidity_min_kit_withdrawn  - too much lqt withdrawn (more than)
   * view_remove_liquidity_min_ctez_withdrawn - fail if no liquidity is given
   * view_remove_liquidity_min_kit_withdrawn  - fail if no liquidity is given
   * cfmm_add_liquidity - error_CfmmTooLate - barely (equal)
   * cfmm_add_liquidity - error_CfmmTooLate - over (unequal)
   * view_add_liquidity_max_kit_deposited - fail if no ctez is given
   * view_add_liquidity_min_lqt_minted    - fail if no ctez is given
2. due to the removal of the following inaccessible error paths (inaccessible because of arithmetic-related reasons)
   * `error_SellKitTooMuchTezBought`
   * `error_BuyKitTooMuchKitBought`
   * `error_AddLiquidityZeroKitDeposited`
   * `error_RemoveLiquidityTooMuchTezWithdrawn`
   * `error_RemoveLiquidityTooMuchKitWithdrawn`

Note that `cfmm.ml` has been and still is reported as having 100% test coverage by `bisect_ppx`, but before this PR it was at 92.31% real. ~~I think that with this PR we get to an actual 100%, but to check that I have to manually switch the `if-then-else`s to `match-with`s at the moment.~~ I (painstakingly) checked and we are now at real 100% coverage for `cfmm.ml`.

