### PR TITLE
Override "burrow" in checker.ml to avoid using outdated values

### DIFF
--- a/src/checker.ml
+++ b/src/checker.ml
@@ -283,7 +283,7 @@ let[@inline] entrypoint_mark_for_liquidation (state, burrow_id: checker * burrow
   let
     { liquidation_reward = liquidation_reward;
       tez_to_auction = tez_to_auction;
-      burrow_state = updated_burrow;
+      burrow_state = burrow;
     } = match burrow_request_liquidation state.parameters burrow with
     | None -> (Ligo.failwith error_NotLiquidationCandidate : liquidation_details)
     | Some type_and_details -> let _, details = type_and_details in details
@@ -292,7 +292,7 @@ let[@inline] entrypoint_mark_for_liquidation (state, burrow_id: checker * burrow
   let state =
     if Ligo.eq_tez_tez tez_to_auction (Ligo.tez_from_literal "0mutez") then
       (* If the slice would be empty, don't create it. *)
-      { state with burrows = Ligo.Big_map.update burrow_id (Some updated_burrow) state.burrows; }
+      { state with burrows = Ligo.Big_map.update burrow_id (Some burrow) state.burrows; }
     else
       (* Otherwise do. *)
       let contents =
@@ -303,7 +303,7 @@ let[@inline] entrypoint_mark_for_liquidation (state, burrow_id: checker * burrow
       let (updated_liquidation_auctions, _leaf_ptr) =
         liquidation_auction_send_to_auction state.liquidation_auctions contents in
       { state with
-        burrows = Ligo.Big_map.update burrow_id (Some updated_burrow) state.burrows;
+        burrows = Ligo.Big_map.update burrow_id (Some burrow) state.burrows;
         liquidation_auctions = updated_liquidation_auctions;
       } in
 


### PR DESCRIPTION
I was trying to transcribe our e2e test into a unit test to trigger
#191 when I came across a bug in `Checker.mark_for_liquidation`.
When calling `compute_min_kit_for_unwarranted` the input, untouched
burrow (`burrow`) was used, instead of the most recent, touched
burrow (`updated_burrow`).

This was easy to fix, but it revealed two issues:
* In `checker.ml` when updating burrows we'd bind the new burrow
  to `updated_burrow` in a few places, which allowed for this sort
  of situation. Easy to fix: in this PR I took the liberty of
  changing this pattern and shadow `burrow` so that there's always
  only one burrow available.

* This whole issue showed up when I got an assertion failure while
  transcribing our e2e test as a unit test.   Interestingly, the e2e test
  worked just fine, even if our   assertion was violated, since we
  erase our assertions before generating the LIGO code. I am
  thinking that perhaps we need a "testing deployment mode" which
  allows us to keep most (all?) of our assertions.