### PR TITLE
Fix issue with units in initial auction bids

### DIFF
--- a/src/liquidationAuction.ml
+++ b/src/liquidationAuction.ml
@@ -302,8 +302,8 @@ let start_liquidation_auction_if_possible
       let start_value =
         let { num = num_sp; den = den_sp; } = start_price in
         kit_of_fraction_ceil
-          (Ligo.mul_int_int (tez_to_mutez (avl_tez auctions.avl_storage new_auction)) num_sp)
-          (Ligo.mul_int_int (Ligo.int_from_literal "1_000_000") den_sp)
+          (Ligo.mul_int_int (tez_to_mutez (avl_tez auctions.avl_storage new_auction)) den_sp)
+          (Ligo.mul_int_int (Ligo.int_from_literal "1_000_000") num_sp)
       in
       let current_auction =
         Some

--- a/tests/testLiquidationAuction.ml
+++ b/tests/testLiquidationAuction.ml
@@ -291,6 +291,24 @@ let suite =
       )
     );
 
+    ("test initial auction minimum bid has expected value" >::
+     fun _ ->
+       Ligo.Tezos.reset();
+       let auctions = liquidation_auction_empty in
+       let (auctions, _) =
+         liquidation_auction_send_to_auction auctions {
+           burrow = burrow_id_1;
+           tez = Ligo.tez_from_literal "2_000_000mutez";
+           min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "4_000_000n")); (* note: randomly chosen *)
+         } in
+       let start_price = {num=(Ligo.int_from_literal "3"); den=(Ligo.int_from_literal "7")} in
+       let auctions = liquidation_auction_touch auctions start_price in
+       let current = Option.get auctions.current_auction in
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "4_666_667n"))
+         ~real:(liquidation_auction_current_auction_minimum_bid current);
+    );
+
     ("test starts descending auction" >::
      fun _ ->
        Ligo.Tezos.reset();


### PR DESCRIPTION
Fixes a bug in `start_liquidation_auction_if_possible` where the initial bid for a liquidation auction was calculated assuming the liquidation price was in units of `kit/tez` while it actually has units of `tez/kit`. Also added a unit / regression test which catches the error in the previous implementation.
