### PR TITLE
ci: Publish code size and gas cost artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ jobs:
         run: nix-shell --run 'make indent && if [ -n "$(git status --porcelain)" ]; then echo "Some files require formatting, run \"make indent\"."; exit 1; fi'
       - name: Build and test
         run: nix-build -A michelson --arg doCheck true
+
+      - name: Export lazy entrypoint sizes
+        run: |
+          cat result/functions.json \
+            | jq --sort-keys '.lazy_functions | map({ key: .name, value: .chunks|add|length|(./2) }) | from_entries' \
+            > entrypoint-sizes.json
+      - uses: actions/upload-artifact@v2.2.4
+        with:
+          name: stats
+          path: entrypoint-sizes.json
+          if-no-files-found: error
   e2e:
     runs-on: ubuntu-latest
     steps:
@@ -46,4 +57,9 @@ jobs:
       - name: Build checker with e2eTestsHack
         run: nix-build -A michelson --arg doCheck false --arg e2eTestsHack true --out-link ./checker-e2eTestsHack
       - name: Run e2e tests
-        run: nix-shell --run "CHECKER_DIR=$PWD/checker-e2eTestsHack python e2e/main.py"
+        run: nix-shell --run "WRITE_GAS_COSTS=$PWD/gas-costs.json CHECKER_DIR=$PWD/checker-e2eTestsHack python e2e/main.py"
+      - uses: actions/upload-artifact@v2.2.4
+        with:
+          name: stats
+          path: gas-costs.json
+          if-no-files-found: error

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -10,9 +10,10 @@ from pytezos.contract.interface import ContractInterface
 from pytezos.operation import MAX_OPERATIONS_TTL
 
 PROJECT_ROOT = os.path.join(os.path.dirname(__file__), "../")
-CHECKER_DIR = os.environ.get(
-    "CHECKER_DIR", os.path.join(PROJECT_ROOT, "generated/michelson")
+CHECKER_DIR = os.getenv(
+    "CHECKER_DIR", default=os.path.join(PROJECT_ROOT, "generated/michelson")
 )
+WRITE_GAS_COSTS = os.getenv("WRITE_GAS_COSTS")
 
 from checker_client.checker import *
 
@@ -158,7 +159,11 @@ class E2ETest(SandboxedTestCase):
             gas_costs.items(), key=lambda tup: int(tup[1]), reverse=True
         ):
             gas_costs_sorted[k] = v
+
         print(json.dumps(gas_costs_sorted, indent=4))
+        if WRITE_GAS_COSTS:
+            with open(WRITE_GAS_COSTS, "w") as f:
+                json.dump(gas_costs_sorted, f, indent=4)
 
 
 class LiquidationsStressTest(SandboxedTestCase):


### PR DESCRIPTION
This PR makes GitHub actions contain the code size and gas cost stats produced by the compilation script and the e2e test.

It is exposed as a `stats.zip` file that can be [found](https://github.com/tezos-checker/checker/actions/runs/1003859468) at the Actions page for a commit (Look at the second heading called "artifacts"). Unfortunately there is [no way](https://github.com/actions/upload-artifact#zipped-artifact-downloads) to have anything other than a zip file.

So, currently this is not extremely useful other than record-keeping purposes. But my plan is merging these first, and after a few weeks create a script to fetch last N artifacts to create a line graph. This might also make it possible to do fancier things like automatically sending a PR reporting the change. But we can think about them later on once we have more data.

Another thing we can do is to have another CI step (possibly nightly) running mutation tests, and export its results in a similar fashion. We can start thinking about it once our mutation-testing strategy is more refined.