### PR TITLE
Improvements to test coverage, reloaded (90.05% => 93.00%)

### DIFF
--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -12,6 +12,11 @@ open LiquidationAuctionPrimitiveTypes
 let property_test_count = 100
 let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
 
+(* This function lets us test all different branches of
+ * CheckerEntrypoints.lazyParamsToLazyFunctionId. This is the reason we pass
+ * the lazy parameters here, instead of the function id and the bytes
+ * separately, so that we can call lazyParamsToLazyFunctionId on each possible
+ * argument and increase test coverage. *)
 let test_deploy_function_with_lazy_params_succeeds lazy_params =
   Ligo.Tezos.reset ();
   Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:leena_addr ~amount:(Ligo.tez_from_literal "0mutez");

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -265,6 +265,23 @@ let suite =
        )
     );
 
+    ("If checker is sealed, users should be able to call CheckerEntrypoint/StrictParams/Balance_of" >::
+     with_sealed_wrapper
+       (fun sealed_wrapper ->
+          let requests = [] in
+          let callback =
+            Option.get
+              (LigoOp.Tezos.get_entrypoint_opt "%some_entrypoint_name_here" alice_addr
+               : (Fa2Interface.fa2_balance_of_response list) Ligo.contract option) in
+          let fa2_balance_of_param = Fa2Interface.{requests; callback;} in
+          let op = CheckerMain.(CheckerEntrypoint (StrictParams (Balance_of fa2_balance_of_param))) in
+          (* This call should succeed *)
+          Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          let _ops, _wrapper = CheckerMain.main (op, sealed_wrapper) in
+          ()
+       )
+    );
+
     ("If checker is sealed, users should be able to call CheckerEntrypoint/LazyParams" >::
      with_sealed_wrapper
        (fun sealed_wrapper ->


### PR DESCRIPTION
This adds another set of tests to improve test coverage. It increases coverage for the following files:

| source file          | from   | to
| ---------------------|--------|--------
| `src/checkerEntrypoints.ml`      | 58.33% | 100.00%
| `src/checkerMain.ml`      | 88.10% |  92.86%

@utdemir @dorranh I might have stumbled upon a bug (or not, I still have to investigate the `FIXME` I left in the comments), but I wouldn't investigate it as part of this PR I think.