### PR TITLE
Represent Parameters.{index,protected_index} as a Ligo.nat

### DIFF
--- a/patches/e2e-tests-hack.patch
+++ b/patches/e2e-tests-hack.patch
@@ -1,12 +1,12 @@
 diff --git a/src/parameters.ml b/src/parameters.ml
-index 395ecd1..4907c90 100644
+index 440a3a3..fc34af5 100644
 --- a/src/parameters.ml
 +++ b/src/parameters.ml
-@@ -211,6 +211,7 @@ let[@inline] compute_current_burrow_fee_index (last_burrow_fee_index: fixedpoint
+@@ -224,6 +224,7 @@ let[@inline] compute_current_burrow_fee_index (last_burrow_fee_index: fixedpoint
  *)
- let[@inline] compute_current_protected_index (last_protected_index: Ligo.tez) (current_index: Ligo.tez) (duration_in_seconds: Ligo.int) : Ligo.tez =
-   assert (Ligo.gt_tez_tez last_protected_index (Ligo.tez_from_literal "0mutez"));
+ let[@inline] compute_current_protected_index (last_protected_index: Ligo.nat) (current_index: Ligo.nat) (duration_in_seconds: Ligo.int) : Ligo.nat =
+   assert (Ligo.gt_nat_nat last_protected_index (Ligo.nat_from_literal "0n"));
 +  let duration_in_seconds = Ligo.mul_int_int duration_in_seconds (Ligo.int_from_literal "1000") in
-   let last_protected_index = tez_to_mutez last_protected_index in
-   fraction_to_tez_floor
+   let last_protected_index = Ligo.int last_protected_index in
+   fraction_to_nat_floor
      (clamp_int

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -744,7 +744,7 @@ let rec touch_oldest
  * exceptions (1. setting the delegate, and 2. call/callback to the oract), all
  * of the operations are outwards calls, to other contracts (no callbacks). It
  * should be safe to leave the order of the transaction reversed. *)
-let[@inline] touch_with_index (state: checker) (index:Ligo.tez) : (LigoOp.operation list * checker) =
+let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.operation list * checker) =
   assert_checker_invariants state;
   let
     { burrows = state_burrows;
@@ -834,7 +834,7 @@ let[@inline] touch_with_index (state: checker) (index:Ligo.tez) : (LigoOp.operat
 let entrypoint_touch (state, _: checker * unit) : (LigoOp.operation list * checker) =
   let index = match state.last_price with
     | None -> state.parameters.index (* use the old one *)
-    | Some i -> Ligo.mul_nat_tez i (Ligo.tez_from_literal "1mutez") in (* FIXME: Is the nat supposed to represent tez? *)
+    | Some i -> i in (* FIXME: Is the nat supposed to represent tez? *)
   touch_with_index state index
 
 (* ************************************************************************* *)

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -19,7 +19,7 @@ val entrypoint_touch : checker * unit -> (LigoOp.operation list * checker)
 (**/**)
 (* ONLY EXPOSED FOR TESTING REASONS. *)
 val assert_checker_invariants : checker -> unit
-val touch_with_index : checker -> Ligo.tez -> (LigoOp.operation list * checker)
+val touch_with_index : checker -> Ligo.nat -> (LigoOp.operation list * checker)
 val calculate_touch_reward : Ligo.timestamp -> kit
 (**/**)
 

--- a/src/common.ml
+++ b/src/common.ml
@@ -60,7 +60,6 @@ let clamp_int (v: Ligo.int) (lower: Ligo.int) (upper: Ligo.int) : Ligo.int =
   min_int upper (max_int v lower)
 
 (* OPERATIONS ON tez *)
-let min_tez (x: Ligo.tez) (y: Ligo.tez) = if Ligo.leq_tez_tez x y then x else y
 let max_tez (x: Ligo.tez) (y: Ligo.tez) = if Ligo.geq_tez_tez x y then x else y
 let tez_to_mutez (x: Ligo.tez) = Ligo.int (Ligo.div_tez_tez x (Ligo.tez_from_literal "1mutez"))
 

--- a/src/common.ml
+++ b/src/common.ml
@@ -64,6 +64,10 @@ let min_tez (x: Ligo.tez) (y: Ligo.tez) = if Ligo.leq_tez_tez x y then x else y
 let max_tez (x: Ligo.tez) (y: Ligo.tez) = if Ligo.geq_tez_tez x y then x else y
 let tez_to_mutez (x: Ligo.tez) = Ligo.int (Ligo.div_tez_tez x (Ligo.tez_from_literal "1mutez"))
 
+(* OPERATIONS ON nat *)
+let min_nat (x: Ligo.nat) (y: Ligo.nat) = if Ligo.leq_nat_nat x y then x else y
+let max_nat (x: Ligo.nat) (y: Ligo.nat) = if Ligo.geq_nat_nat x y then x else y
+
 (* BEGIN_OCAML *)
 [@@@coverage off]
 let compare_int (i: Ligo.int) (j: Ligo.int) : Int.t =

--- a/src/common.mli
+++ b/src/common.mli
@@ -22,6 +22,10 @@ val min_tez : Ligo.tez -> Ligo.tez -> Ligo.tez
 val max_tez : Ligo.tez -> Ligo.tez -> Ligo.tez
 val tez_to_mutez : Ligo.tez -> Ligo.int
 
+(* OPERATIONS ON nat *)
+val min_nat : Ligo.nat -> Ligo.nat -> Ligo.nat
+val max_nat : Ligo.nat -> Ligo.nat -> Ligo.nat
+
 (* BEGIN_OCAML *)
 val compare_int : Ligo.int -> Ligo.int -> Int.t
 val compare_nat : Ligo.nat -> Ligo.nat -> Int.t

--- a/src/common.mli
+++ b/src/common.mli
@@ -18,7 +18,6 @@ val fdiv_int_int : Ligo.int -> Ligo.int -> Ligo.int
 val clamp_int : Ligo.int -> Ligo.int -> Ligo.int -> Ligo.int
 
 (* OPERATIONS ON tez *)
-val min_tez : Ligo.tez -> Ligo.tez -> Ligo.tez
 val max_tez : Ligo.tez -> Ligo.tez -> Ligo.tez
 val tez_to_mutez : Ligo.tez -> Ligo.int
 

--- a/src/ligo.ml
+++ b/src/ligo.ml
@@ -189,6 +189,8 @@ let sub_nat_nat = Z.sub
 
 let mul_nat_nat = Z.mul
 
+let mul_int_nat = Z.mul
+
 let div_nat_nat = Z.div
 
 let eq_nat_nat = Z.equal

--- a/src/ligo.mli
+++ b/src/ligo.mli
@@ -188,6 +188,7 @@ val ediv_int_int : int -> int -> (int * nat) option
 val add_nat_nat : nat -> nat -> nat (* IN LIGO: ( + ) *)
 val sub_nat_nat : nat -> nat -> int (* IN LIGO: ( - ) *)
 val mul_nat_nat : nat -> nat -> nat (* IN LIGO: ( * ) *)
+val mul_int_nat : int -> nat -> int (* IN LIGO: ( * ) *)
 
 val eq_nat_nat : nat -> nat -> bool  (* IN LIGO: ( = ) *)
 val lt_nat_nat : nat -> nat -> bool  (* IN LIGO: ( < ) *)

--- a/src/ligo.mligo
+++ b/src/ligo.mligo
@@ -9,6 +9,7 @@
 
 [@inline] let mul_int_int (i: int) (j: int) : int = i * j
 [@inline] let mul_nat_tez (i: nat) (j: tez) : tez = i * j
+[@inline] let mul_int_nat (i: int) (j: nat) : int = i * j
 
 [@inline] let div_int_int (i: int) (j: int) : int = i / j
 [@inline] let div_nat_nat (i: nat) (j: nat) : nat = i / j

--- a/src/parameters.ml
+++ b/src/parameters.ml
@@ -324,9 +324,9 @@ let[@inline] compute_current_target (current_q: fixedpoint) (current_index: Ligo
     (fdiv_int_int
        (Ligo.mul_int_int
           den
-          (Ligo.mul_int_int
+          (Ligo.mul_int_nat
              (fixedpoint_to_raw current_q)
-             (Ligo.int current_index)
+             current_index
           )
        )
        (Ligo.mul_int_int

--- a/src/ratio.ml
+++ b/src/ratio.ml
@@ -30,6 +30,20 @@ let fraction_to_tez_floor (x_num: Ligo.int) (x_den: Ligo.int) : Ligo.tez =
        quot (* ignore the remainder; we floor towards zero here *)
     )
 
+let fraction_to_nat_floor (x_num: Ligo.int) (x_den: Ligo.int) : Ligo.nat =
+  assert (Ligo.gt_int_int x_den (Ligo.int_from_literal "0"));
+  match Ligo.is_nat x_num with
+  | None -> (failwith "Ratio.fraction_to_nat_floor: negative" : Ligo.nat)
+  | Some n ->
+    (match Ligo.ediv_nat_nat n (Ligo.abs x_den) with
+     (* Note: Ignoring coverage for the case below since the assertion above makes it unreachable in OCaml *)
+     | None -> (failwith "Ratio.fraction_to_nat_floor: zero denominator" : Ligo.nat)
+               [@coverage off]
+     | Some quot_and_rem ->
+       let (quot, _) = quot_and_rem in
+       quot (* ignore the remainder; we floor towards zero here *)
+    )
+
 (* Predefined values *)
 let[@inline] zero_ratio : ratio = { num = Ligo.int_from_literal "0"; den = Ligo.int_from_literal "1"; }
 let[@inline] one_ratio : ratio = { num = Ligo.int_from_literal "1"; den = Ligo.int_from_literal "1"; }

--- a/tests/testArbitrary.ml
+++ b/tests/testArbitrary.ml
@@ -24,6 +24,12 @@ let arb_positive_lqt = QCheck.map (fun x -> lqt_of_denomination (Ligo.nat_from_l
 
 let arb_nat = QCheck.map (fun x -> Ligo.nat_from_literal ((string_of_int x) ^ "n")) QCheck.(0 -- max_int)
 
+(* somewhere between 0 and 3 *)
+let arb_small_nat =
+  QCheck.map
+    (fun x -> Ligo.nat_from_literal ((string_of_int x) ^ "n"))
+    QCheck.(1 -- ((max_int / 479_988_656_967) / 4))
+
 let arb_liquidation_slice_contents =
   QCheck.map
     (fun tz ->

--- a/tests/testArbitrary.ml
+++ b/tests/testArbitrary.ml
@@ -10,11 +10,10 @@ let arb_positive_ctez = QCheck.map (fun x -> ctez_of_muctez (Ligo.nat_from_liter
 
 let arb_address = QCheck.map Ligo.address_of_string QCheck.(string_of_size (Gen.return 36))
 
-(* somewhere between 0 and 3 tez *)
 let arb_small_tez =
   QCheck.map
     (fun x -> Ligo.tez_from_literal ((string_of_int x) ^ "mutez"))
-    QCheck.(1 -- ((max_int / 479_988_656_967) / 4))
+    QCheck.(1 -- 2_401_976)
 
 let arb_kit = QCheck.map (fun x -> kit_of_mukit (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(0 -- max_int)
 let arb_positive_kit = QCheck.map (fun x -> kit_of_mukit (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(1 -- max_int)
@@ -24,11 +23,11 @@ let arb_positive_lqt = QCheck.map (fun x -> lqt_of_denomination (Ligo.nat_from_l
 
 let arb_nat = QCheck.map (fun x -> Ligo.nat_from_literal ((string_of_int x) ^ "n")) QCheck.(0 -- max_int)
 
-(* somewhere between 0 and 3 *)
 let arb_small_nat =
+  print_string ("\n" ^ string_of_int max_int ^ "\n");
   QCheck.map
     (fun x -> Ligo.nat_from_literal ((string_of_int x) ^ "n"))
-    QCheck.(1 -- ((max_int / 479_988_656_967) / 4))
+    QCheck.(1 -- 2_401_976)
 
 let arb_liquidation_slice_contents =
   QCheck.map

--- a/tests/testBurrow.ml
+++ b/tests/testBurrow.ml
@@ -768,7 +768,7 @@ let suite =
         *  potentially obscured by rounding. This high of a difference between the
         *  index and protected index is unlikely to occur in real-world scenarios.
        *)
-       let parameters = Parameters.({initial_parameters with index=(Ligo.tez_from_literal "100_000_000_000mutez");}) in
+       let parameters = Parameters.({initial_parameters with index=(Ligo.nat_from_literal "100_000_000_000n");}) in
        assert_int_equal
          ~expected:(Ligo.int_from_literal "707856")
          ~real:(Burrow.compute_tez_to_auction parameters burrow)

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -60,7 +60,7 @@ let suite =
      fun _ ->
        Ligo.Tezos.reset ();
        let checker1 = empty_checker in
-       let ops, checker2 = Checker.touch_with_index checker1 (Ligo.tez_from_literal "0mutez") in
+       let ops, checker2 = Checker.touch_with_index checker1 (Ligo.nat_from_literal "0n") in
 
        assert_operation_list_equal ~expected:[] ~real:ops;
        assert_equal checker1 checker2; (* NOTE: we really want them to be identical here, hence the '='. *)
@@ -993,7 +993,7 @@ let suite =
           	* take more time I guess). *)
        Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
-       let _ops, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_001mutez") in
+       let _ops, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_001n") in
 
        let ops, checker = Checker.entrypoint_touch_burrow (checker, burrow_id) in
        assert_operation_list_equal ~expected:[] ~real:ops;
@@ -1009,7 +1009,7 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:(211*60) ~blocks_passed:211 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
        let kit_before_reward = get_balance_of checker bob_addr kit_token_id in
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_200_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_200_000n") in
        let kit_after_reward = get_balance_of checker bob_addr kit_token_id in
 
        let touch_reward = Ligo.sub_nat_nat kit_after_reward kit_before_reward in
@@ -1060,7 +1060,7 @@ let suite =
          (fun () -> Checker.view_current_liquidation_auction_minimum_bid ((), checker));
 
        let kit_before_reward = get_balance_of checker bob_addr kit_token_id in
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_200_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_200_000n") in
        let kit_after_reward = get_balance_of checker bob_addr kit_token_id in
 
        let touch_reward = Ligo.sub_nat_nat kit_after_reward kit_before_reward in
@@ -1075,7 +1075,7 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:(5*60) ~blocks_passed:5 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
        let kit_before_reward = get_balance_of checker alice_addr kit_token_id in
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_200_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_200_000n") in
        let kit_after_reward = get_balance_of checker alice_addr kit_token_id in
 
        let touch_reward = Ligo.sub_nat_nat kit_after_reward kit_before_reward in
@@ -1101,7 +1101,7 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:(30*60) ~blocks_passed:30 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
        let kit_before_reward = get_balance_of checker alice_addr kit_token_id in
-       let ops, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_200_000mutez") in
+       let ops, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_200_000n") in
        let kit_after_reward = get_balance_of checker alice_addr kit_token_id in
 
        let touch_reward = Ligo.sub_nat_nat kit_after_reward kit_before_reward in
@@ -1182,7 +1182,7 @@ let suite =
           	* fees alone if the index remains the same. *)
        let blocks_passed = 211 in (* NOTE: I am a little surprised/worried about this being again 211... *)
        Ligo.Tezos.new_transaction ~seconds_passed:(60*blocks_passed) ~blocks_passed:blocks_passed ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _ops, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_105_283mutez") in (* sup *)
+       let _ops, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_105_283n") in (* sup *)
        let _ops, checker = Checker.entrypoint_touch_burrow (checker, burrow_id) in
 
        (* Ensure that the burrow is liquidatable. *)
@@ -1213,7 +1213,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_create_burrow (empty_checker, (Ligo.nat_from_literal "0n", None)) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to deposit some tez to the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:amount;
        let _ = Checker.entrypoint_deposit_tez (checker, Ligo.nat_from_literal "0n") in
@@ -1229,7 +1229,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_create_burrow (empty_checker, (Ligo.nat_from_literal "0n", None)) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to withdraw some tez from the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.entrypoint_withdraw_tez (checker, (Constants.creation_deposit, Ligo.nat_from_literal "0n")) in
@@ -1245,7 +1245,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_create_burrow (empty_checker, (Ligo.nat_from_literal "0n", None)) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to mint some kit out of the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "1n"))) in
@@ -1264,7 +1264,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "1n"))) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to burn some kit into the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.entrypoint_burn_kit (checker, (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "1n"))) in
@@ -1283,7 +1283,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_deactivate_burrow (checker, (Ligo.nat_from_literal "0n", !Ligo.Tezos.sender)) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to activate the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:amount;
        let _ = Checker.entrypoint_activate_burrow (checker, Ligo.nat_from_literal "0n") in
@@ -1299,7 +1299,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_create_burrow (empty_checker, (Ligo.nat_from_literal "0n", None)) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to deactivate the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.entrypoint_deactivate_burrow (checker, (Ligo.nat_from_literal "0n", !Ligo.Tezos.sender)) in
@@ -1316,7 +1316,7 @@ let suite =
        let burrow_id = (!Ligo.Tezos.sender, Ligo.nat_from_literal "0n") in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to mark the untouched burrow for liquidation *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        (* TODO: Would be nice to create the conditions for entrypoint_mark_for_liquidation
@@ -1337,7 +1337,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_create_burrow (empty_checker, (Ligo.nat_from_literal "0n", None)) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to set the delegate of the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.entrypoint_set_burrow_delegate (checker, (Ligo.nat_from_literal "0n", None)) in
@@ -1493,7 +1493,7 @@ let suite =
        let burrow_id = (!Ligo.Tezos.sender, Ligo.nat_from_literal "0n") in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to view the max mintable kit from the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.view_burrow_max_mintable_kit (burrow_id, checker) in
@@ -1510,7 +1510,7 @@ let suite =
        let burrow_id = (!Ligo.Tezos.sender, Ligo.nat_from_literal "0n") in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to view whether the untouched burrow is overburrowed *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.view_is_burrow_overburrowed (burrow_id, checker) in
@@ -1527,7 +1527,7 @@ let suite =
        let burrow_id = (!Ligo.Tezos.sender, Ligo.nat_from_literal "0n") in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.tez_from_literal "1_000_000mutez") in
+       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to view whether the untouched burrow is liquidatable *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.view_is_burrow_liquidatable (burrow_id, checker) in

--- a/tests/testLiquidation.ml
+++ b/tests/testLiquidation.ml
@@ -78,8 +78,8 @@ Other properties
 
 let params : parameters =
   { q = fixedpoint_of_ratio_floor (make_ratio (Ligo.int_from_literal "1015") (Ligo.int_from_literal "1000"));
-    index = Ligo.tez_from_literal "320_000mutez";
-    protected_index = Ligo.tez_from_literal "360_000mutez";
+    index = Ligo.nat_from_literal "320_000n";
+    protected_index = Ligo.nat_from_literal "360_000n";
     target = fixedpoint_of_ratio_floor (make_ratio (Ligo.int_from_literal "108") (Ligo.int_from_literal "100"));
     drift = fixedpoint_zero;
     drift_derivative = fixedpoint_zero;

--- a/tests/testParameters.ml
+++ b/tests/testParameters.ml
@@ -9,7 +9,7 @@ let property_test_count = 100
 let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
 
 let rec call_touch_times
-    (index: Ligo.tez)
+    (index: Ligo.nat)
     (kit_in_tez: ratio)
     (n: int)
     (params: parameters)
@@ -298,7 +298,7 @@ let test_protected_index_follows_index =
   @@ QCheck.Test.make
     ~name:"test_protected_index_follows_index"
     ~count:property_test_count
-    (QCheck.pair TestArbitrary.arb_small_tez QCheck.small_nat)
+    (QCheck.pair TestArbitrary.arb_small_nat QCheck.small_nat)
   @@ fun (index, lvl) ->
   Ligo.Tezos.reset();
 
@@ -326,38 +326,37 @@ let test_protected_index_pace =
     let kit_in_tez = one_ratio in
 
     (* UPWARD MOVES *)
-    let very_high_index =
-      let x = mul_ratio (ratio_of_int (Ligo.int_from_literal "1000")) (ratio_of_tez params.index) in
-      fraction_to_tez_floor x.num x.den in
+    let very_high_index = Ligo.abs (Ligo.mul_int_int (Ligo.int_from_literal "1000") (Ligo.int params.index)) in
     (* One hour, upward move, touched in every block *)
     (* Initial : 1.000000 *)
     (* Final   : 1.030420 (=103.0420% of initial; slightly over 3%) *)
     Ligo.Tezos.reset();
     let new_params = call_touch_times very_high_index kit_in_tez (60 (* 60 blocks ~ 1h *)) params in
-    assert_tez_equal ~expected:(Ligo.tez_from_literal "1_030_420mutez") ~real:new_params.protected_index;
+    assert_nat_equal ~expected:(Ligo.nat_from_literal "1_030_420n") ~real:new_params.protected_index;
     (* One day, upward move, touched in every block *)
     (* Initial : 1.000000 *)
     (* Final   : 2.053031 (=205.3031% of initial; slightly over double) *)
     Ligo.Tezos.reset();
     let new_params = call_touch_times very_high_index kit_in_tez (60 * 24 (* 60 blocks ~ 1h *)) params in
-    assert_tez_equal ~expected:(Ligo.tez_from_literal "2_053_031mutez") ~real:new_params.protected_index;
+    assert_nat_equal ~expected:(Ligo.nat_from_literal "2_053_031n") ~real:new_params.protected_index;
 
     (* DOWNWARD MOVES *)
     let very_low_index =
-      let x = mul_ratio (make_ratio (Ligo.int_from_literal "1") (Ligo.int_from_literal "1000")) (ratio_of_tez params.index) in
-      fraction_to_tez_floor x.num x.den in
+      fraction_to_nat_floor
+        (Ligo.int params.index)
+        (Ligo.int_from_literal "1_000") in
     (* One hour, downward move, touched in every block *)
     (* Initial : 1.000000 *)
     (* Final   : 0.970407 (=2.9593% less than initial; slightly under 3% *)
     Ligo.Tezos.reset();
     let new_params = call_touch_times very_low_index kit_in_tez (60 (* 60 blocks ~ 1h *)) params in
-    assert_tez_equal ~expected:(Ligo.tez_from_literal "970_407mutez") ~real:new_params.protected_index;
+    assert_nat_equal ~expected:(Ligo.nat_from_literal "970_407n") ~real:new_params.protected_index;
     (* One day, downward move, touched in every block *)
     (* Initial : 1.000000 *)
     (* Final   : 0.486151 (=51.3849% less than initial; slightly more than halved) *)
     Ligo.Tezos.reset();
     let new_params = call_touch_times very_low_index kit_in_tez (60 * 24 (* 60 blocks ~ 1h *)) params in
-    assert_tez_equal ~expected:(Ligo.tez_from_literal "486_151mutez") ~real:new_params.protected_index
+    assert_nat_equal ~expected:(Ligo.nat_from_literal "486_151n") ~real:new_params.protected_index
 
 (* ************************************************************************* *)
 (*                                 Prices                                    *)
@@ -367,7 +366,7 @@ let test_protected_index_pace =
  *   src/parameters.ml:29 (1_000_000mutez => 999_999mutez) *)
 let test_initial_tz_minting_equals_initial_tz_liquidation =
   "initially tz_minting equals tz_liquidation" >:: fun _ ->
-    assert_tez_equal
+    assert_nat_equal
       ~expected:(tz_liquidation initial_parameters)
       ~real:(tz_minting initial_parameters)
 
@@ -385,7 +384,7 @@ let test_minting_index_low_bounded =
   @@ QCheck.Test.make
     ~name:"test_minting_index_low_bounded"
     ~count:property_test_count
-    (QCheck.map (fun x -> Ligo.tez_from_literal (string_of_int x ^ "mutez")) QCheck.(1 -- 999_999))
+    (QCheck.map (fun x -> Ligo.nat_from_literal (string_of_int x ^ "n")) QCheck.(1 -- 999_999))
   @@ fun index ->
   Ligo.Tezos.reset ();
 
@@ -394,7 +393,7 @@ let test_minting_index_low_bounded =
 
   let _total_accrual_to_cfmm, new_params = parameters_touch index kit_in_tez params in
 
-  (tz_minting new_params >= Ligo.tez_from_literal "999_500mutez") (* 0.05% down, at "best" *)
+  (tz_minting new_params >= Ligo.nat_from_literal "999_500n") (* 0.05% down, at "best" *)
 
 (* The pace of change of the minting index is unbounded on the high side.
  * George: What about the pace of change of the minting price (affected also by
@@ -410,14 +409,14 @@ let test_minting_index_high_unbounded =
   @@ QCheck.Test.make
     ~name:"test_minting_index_high_unbounded"
     ~count:property_test_count
-    (QCheck.map (fun x -> Ligo.tez_from_literal (string_of_int x ^ "mutez")) QCheck.(1_000_001 -- max_int))
+    (QCheck.map (fun x -> Ligo.nat_from_literal (string_of_int x ^ "n")) QCheck.(1_000_001 -- max_int))
   @@ fun index ->
   Ligo.Tezos.reset ();
   (* just the next block *)
   Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
   let _total_accrual_to_cfmm, new_params = parameters_touch index kit_in_tez params in
-  assert_tez_equal
+  assert_nat_equal
     ~expected:index
     ~real:(tz_minting new_params);
   true
@@ -436,7 +435,7 @@ let test_liquidation_index_high_bounded =
   @@ QCheck.Test.make
     ~name:"test_liquidation_index_high_bounded"
     ~count:property_test_count
-    (QCheck.map (fun x -> Ligo.tez_from_literal (string_of_int x ^ "mutez")) QCheck.(1_000_001 -- max_int))
+    (QCheck.map (fun x -> Ligo.nat_from_literal (string_of_int x ^ "n")) QCheck.(1_000_001 -- max_int))
   @@ fun index ->
   Ligo.Tezos.reset ();
   (* just the next block *)
@@ -445,7 +444,7 @@ let test_liquidation_index_high_bounded =
   let _total_accrual_to_cfmm, new_params = parameters_touch index kit_in_tez params in
   (* not very likely to hit the < case here I think;
    * perhaps we need a different generator *)
-  (tz_liquidation new_params <= Ligo.tez_from_literal "1_000_500mutez") (* 0.05% up, at "best" *)
+  (tz_liquidation new_params <= Ligo.nat_from_literal "1_000_500n") (* 0.05% up, at "best" *)
 
 (* The pace of change of the liquidation index is unbounded on the low side.
  * George: What about the pace of change of the liquidation price (affected
@@ -462,13 +461,13 @@ let test_liquidation_index_low_unbounded =
   @@ QCheck.Test.make
     ~name:"test_liquidation_index_low_unbounded"
     ~count:property_test_count
-    (QCheck.map (fun x -> Ligo.tez_from_literal (string_of_int x ^ "mutez")) QCheck.(1 -- 999_999))
+    (QCheck.map (fun x -> Ligo.nat_from_literal (string_of_int x ^ "n")) QCheck.(1 -- 999_999))
   @@ fun index ->
   (* just the next block *)
   Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
   let _total_accrual_to_cfmm, new_params = parameters_touch index kit_in_tez params in
-  assert_tez_equal
+  assert_nat_equal
     ~expected:index
     ~real:(tz_liquidation new_params);
   true
@@ -486,8 +485,8 @@ let test_touch_0 =
     let in_params =
       Parameters.{
         q = fixedpoint_one;
-        index = Ligo.tez_from_literal "1_000_000mutez";
-        protected_index = Ligo.tez_from_literal "1_000_000mutez";
+        index = Ligo.nat_from_literal "1_000_000n";
+        protected_index = Ligo.nat_from_literal "1_000_000n";
         target = fixedpoint_one;
         drift = fixedpoint_zero;
         drift_derivative = fixedpoint_zero;
@@ -500,8 +499,8 @@ let test_touch_0 =
     let expected_out_params =
       Parameters.{
         q = fixedpoint_one;
-        index = Ligo.tez_from_literal "500_000mutez";
-        protected_index = Ligo.tez_from_literal "1_000_000mutez";
+        index = Ligo.nat_from_literal "500_000n";
+        protected_index = Ligo.nat_from_literal "1_000_000n";
         target = fixedpoint_of_hex_string "0.2AAAAAAAAAAAAAAA";
         drift_derivative = fixedpoint_zero;
         drift = fixedpoint_zero;
@@ -514,7 +513,7 @@ let test_touch_0 =
 
     (* Non-trivial values for the arguments. *)
     let kit_in_tez = make_ratio (Ligo.int_from_literal "3") (Ligo.int_from_literal "1") in
-    let index = Ligo.tez_from_literal "500_000mutez" in
+    let index = Ligo.nat_from_literal "500_000n" in
     (* Touch in the same block. I wonder if we wish to allow this for a local function such as parameters_touch. *)
     Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
     let total_accrual_to_cfmm, out_params = parameters_touch index kit_in_tez in_params in
@@ -532,9 +531,9 @@ let test_touch_1 =
   "test_touch_1" >:: fun _ ->
     let initial_parameters : parameters =
       { q = fixedpoint_of_hex_string "0.E666666666666666"; (* 0.9 *)
-        index = Ligo.tez_from_literal "360_000mutez";
+        index = Ligo.nat_from_literal "360_000n";
         target = fixedpoint_of_hex_string "1.147AE147AE147AE1"; (* 1.08 *)
-        protected_index = Ligo.tez_from_literal "350_000mutez";
+        protected_index = Ligo.nat_from_literal "350_000n";
         drift = fixedpoint_zero;
         drift_derivative = fixedpoint_zero;
         burrow_fee_index = fixedpoint_one;
@@ -546,14 +545,14 @@ let test_touch_1 =
     Ligo.Tezos.reset ();
     Ligo.Tezos.new_transaction ~seconds_passed:3600 ~blocks_passed:60 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
-    let new_index = Ligo.tez_from_literal "340_000mutez" in
+    let new_index = Ligo.nat_from_literal "340_000n" in
     let kit_in_tez = make_ratio (Ligo.int_from_literal "305") (Ligo.int_from_literal "1000") in
     let total_accrual_to_cfmm, new_parameters = parameters_touch new_index kit_in_tez initial_parameters in
     assert_parameters_equal
       ~expected:{
         q = fixedpoint_of_hex_string "0.E6666895A3EC8BA5"; (* 0.90000013020828555983 *)
-        index = Ligo.tez_from_literal "340_000mutez";
-        protected_index = Ligo.tez_from_literal "340_000mutez";
+        index = Ligo.nat_from_literal "340_000n";
+        protected_index = Ligo.nat_from_literal "340_000n";
         target = fixedpoint_of_hex_string "1.00D6E1B366FF4BEE"; (* 1.00327883367481013224 *)
         drift_derivative = fixedpoint_of_hex_string "0.000000000012DA63"; (* 0.00000000000006697957 *)
         drift  = fixedpoint_of_hex_string "0.00000000848F8818"; (* 0.00000000012056322737 *)
@@ -571,9 +570,9 @@ let test_touch_2 =
   "test_touch_2" >:: fun _ ->
     let initial_parameters : parameters =
       { q = fixedpoint_of_hex_string "0.E666666666666666"; (* 0.9 *)
-        index = Ligo.tez_from_literal "360_000mutez";
+        index = Ligo.nat_from_literal "360_000n";
         target = fixedpoint_of_hex_string "1.147AE147AE147AE1"; (* 1.08 *)
-        protected_index = Ligo.tez_from_literal "350_000mutez";
+        protected_index = Ligo.nat_from_literal "350_000n";
         drift = fixedpoint_zero;
         drift_derivative = fixedpoint_zero;
         burrow_fee_index = fixedpoint_one;
@@ -585,14 +584,14 @@ let test_touch_2 =
     Ligo.Tezos.reset ();
     Ligo.Tezos.new_transaction ~seconds_passed:3600 ~blocks_passed:60 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
-    let new_index = Ligo.tez_from_literal "340_000mutez" in
+    let new_index = Ligo.nat_from_literal "340_000n" in
     let kit_in_tez = make_ratio (Ligo.int_from_literal "305") (Ligo.int_from_literal "1000") in
     let total_accrual_to_cfmm, new_parameters = parameters_touch new_index kit_in_tez initial_parameters in
     assert_parameters_equal
       ~expected:{
         q = fixedpoint_of_hex_string "0.E6666895A3EC8BA5";
-        index = Ligo.tez_from_literal "340000mutez";
-        protected_index = Ligo.tez_from_literal "340000mutez";
+        index = Ligo.nat_from_literal "340000n";
+        protected_index = Ligo.nat_from_literal "340000n";
         target = fixedpoint_of_hex_string "1.00D6E1B366FF4BEE";
         drift_derivative = fixedpoint_of_hex_string "0.000000000012DA63";
         drift = fixedpoint_of_hex_string "0.00000000848F8818";


### PR DESCRIPTION
Until now we've been converting the `nat` we get from the
oracle into `tez` to match intuition, but in Michelson `tez`
is represented using 64 bit signed integers ([source](https://gitlab.com/tezos/tezos/-/blob/master/docs/009/michelson.rst)), which
can lead to unnecessary overflows.