### PR TITLE
Improvements to test coverage (89.56% => 90.05%)

### DIFF
--- a/src/burrow.ml
+++ b/src/burrow.ml
@@ -535,7 +535,12 @@ let burrow_request_liquidation (p: parameters) (b: burrow) : liquidation_result 
       let b_without_reward = { b with collateral = Ligo.sub_tez_tez (Ligo.sub_tez_tez b.collateral partial_reward) creation_deposit } in
       let tez_to_auction = compute_tez_to_auction p b_without_reward in
 
-      if (Ligo.lt_int_int tez_to_auction (Ligo.int_from_literal "0")) || (Ligo.gt_int_int tez_to_auction (tez_to_mutez b_without_reward.collateral)) then
+      (* FIXME: The property checked by the following assertion is quite
+       * intricate to prove. We probably should include the proof somewhere
+       * in the codebase. *)
+      assert (Ligo.gt_int_int tez_to_auction (Ligo.int_from_literal "0"));
+
+      if Ligo.gt_int_int tez_to_auction (tez_to_mutez b_without_reward.collateral) then
         (* Case 2b.1: With the current price it's impossible to make the burrow
          * not undercollateralized; pay the liquidation reward, stash away the
          * creation deposit, and liquidate all the remaining collateral, even if

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -284,7 +284,10 @@ let[@inline] entrypoint_mark_for_liquidation (state, burrow_id: checker * burrow
       tez_to_auction = tez_to_auction;
       burrow_state = burrow;
     } = match burrow_request_liquidation state.parameters burrow with
-    | None -> (Ligo.failwith error_NotLiquidationCandidate : liquidation_details)
+    | None ->
+      (* Note: disabling coverage for the unreported but accessed right-hand side;
+       * accessibility is sufficiently marked on the pattern itself. *)
+      ((Ligo.failwith error_NotLiquidationCandidate [@coverage off]): liquidation_details)
     | Some type_and_details -> let _, details = type_and_details in details
   in
 

--- a/src/checkerMain.ml
+++ b/src/checkerMain.ml
@@ -89,16 +89,32 @@ let main (op, state: params * wrapper): LigoOp.operation list * wrapper =
               let metadata = Ligo.Big_map.add "" metadata_url metadata in
 
               ([touchOp], lazy_functions, metadata, Sealed checker)
-            | CheckerEntrypoint _ -> (Ligo.failwith error_ContractNotDeployed: LigoOp.operation list * lazy_function_map * (string, Ligo.bytes) Ligo.big_map * deployment_state)
+            | CheckerEntrypoint _ ->
+              (* Note: disabling coverage for the unreported but accessed right-hand side;
+               * accessibility is sufficiently marked on the pattern itself. *)
+              ((Ligo.failwith error_ContractNotDeployed [@coverage off]): LigoOp.operation list * lazy_function_map * (string, Ligo.bytes) Ligo.big_map * deployment_state)
           end
-        | false -> (Ligo.failwith error_UnauthorisedCaller: LigoOp.operation list * lazy_function_map * (string, Ligo.bytes) Ligo.big_map * deployment_state)
+        | false ->
+          (* Note: disabling coverage for the unreported but accessed right-hand side;
+           * accessibility is sufficiently marked on the pattern itself. *)
+          ((Ligo.failwith error_UnauthorisedCaller [@coverage off]): LigoOp.operation list * lazy_function_map * (string, Ligo.bytes) Ligo.big_map * deployment_state)
       end
     | Sealed checker ->
       let ops, checker =
         match op with
-        | DeployFunction _ -> (Ligo.failwith error_ContractAlreadyDeployed: LigoOp.operation list * checker)
-        | SealContract _ -> (Ligo.failwith error_ContractAlreadyDeployed: LigoOp.operation list * checker)
-        | DeployMetadata _ -> (Ligo.failwith error_ContractAlreadyDeployed: LigoOp.operation list * checker)
+        | DeployFunction _ ->
+          (* Note: disabling coverage for the unreported but accessed right-hand side;
+           * accessibility is sufficiently marked on the pattern itself. *)
+          ((Ligo.failwith error_ContractAlreadyDeployed [@coverage off]): LigoOp.operation list * checker)
+        | SealContract _ ->
+          (* Note: disabling coverage for the unreported but accessed right-hand side;
+           * accessibility is sufficiently marked on the pattern itself. *)
+          ((Ligo.failwith error_ContractAlreadyDeployed [@coverage off]): LigoOp.operation list * checker)
+        | DeployMetadata _ ->
+          (* Note: disabling coverage for the unreported but accessed right-hand side;
+           * accessibility is sufficiently marked on the pattern itself. *)
+          ((Ligo.failwith error_ContractAlreadyDeployed [@coverage off]): LigoOp.operation list * checker)
+          [@coverage off]
         | CheckerEntrypoint op -> begin
             match op with
             | StrictParams op -> begin

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -48,8 +48,12 @@ type wrapper =
   ; deployment_state : deployment_state
   }
 
