### PR TITLE
Add extra unit tests for sliceList.ml

### DIFF
--- a/src/sliceList.ml
+++ b/src/sliceList.ml
@@ -161,11 +161,17 @@ let[@inline] slice_list_remove (l:slice_list) (auctions:liquidation_auctions) (e
       else
         (* Case 2: We are removing the oldest slice *)
       if ptr = bounds.slice_list_oldest_ptr then
-        (* Case 2.1 it is the only element (i.e. also the youngest slice). The list is now empty *)
         match slice.younger with
-        | None ->
-          assert (ptr = bounds.slice_list_youngest_ptr);
-          (None: slice_list_bounds option)
+        (* Case 2.1 it is the only element (i.e. also the youngest slice). The list is now empty *)
+        (* NOTE: This branch is unreachable in the current implementation since slice lists of
+         * a single element have slice_list_oldest_ptr = slice_list_youngest_ptr != None. This
+         * means that any single-element lists will go down the single element if- branch above
+         * (case 1.1), but we still need to perform pattern patching here since slice_list_bounds
+         * is of type option. Disabling coverage for this branch since it is unreachable.
+        *)
+        | None -> (
+            assert (ptr = bounds.slice_list_youngest_ptr);
+            (None: slice_list_bounds option)) [@coverage off]
         (* Case 2.2 there is another element. This one is now the oldest *)
         | Some younger_ptr -> Some {bounds with slice_list_oldest_ptr=younger_ptr;}
         (* Case 3: we are removing an element assumed to be in the interior of the list.

--- a/src/sliceList.ml
+++ b/src/sliceList.ml
@@ -167,11 +167,11 @@ let[@inline] slice_list_remove (l:slice_list) (auctions:liquidation_auctions) (e
          * a single element have slice_list_oldest_ptr = slice_list_youngest_ptr != None. This
          * means that any single-element lists will go down the single element if- branch above
          * (case 1.1), but we still need to perform pattern patching here since slice_list_bounds
-         * is of type option. Disabling coverage for this branch since it is unreachable.
+         * is of type option.
         *)
-        | None -> (
-            assert (ptr = bounds.slice_list_youngest_ptr);
-            (None: slice_list_bounds option)) [@coverage off]
+        | None ->
+          assert (ptr = bounds.slice_list_youngest_ptr);
+          (None: slice_list_bounds option)
         (* Case 2.2 there is another element. This one is now the oldest *)
         | Some younger_ptr -> Some {bounds with slice_list_oldest_ptr=younger_ptr;}
         (* Case 3: we are removing an element assumed to be in the interior of the list.


### PR DESCRIPTION
This PR increases test coverage for `sliceList.ml` to what should be 100%. Sadly the known issue with `bisect_ppx` and calling `Ligo.failwith` prevent the file from being reported as 100%.