### PR TITLE
Add mechanism for ignoring lines in mutation tests

### DIFF
--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -10,6 +10,9 @@ See '--help' for usage, an example:
 This script is currently meant to be used in a more interactive fashion. Edit the
 mutations MUTATION_GROUPS as needed.
 
+You can use the (* SKIP_MUTATION *) in-line comment to have this script ignore
+certain lines in the source modules.
+
 WARNING: This script edits the src files in-place and attempts to restore changes
 using git. If the script exits ungracefully you might need to clean up your
 working tree.
@@ -168,6 +171,9 @@ def mutate(
         # aggressive (e.g. in cases with an inline comment talking about assertions), but
         # this doesn't seem to be a common case.
         if "assert" in stripped:
+            continue
+        # Similar logic for lines which are manually flagged as needing to be ignored
+        if "SKIP_MUTATION" in stripped:
             continue
         match = before_regex.match(l)
         if match:

--- a/src/burrow.ml
+++ b/src/burrow.ml
@@ -548,7 +548,7 @@ let burrow_request_liquidation (p: parameters) (b: burrow) : liquidation_result 
         let tez_to_auction = b_without_reward.collateral in (* OVERRIDE *)
         let final_burrow =
           { b with
-            collateral = Ligo.tez_from_literal "0mutez"; (* SKIP_MUTATION *)
+            collateral = Ligo.tez_from_literal "0mutez";
             collateral_at_auction = Ligo.add_tez_tez b.collateral_at_auction tez_to_auction;
           } in
         Some

--- a/src/burrow.ml
+++ b/src/burrow.ml
@@ -548,7 +548,7 @@ let burrow_request_liquidation (p: parameters) (b: burrow) : liquidation_result 
         let tez_to_auction = b_without_reward.collateral in (* OVERRIDE *)
         let final_burrow =
           { b with
-            collateral = Ligo.tez_from_literal "0mutez";
+            collateral = Ligo.tez_from_literal "0mutez"; (* SKIP_MUTATION *)
             collateral_at_auction = Ligo.add_tez_tez b.collateral_at_auction tez_to_auction;
           } in
         Some


### PR DESCRIPTION
Added a basic mechanism to `mutate.py` which allows us to skip lines containing an in-line `(* SKIP_MUTATION *)` comment. This uses the same rough approach that the script uses for assertions, which is faster than using a regex but will potentially catch stuff like string literals in the code with content like `let x = "SKIP_MUTATION_FOR_SOME_REASON" in ...`. There aren't any existing examples of this in the code base though, and I think we are fairly safe from running into such issues.