+[@@@coverage off]
+
 type view_current_liquidation_auction_minimum_bid_result =
   { auction_id: liquidation_auction_id
   ; minimum_bid: kit
   }
 [@@deriving show]
+
+[@@@coverage on]

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -52,3 +52,4 @@ type view_current_liquidation_auction_minimum_bid_result =
   { auction_id: liquidation_auction_id
   ; minimum_bid: kit
   }
+[@@deriving show]

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -1079,8 +1079,20 @@ let suite =
        let kit_after_reward = get_balance_of checker alice_addr kit_token_id in
 
        let touch_reward = Ligo.sub_nat_nat kit_after_reward kit_before_reward in
-       let auction_id = (Checker.view_current_liquidation_auction_minimum_bid ((), checker)).auction_id in
+       let min_bid = Checker.view_current_liquidation_auction_minimum_bid ((), checker) in
 
+       let auction_id =
+         min_bid.auction_id in
+       assert_kit_equal
+         ~expected:(kit_of_mukit (Ligo.nat_from_literal "2_709_185n"))
+         ~real:min_bid.minimum_bid;
+
+       (* Bid the minimum first *)
+       let (ops, checker) =
+         Checker.entrypoint_liquidation_auction_place_bid (checker, (auction_id, min_bid.minimum_bid)) in
+       assert_operation_list_equal ~expected:[] ~real:ops;
+
+       (* Same person increases the bid *)
        let (ops, checker) =
          Checker.entrypoint_liquidation_auction_place_bid
            ( checker

--- a/tests/testCommon.ml
+++ b/tests/testCommon.ml
@@ -80,17 +80,47 @@ let suite =
          ~real:(clamp_int (Ligo.int_from_literal "8") (Ligo.int_from_literal "-5") (Ligo.int_from_literal "7"));
     );
 
+    "max_tez - first greater than the second" >::
+    (fun _ ->
+       assert_tez_equal
+         ~expected:(Ligo.tez_from_literal "9_337_600_103_819mutez")
+         ~real:(max_tez (Ligo.tez_from_literal "9_337_600_103_819mutez") (Ligo.tez_from_literal "9_337_600_103_818mutez")) (* note: randomly chosen *)
+    );
+
+    "max_tez - second greater than the first" >::
+    (fun _ ->
+       assert_tez_equal
+         ~expected:(Ligo.tez_from_literal "9_337_600_103_819mutez")
+         ~real:(max_tez (Ligo.tez_from_literal "9_337_600_103_818mutez") (Ligo.tez_from_literal "9_337_600_103_819mutez")) (* note: randomly chosen *)
+    );
+
     "fraction_to_tez_floor" >::
     (fun _ ->
        assert_tez_equal
          ~expected:(Ligo.tez_from_literal "333_333mutez")
          ~real:(fraction_to_tez_floor (Ligo.int_from_literal "1") (Ligo.int_from_literal "3"))
     );
+
     "fraction_to_tez_floor - fails for negative numerators" >::
     (fun _ ->
        assert_raises
          (Failure (Ligo.string_of_int internalError_FractionToTezFloorNegative))
          (fun _ -> fraction_to_tez_floor (Ligo.int_from_literal "-1") (Ligo.int_from_literal "2")
+         )
+    );
+
+    "fraction_to_nat_floor" >::
+    (fun _ ->
+       assert_nat_equal
+         ~expected:(Ligo.nat_from_literal "333_333n")
+         ~real:(fraction_to_nat_floor (Ligo.int_from_literal "1_000_000") (Ligo.int_from_literal "3"))
+    );
+
+    "fraction_to_nat_floor - fails for negative numerators" >::
+    (fun _ ->
+       assert_raises
+         (Failure (Ligo.string_of_int internalError_FractionToNatFloorNegative))
+         (fun _ -> fraction_to_nat_floor (Ligo.int_from_literal "-1") (Ligo.int_from_literal "2")
          )
     );
   ]


### PR DESCRIPTION
This is another attempt to improve test coverage. It increases coverage for the following files:

| source file          | from   | to
| ---------------------|--------|--------
| `src/common.ml`      | 97.75% | 100.00%
| `src/burrow.ml`      | 96.48% |  96.85%
| `src/checkerMain.ml` | 79.17% |  88.10%
| `src/checker.ml`     | 83.58% |  84.40%

There is still room for improvement (quite some, I think), but I've already seen that the following will not allow us to get to 100% coverage:

* aantron/bisect_ppx#377
* Can't get `LigoOp.Tezos.get_entrypoint_opt` to return `None` without emulating the chain somehow.
* Can't create meaningful values of type `Ligo.contract` to be able to call to `Balance_of` without emulating the chain somehow. This we still might be able to fake, but I am not sure how valuable that is.