### PR TITLE
Correct treatment of excess when burning kit

### DIFF
--- a/docs/spec/burrow-state-liquidations.rst
+++ b/docs/spec/burrow-state-liquidations.rst
@@ -21,8 +21,6 @@ State
    increase over time, since the burrowing fee and the adjustment fee
    are added to it. So, effectively, before doing anything else with a
    burrow, we update its state (“touch” it, see below).
--  ``excess_kit``: additional kit stored in the burrow, when
-   ``outstanding_kit`` is zero.
 -  ``collateral_at_auction``: the total amount of tez that has been sent
    to auctions from this burrow, to be sold for kit.
 - ``last_touched``: the last time the burrow was touched.
@@ -41,15 +39,6 @@ update the state of the burrow, by touching it. The effect of this is to
 ::
 
    new_last_touched = now
-
-- Re-balance
-  ``outstanding_kit`` and ``excess_kit``: either ``outstanding_kit`` or
-  ``excess_kit`` is zero
-
-::
-
-   new_outstanding_kit = old_outstanding_kit - min old_outstanding_kit old_excess_kit
-   new_excess_kit      = old_excess_kit      - min old_outstanding_kit old_excess_kit
 
 - To add accrued burrow and adjustment fee to its outstanding kit
 

--- a/docs/spec/functional_spec.rst
+++ b/docs/spec/functional_spec.rst
@@ -80,9 +80,9 @@ there is not enough collateral, or if the sender is not the burrow owner.
 Burn kit
 --------
 
-Deposit/burn a non-negative amount of kit to a burrow. If there is excess
-kit, simply store it into the burrow. Fail if the burrow does not exist, or
-if the sender is not the burrow owner.
+Deposit/burn a non-negative amount of kit to a burrow. If there is excess kit,
+simply credit it back to the burrow owner. Fail if the burrow does not exist,
+or if the sender is not the burrow owner.
 
 ``burn_kit: (pair nat nat)``
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -104,7 +104,6 @@ lots sent to auction, etc. We use several functions for checking that a valid
 state is maintained:
 
   1. `Checker.assert_checker_invariants`
-  1. `Burrow.assert_burrow_invariants`
   1. `LiquidationAuction.assert_liquidation_auction_invariants`
   1. `Avl.assert_avl_invariants`
 

--- a/scripts/generate-ligo.sh
+++ b/scripts/generate-ligo.sh
@@ -75,7 +75,6 @@ for name in "${inputs[@]}"; do
 
     # delete assertions
     sed 's/^ *assert .*//g' |
-    sed 's/^ *assert_burrow_invariants .*//g' |
     sed 's/^ *assert_checker_invariants .*//g' |
     sed 's/^ *assert_liquidation_auction_invariants .*//g' |
     sed 's/^ *assert_burrow_slices_invariants .*//g' |

--- a/src/burrow.mli
+++ b/src/burrow.mli
@@ -60,16 +60,13 @@ val burrow_is_cancellation_warranted : parameters -> burrow -> Ligo.tez -> bool
   * - Updating the outstanding kit to reflect accrued burrow fees and imbalance adjustment.
   * - Update the last observed adjustment index
   * - Update the last observed timestamp.
-  * - NOTE: Are there any other tasks to put in this list?
 *)
 val burrow_touch : parameters -> burrow -> burrow
 
-(** Deposit the kit earnings from the liquidation of a slice into the burrow.
-  * That is, (a) update the outstanding kit, and (b) adjust the burrow's
-  * pointers to the liquidation queue accordingly (which is a no-op if we are
-  * not deleting the youngest or the oldest liquidation slice). *)
-(* NOTE: the liquidation slice must be the one pointed to by the leaf pointer. *)
-val burrow_return_kit_from_auction : LiquidationAuctionPrimitiveTypes.liquidation_slice_contents -> kit -> burrow -> burrow
+(** Deposit the kit earnings from the liquidation of a slice into the burrow
+  * (i.e., update the outstanding kit and the collateral at auction). Return
+  * the amount of kit repaied, and the amount of excess kit. *)
+val burrow_return_kit_from_auction : LiquidationAuctionPrimitiveTypes.liquidation_slice_contents -> kit -> burrow -> burrow * kit * kit
 
 (** Cancel the liquidation of a slice. That is, (a) return the tez that is part
   * of a liquidation slice back to the burrow and (b) adjust the burrow's
@@ -94,9 +91,9 @@ val burrow_withdraw_tez : parameters -> Ligo.tez -> burrow -> burrow
   * not overburrow it *)
 val burrow_mint_kit : parameters -> kit -> burrow -> burrow
 
-(** Deposit/burn a non-negative amount of kit to the burrow. If there is
-  * excess kit, simply store it into the burrow. *)
-val burrow_burn_kit : parameters -> kit -> burrow -> burrow
+(** Deposit/burn a non-negative amount of kit to the burrow. Return the amount
+  * of kit burned. *)
+val burrow_burn_kit : parameters -> kit -> burrow -> burrow * kit
 
 (** Activate a currently inactive burrow. This operation will fail if either
   * the burrow is already active, or if the amount of tez given is less than
@@ -162,7 +159,6 @@ val make_burrow_for_test :
   delegate:(Ligo.key_hash option) ->
   collateral:Ligo.tez ->
   outstanding_kit:kit ->
-  excess_kit:kit ->
   adjustment_index:fixedpoint ->
   collateral_at_auction:Ligo.tez ->
   last_touched:Ligo.timestamp ->
@@ -178,7 +174,4 @@ val burrow_is_optimistically_overburrowed : parameters -> burrow -> bool
 
 (* Additional record accessor for testing purposes only *)
 val burrow_outstanding_kit : burrow -> kit
-
-(* Additional record accessor for testing purposes only *)
-val burrow_excess_kit : burrow -> kit
 (* END_OCAML *)

--- a/src/burrow.mli
+++ b/src/burrow.mli
@@ -65,7 +65,7 @@ val burrow_touch : parameters -> burrow -> burrow
 
 (** Deposit the kit earnings from the liquidation of a slice into the burrow
   * (i.e., update the outstanding kit and the collateral at auction). Return
-  * the amount of kit repaied, and the amount of excess kit. *)
+  * the amount of kit repaid, and the amount of excess kit. *)
 val burrow_return_kit_from_auction : LiquidationAuctionPrimitiveTypes.liquidation_slice_contents -> kit -> burrow -> burrow * kit * kit
 
 (** Cancel the liquidation of a slice. That is, (a) return the tez that is part

--- a/src/burrow.mli
+++ b/src/burrow.mli
@@ -147,8 +147,6 @@ val pp_liquidation_result : Format.formatter -> liquidation_result -> unit
 
 val burrow_request_liquidation : parameters -> burrow -> liquidation_result
 
-val assert_burrow_invariants : burrow -> unit
-
 (* BEGIN_OCAML *)
 val burrow_collateral : burrow -> Ligo.tez
 val burrow_active : burrow -> bool

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -28,10 +28,10 @@ let assert_checker_invariants (state: checker) : unit =
   ( if fa2_get_total_kit_balance state.fa2_state = state.parameters.circulating_kit
     then ()
     else failwith (
-      "\n" ^ "TOTAL KIT_BALANCE : " ^ Kit.show_kit (fa2_get_total_kit_balance state.fa2_state) ^
-      "\n" ^ "CIRCULATING_KIT   : " ^ Kit.show_kit state.parameters.circulating_kit ^
-      "\n"
-    )
+        "\n" ^ "TOTAL KIT_BALANCE : " ^ Kit.show_kit (fa2_get_total_kit_balance state.fa2_state) ^
+        "\n" ^ "CIRCULATING_KIT   : " ^ Kit.show_kit state.parameters.circulating_kit ^
+        "\n"
+      )
   );
   assert (fa2_get_total_kit_balance state.fa2_state = state.parameters.circulating_kit);
   (* Check that the total kit that checker owns (plus one - because of the
@@ -428,7 +428,7 @@ let touch_liquidation_slice
  * computed are independent from each other, this needs not be a problem. *)
 let rec touch_liquidation_slices_rec
     (ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state, slices
-     : LigoOp.operation list * liquidation_auctions * burrow_map * parameters * fa2_state * leaf_ptr list)
+                                                                                        : LigoOp.operation list * liquidation_auctions * burrow_map * parameters * fa2_state * leaf_ptr list)
   : (LigoOp.operation list * liquidation_auctions * burrow_map * parameters * fa2_state) =
   match slices with
   | [] -> (ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state)
@@ -732,7 +732,7 @@ let calculate_touch_reward (last_touched: Ligo.timestamp) : kit =
  * problem. *)
 let rec touch_oldest
     (ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state, maximum
-     : LigoOp.operation list * liquidation_auctions * burrow_map * parameters * fa2_state * Ligo.nat)
+                                                                                        : LigoOp.operation list * liquidation_auctions * burrow_map * parameters * fa2_state * Ligo.nat)
   : (LigoOp.operation list * liquidation_auctions * burrow_map * parameters * fa2_state) =
   match Ligo.is_nat (Ligo.sub_nat_nat maximum (Ligo.nat_from_literal "1n")) with
   | None -> (ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state)

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -416,9 +416,8 @@ let touch_liquidation_slice
     state_parameters in
 
   let new_state_fa2_state =
-    let state_fa2_state = ledger_withdraw_kit (state_fa2_state, !Ligo.Tezos.self_address, repaid_kit) in  (* this is repaid to the burrow (burned) *)
-    let state_fa2_state = ledger_withdraw_kit (state_fa2_state, !Ligo.Tezos.self_address, kit_to_burn) in (* this has to be burned, for everyone   *)
-    let state_fa2_state = ledger_withdraw_kit (state_fa2_state, !Ligo.Tezos.self_address, excess_kit) in  (* gotta give this to the burrow owner   *)
+    let checkers_kit_to_remove = kit_add (kit_add repaid_kit kit_to_burn) excess_kit in
+    let state_fa2_state = ledger_withdraw_kit (state_fa2_state, !Ligo.Tezos.self_address, checkers_kit_to_remove) in
     let state_fa2_state = ledger_issue_kit (state_fa2_state, burrow_owner, excess_kit) in
     state_fa2_state in
 

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -809,8 +809,18 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
       touch_oldest ([op], state_liquidation_auctions, state_burrows, kit_zero, kit_zero, number_of_slices_to_process) in
     let state_parameters =
       { state_parameters with
-        outstanding_kit = kit_sub state_parameters.outstanding_kit kit_to_repay;
-        circulating_kit = kit_sub state_parameters.circulating_kit (kit_add kit_to_repay kit_to_burn);
+        outstanding_kit =
+          if kit_to_repay > state_parameters.outstanding_kit
+          then (failwith ("so, it can happen, then (f):"
+                          ^ "(outstanding = " ^ Kit.show_kit state_parameters.outstanding_kit ^ ")"
+                          ^ "(kit_to_repay = " ^ Kit.show_kit kit_to_repay ^ ")"
+                         )
+                : kit) (* (Ligo.failwith (kit_to_mukit_int state_parameters.outstanding_kit) : kit) *)
+          else kit_sub state_parameters.outstanding_kit kit_to_repay;
+        circulating_kit =
+          if (kit_add kit_to_repay kit_to_burn) > state_parameters.circulating_kit
+          then (failwith "so, it can happen, then (e)" : kit)
+          else kit_sub state_parameters.circulating_kit (kit_add kit_to_repay kit_to_burn);
       } in
 
     (* Do all the ledger stuff at the end, in one go *)

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -25,6 +25,14 @@ let assert_checker_invariants (state: checker) : unit =
   assert_liquidation_auction_invariants state.liquidation_auctions;
   (* Check that the total kit tracked on the fa2 ledger is consistent with
    * (i.e., equal to) the circulating kit as stored in the state parameters. *)
+  ( if fa2_get_total_kit_balance state.fa2_state = state.parameters.circulating_kit
+    then ()
+    else failwith (
+      "\n" ^ "TOTAL KIT_BALANCE : " ^ Kit.show_kit (fa2_get_total_kit_balance state.fa2_state) ^
+      "\n" ^ "CIRCULATING_KIT   : " ^ Kit.show_kit state.parameters.circulating_kit ^
+      "\n"
+    )
+  );
   assert (fa2_get_total_kit_balance state.fa2_state = state.parameters.circulating_kit);
   (* Check that the total kit that checker owns (plus one - because of the
    * phantom kit token in the cfmm) is at least as much as the total kit in the
@@ -215,7 +223,7 @@ let entrypoint_burn_kit (state, (burrow_no, kit): checker * (Ligo.nat * kit)) : 
   let _ = ensure_no_tez_given () in
   let burrow = find_burrow state.burrows burrow_id in
   let _ = ensure_burrow_has_no_unclaimed_slices state.liquidation_auctions burrow_id in
-  let burrow = burrow_burn_kit state.parameters kit burrow in
+  let burrow, actual_burned = burrow_burn_kit state.parameters kit burrow in
   (* Note: there should be no way to remove more kit from circulation than what
    * is already in circulation. If anyone tries to do so, it means that they
    * try to remove kit they do not own. So, either
@@ -227,8 +235,8 @@ let entrypoint_burn_kit (state, (burrow_no, kit): checker * (Ligo.nat * kit)) : 
   let state =
     {state with
      burrows = Ligo.Big_map.update burrow_id (Some burrow) state.burrows;
-     parameters = remove_outstanding_and_circulating_kit state.parameters kit;
-     fa2_state = ledger_withdraw_kit (state.fa2_state, !Ligo.Tezos.sender, kit);
+     parameters = remove_outstanding_and_circulating_kit state.parameters actual_burned;
+     fa2_state = ledger_withdraw_kit (state.fa2_state, !Ligo.Tezos.sender, actual_burned); (* the burrow owner keeps the rest *)
     } in
   assert_checker_invariants state;
   (([]: LigoOp.operation list), state)
@@ -348,8 +356,10 @@ let touch_liquidation_slice
     (ops: LigoOp.operation list)
     (auctions: liquidation_auctions)
     (state_burrows: burrow_map)
+    (state_parameters: parameters)
+    (state_fa2_state: fa2_state)
     (leaf_ptr: leaf_ptr)
-  : (LigoOp.operation list * liquidation_auctions * burrow_map * kit * kit) =
+  : (LigoOp.operation list * liquidation_auctions * burrow_map * parameters * fa2_state) =
 
   let _ = ensure_valid_leaf_ptr auctions.avl_storage leaf_ptr in
 
@@ -390,36 +400,47 @@ let touch_liquidation_slice
     (kit_sub corresponding_kit penalty, penalty)
   in
 
+  let burrow_owner, _burrow_id = slice.burrow in
   let burrow = find_burrow state_burrows slice.burrow in
-  let state_burrows =
-    Ligo.Big_map.update
-      slice.burrow
-      (Some (burrow_return_kit_from_auction slice kit_to_repay burrow))
-      state_burrows in
+  let burrow, repaid_kit, excess_kit = burrow_return_kit_from_auction slice kit_to_repay burrow in
+  let state_burrows = Ligo.Big_map.update slice.burrow (Some burrow) state_burrows in
+
+  let state_parameters =
+    let state_parameters = remove_outstanding_and_circulating_kit state_parameters repaid_kit in (* NOTE: MIGHT FAIL DUE TO #209. *)
+    let state_parameters = remove_circulating_kit state_parameters kit_to_burn in (* the excess kit remains in circulation *)
+    state_parameters in
+
+  let state_fa2_state =
+    let state_fa2_state = ledger_withdraw_kit (state_fa2_state, !Ligo.Tezos.self_address, repaid_kit) in  (* this is repaid to the burrow (burned) : -CIRCU | -OUTST *) (* NOTE: MIGHT FAIL DUE TO #209. *)
+    let state_fa2_state = ledger_withdraw_kit (state_fa2_state, !Ligo.Tezos.self_address, kit_to_burn) in (* this has to be burned, for everyone   : -CIRCU |        *)
+    let state_fa2_state = ledger_withdraw_kit (state_fa2_state, !Ligo.Tezos.self_address, excess_kit) in  (* gotta give this to the burrow owner   :        |        *)
+    let state_fa2_state = ledger_issue_kit (state_fa2_state, burrow_owner, excess_kit) in
+    state_fa2_state in
 
   (* Signal the burrow to send the tez to checker. *)
   let op = match (LigoOp.Tezos.get_entrypoint_opt "%burrowSendSliceToChecker" (burrow_address burrow): Ligo.tez Ligo.contract option) with
     | Some c -> LigoOp.Tezos.tez_transaction slice.tez (Ligo.tez_from_literal "0mutez") c
     | None -> (Ligo.failwith error_GetEntrypointOptFailureBurrowSendSliceToChecker : LigoOp.operation) in
-  ((op :: ops), auctions, state_burrows, kit_to_repay, kit_to_burn)
+  ((op :: ops), auctions, state_burrows, state_parameters, state_fa2_state)
 
 (* NOTE: The list of operations returned is in reverse order (with respect to
  * the order the input slices were processed in). However, since the operations
  * computed are independent from each other, this needs not be a problem. *)
 let rec touch_liquidation_slices_rec
-    (ops, state_liquidation_auctions, state_burrows, old_kit_to_repay, old_kit_to_burn, slices: LigoOp.operation list * liquidation_auctions * burrow_map * kit * kit * leaf_ptr list)
-  : (LigoOp.operation list * liquidation_auctions * burrow_map * kit * kit) =
+    (ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state, slices
+     : LigoOp.operation list * liquidation_auctions * burrow_map * parameters * fa2_state * leaf_ptr list)
+  : (LigoOp.operation list * liquidation_auctions * burrow_map * parameters * fa2_state) =
   match slices with
-  | [] -> (ops, state_liquidation_auctions, state_burrows, old_kit_to_repay, old_kit_to_burn)
+  | [] -> (ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state)
   | x::xs ->
-    let new_ops, new_state_liquidation_auctions, new_state_burrows, new_kit_to_repay, new_kit_to_burn =
-      touch_liquidation_slice ops state_liquidation_auctions state_burrows x in
+    let ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state =
+      touch_liquidation_slice ops state_liquidation_auctions state_burrows state_parameters state_fa2_state x in
     touch_liquidation_slices_rec
-      ( new_ops,
-        new_state_liquidation_auctions,
-        new_state_burrows,
-        kit_add old_kit_to_repay new_kit_to_repay,
-        kit_add old_kit_to_burn new_kit_to_burn,
+      ( ops,
+        state_liquidation_auctions,
+        state_burrows,
+        state_parameters,
+        state_fa2_state,
         xs
       )
 
@@ -441,17 +462,8 @@ let[@inline] entrypoint_touch_liquidation_slices (state, slices: checker * leaf_
       external_contracts = state_external_contracts;
     } = state in
 
-  let new_ops, state_liquidation_auctions, state_burrows, kit_to_repay, kit_to_burn =
-    touch_liquidation_slices_rec (([]: LigoOp.operation list), state_liquidation_auctions, state_burrows, kit_zero, kit_zero, slices) in
-  let state_parameters =
-    let state_parameters = remove_outstanding_and_circulating_kit state_parameters kit_to_repay in
-    let state_parameters = remove_circulating_kit state_parameters kit_to_burn in
-    state_parameters in
-
-  let state_fa2_state =
-    let state_fa2_state = ledger_withdraw_kit (state_fa2_state, !Ligo.Tezos.self_address, kit_to_repay) in
-    let state_fa2_state = ledger_withdraw_kit (state_fa2_state, !Ligo.Tezos.self_address, kit_to_burn) in
-    state_fa2_state in
+  let ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state =
+    touch_liquidation_slices_rec (([]: LigoOp.operation list), state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state, slices) in
 
   let state =
     { burrows = state_burrows;
@@ -463,7 +475,7 @@ let[@inline] entrypoint_touch_liquidation_slices (state, slices: checker * leaf_
       external_contracts = state_external_contracts;
     } in
   assert_checker_invariants state;
-  (new_ops, state)
+  (ops, state)
 
 (* ************************************************************************* *)
 (**                                 CFMM                                     *)
@@ -719,23 +731,24 @@ let calculate_touch_reward (last_touched: Ligo.timestamp) : kit =
  * operations computed are independent from each other, this needs not be a
  * problem. *)
 let rec touch_oldest
-    (ops, state_liquidation_auctions, state_burrows, old_kit_to_repay, old_kit_to_burn, maximum: LigoOp.operation list * liquidation_auctions * burrow_map * kit * kit * Ligo.nat)
-  : (LigoOp.operation list * liquidation_auctions * burrow_map * kit * kit) =
+    (ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state, maximum
+     : LigoOp.operation list * liquidation_auctions * burrow_map * parameters * fa2_state * Ligo.nat)
+  : (LigoOp.operation list * liquidation_auctions * burrow_map * parameters * fa2_state) =
   match Ligo.is_nat (Ligo.sub_nat_nat maximum (Ligo.nat_from_literal "1n")) with
-  | None -> (ops, state_liquidation_auctions, state_burrows, old_kit_to_repay, old_kit_to_burn)
+  | None -> (ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state)
   | Some maximum ->
     begin
       match liquidation_auction_oldest_completed_liquidation_slice state_liquidation_auctions with
-      | None -> (ops, state_liquidation_auctions, state_burrows, old_kit_to_repay, old_kit_to_burn)
+      | None -> (ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state)
       | Some leaf ->
-        let new_ops, new_state_liquidation_auctions, new_state_burrows, new_kit_to_repay, new_kit_to_burn =
-          touch_liquidation_slice ops state_liquidation_auctions state_burrows leaf in
+        let ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state =
+          touch_liquidation_slice ops state_liquidation_auctions state_burrows state_parameters state_fa2_state leaf in
         touch_oldest
-          ( new_ops,
-            new_state_liquidation_auctions,
-            new_state_burrows,
-            kit_add old_kit_to_repay new_kit_to_repay,
-            kit_add old_kit_to_burn new_kit_to_burn,
+          ( ops,
+            state_liquidation_auctions,
+            state_burrows,
+            state_parameters,
+            state_fa2_state,
             maximum
           )
     end
@@ -772,13 +785,15 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
      * update the circulating kit accordingly.*)
     let reward = calculate_touch_reward state_parameters.last_touched in
     let state_parameters = add_circulating_kit state_parameters reward in
+    let state_fa2_state = ledger_issue_kit (state_fa2_state, !Ligo.Tezos.sender, reward) in
 
     (* 2: Update the system parameters and add accrued burrowing fees to the
      * cfmm sub-contract. *)
     let kit_in_tez_in_prev_block = (cfmm_kit_in_ctez_in_prev_block state_cfmm) in (* FIXME: times ctez_in_tez *)
     let total_accrual_to_cfmm, state_parameters = parameters_touch index kit_in_tez_in_prev_block state_parameters in
-    (* Note: state_parameters.circulating kit here already inlcludes the accrual to the CFMM. *)
+    (* Note: state_parameters.circulating kit here already includes the accrual to the CFMM. *)
     let state_cfmm = cfmm_add_accrued_kit state_cfmm total_accrual_to_cfmm in
+    let state_fa2_state = ledger_issue_kit (state_fa2_state, !Ligo.Tezos.self_address, total_accrual_to_cfmm) in
 
     (* 3: Update auction-related info (e.g. start a new auction). Note that we
      * always start auctions using the current liquidation price. We could also
@@ -805,29 +820,8 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
         (get_oracle_entrypoint state_external_contracts) in
 
     (* TODO: Figure out how many slices we can process per checker entrypoint_touch.*)
-    let ops, state_liquidation_auctions, state_burrows, kit_to_repay, kit_to_burn =
-      touch_oldest ([op], state_liquidation_auctions, state_burrows, kit_zero, kit_zero, number_of_slices_to_process) in
-    let state_parameters =
-      { state_parameters with
-        outstanding_kit =
-          if kit_to_repay > state_parameters.outstanding_kit
-          then (failwith ("so, it can happen, then (f):"
-                          ^ "(outstanding = " ^ Kit.show_kit state_parameters.outstanding_kit ^ ")"
-                          ^ "(kit_to_repay = " ^ Kit.show_kit kit_to_repay ^ ")"
-                         )
-                : kit) (* (Ligo.failwith (kit_to_mukit_int state_parameters.outstanding_kit) : kit) *)
-          else kit_sub state_parameters.outstanding_kit kit_to_repay;
-        circulating_kit =
-          if (kit_add kit_to_repay kit_to_burn) > state_parameters.circulating_kit
-          then (failwith "so, it can happen, then (e)" : kit)
-          else kit_sub state_parameters.circulating_kit (kit_add kit_to_repay kit_to_burn);
-      } in
-
-    (* Do all the ledger stuff at the end, in one go *)
-    let state_fa2_state =
-      let state_fa2_state = ledger_issue_kit (state_fa2_state, !Ligo.Tezos.sender, reward) in
-      let state_fa2_state = ledger_issue_then_withdraw_kit (state_fa2_state, !Ligo.Tezos.self_address, total_accrual_to_cfmm, kit_add kit_to_repay kit_to_burn) in
-      state_fa2_state in
+    let ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state =
+      touch_oldest ([op], state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state, number_of_slices_to_process) in
 
     let state =
       { burrows = state_burrows;

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -38,8 +38,6 @@ let assert_checker_invariants (state: checker) : unit =
   (* Per-burrow assertions *)
   List.iter
     (fun (burrow_address, burrow) ->
-       assert_burrow_invariants burrow;
-
        match Ligo.Big_map.find_opt burrow_address state.liquidation_auctions.burrow_slices with
        | None ->
          assert (burrow_collateral_at_auction burrow = Ligo.tez_from_literal "0mutez");

--- a/src/fa2Interface.ml
+++ b/src/fa2Interface.ml
@@ -351,8 +351,7 @@ let fa2_get_token_balance (st: fa2_state) (token_id: fa2_token_id): Ligo.nat =
 let fa2_get_total_kit_balance (st: fa2_state) : kit = kit_of_mukit (fa2_get_token_balance st kit_token_id)
 let fa2_get_total_lqt_balance (st: fa2_state) : lqt = lqt_of_denomination (fa2_get_token_balance st lqt_token_id)
 
-
-let get_credits_from_fa2_state (st: fa2_state) : ((Ligo.address * Ligo.nat) list) =
+let get_kit_credits_from_fa2_state (st: fa2_state) : ((Ligo.address * Ligo.nat) list) =
   (* Note: for now let's just focus on the kit on the ledger. *)
   let kit_map =
     Ligo.Big_map.bindings st.ledger

--- a/src/fa2Interface.ml
+++ b/src/fa2Interface.ml
@@ -351,5 +351,16 @@ let fa2_get_token_balance (st: fa2_state) (token_id: fa2_token_id): Ligo.nat =
 let fa2_get_total_kit_balance (st: fa2_state) : kit = kit_of_mukit (fa2_get_token_balance st kit_token_id)
 let fa2_get_total_lqt_balance (st: fa2_state) : lqt = lqt_of_denomination (fa2_get_token_balance st lqt_token_id)
 
+
+let get_credits_from_fa2_state (st: fa2_state) : ((Ligo.address * Ligo.nat) list) =
+  (* Note: for now let's just focus on the kit on the ledger. *)
+  let kit_map =
+    Ligo.Big_map.bindings st.ledger
+    |> List.filter (fun ((id, _owner), _amnt) -> id = kit_token_id)
+    |> List.map (fun ((_id, owner), amnt) -> (owner, amnt))
+    |> List.stable_sort compare
+  in
+  kit_map
+
 [@@@coverage on]
 (* END_OCAML *)

--- a/src/parameters.ml
+++ b/src/parameters.ml
@@ -441,10 +441,7 @@ let parameters_touch
     compute_current_target current_q current_index current_kit_in_tez in
   let current_outstanding_with_fees =
     compute_current_outstanding_with_fees parameters_outstanding_kit parameters_burrow_fee_index current_burrow_fee_index in
-  let accrual_to_cfmm =
-    if parameters_outstanding_kit > current_outstanding_with_fees
-    then (failwith "so, it can happen, then (a)" : kit)
-    else kit_sub current_outstanding_with_fees parameters_outstanding_kit in (* NOTE: can this be negative? *)
+  let accrual_to_cfmm = kit_sub current_outstanding_with_fees parameters_outstanding_kit in (* NOTE: can this be negative? *)
   let current_outstanding_kit =
     compute_current_outstanding_kit current_outstanding_with_fees parameters_imbalance_index current_imbalance_index in
   let current_circulating_kit =
@@ -474,10 +471,7 @@ let[@inline] add_circulating_kit (parameters: parameters) (kit: kit) : parameter
 (** Remove some kit from the total amount of kit in circulation. *)
 let[@inline] remove_circulating_kit (parameters: parameters) (kit: kit) : parameters =
   assert (geq_kit_kit parameters.circulating_kit kit);
-  { parameters with circulating_kit =
-                      if kit > parameters.circulating_kit
-                      then (failwith "so, it can happen, then (d)" : kit)
-                      else kit_sub parameters.circulating_kit kit; }
+  { parameters with circulating_kit = kit_sub parameters.circulating_kit kit; }
 
 (** Add some kit to the total amount of kit required to close all burrows and
     the kit in circulation. This is the case when a burrow owner mints kit. *)
@@ -491,13 +485,8 @@ let[@inline] add_outstanding_and_circulating_kit (parameters: parameters) (kit: 
     and the kit in circulation. This is the case when a burrow owner burns kit. *)
 let[@inline] remove_outstanding_and_circulating_kit (parameters: parameters) (kit: kit) : parameters =
   assert (geq_kit_kit parameters.outstanding_kit kit);
+  assert (geq_kit_kit parameters.circulating_kit kit);
   { parameters with
-    outstanding_kit =
-      if kit > parameters.outstanding_kit
-      then (failwith "so, it can happen, then (c)" : kit)
-      else kit_sub parameters.outstanding_kit kit;
-    circulating_kit =
-      if kit > parameters.circulating_kit
-      then (failwith "so, it can happen, then (b)" : kit)
-      else kit_sub parameters.circulating_kit kit;
+    outstanding_kit = kit_sub parameters.outstanding_kit kit;
+    circulating_kit = kit_sub parameters.circulating_kit kit;
   }

--- a/src/parameters.ml
+++ b/src/parameters.ml
@@ -442,7 +442,9 @@ let parameters_touch
   let current_outstanding_with_fees =
     compute_current_outstanding_with_fees parameters_outstanding_kit parameters_burrow_fee_index current_burrow_fee_index in
   let accrual_to_cfmm =
-    kit_sub current_outstanding_with_fees parameters_outstanding_kit in (* NOTE: can this be negative? *)
+    if parameters_outstanding_kit > current_outstanding_with_fees
+    then (failwith "so, it can happen, then (a)" : kit)
+    else kit_sub current_outstanding_with_fees parameters_outstanding_kit in (* NOTE: can this be negative? *)
   let current_outstanding_kit =
     compute_current_outstanding_kit current_outstanding_with_fees parameters_imbalance_index current_imbalance_index in
   let current_circulating_kit =
@@ -472,7 +474,10 @@ let[@inline] add_circulating_kit (parameters: parameters) (kit: kit) : parameter
 (** Remove some kit from the total amount of kit in circulation. *)
 let[@inline] remove_circulating_kit (parameters: parameters) (kit: kit) : parameters =
   assert (geq_kit_kit parameters.circulating_kit kit);
-  { parameters with circulating_kit = kit_sub parameters.circulating_kit kit; }
+  { parameters with circulating_kit =
+                      if kit > parameters.circulating_kit
+                      then (failwith "so, it can happen, then (d)" : kit)
+                      else kit_sub parameters.circulating_kit kit; }
 
 (** Add some kit to the total amount of kit required to close all burrows and
     the kit in circulation. This is the case when a burrow owner mints kit. *)
@@ -487,6 +492,12 @@ let[@inline] add_outstanding_and_circulating_kit (parameters: parameters) (kit: 
 let[@inline] remove_outstanding_and_circulating_kit (parameters: parameters) (kit: kit) : parameters =
   assert (geq_kit_kit parameters.outstanding_kit kit);
   { parameters with
-    outstanding_kit = kit_sub parameters.outstanding_kit kit;
-    circulating_kit = kit_sub parameters.circulating_kit kit;
+    outstanding_kit =
+      if kit > parameters.outstanding_kit
+      then (failwith "so, it can happen, then (c)" : kit)
+      else kit_sub parameters.outstanding_kit kit;
+    circulating_kit =
+      if kit > parameters.circulating_kit
+      then (failwith "so, it can happen, then (b)" : kit)
+      else kit_sub parameters.circulating_kit kit;
   }

--- a/tests/testBurrow.ml
+++ b/tests/testBurrow.ml
@@ -940,66 +940,6 @@ let suite =
     );
 
     (* =========================================================================================== *)
-    (* Property tests for ensuring burrow invariants are obeyed *)
-    (* =========================================================================================== *)
-    (
-      qcheck_to_ounit
-      @@ QCheck.Test.make
-        ~name:"burrow_mint_kit - returned burrow obeys burrow invariants"
-        ~count:property_test_count
-        TestArbitrary.arb_kit
-      @@ fun (burrow_kit) ->
-      (* scale it down, since we will need to multiply it by 10 to compute a tez amount *)
-      let burrow_kit =
-        kit_of_fraction_floor
-          (kit_to_mukit_int burrow_kit)
-          (Ligo.mul_int_int Kit.kit_scaling_factor_int (Ligo.int_from_literal "10")) in
-
-      let kit_to_mint = kit_of_mukit (Ligo.nat_from_literal "10n") in
-      (* Random kit balances which obey the burrow invariants and allow minting kit_to_mint without overburrowing *)
-      let outstanding = burrow_kit in
-      let collateral = Ligo.mul_tez_nat (Ligo.tez_from_literal "10mutez") (kit_to_mukit_nat burrow_kit) in
-
-      let burrow0 = Burrow.make_burrow_for_test
-          ~outstanding_kit:outstanding
-          ~active:true
-          ~address:burrow_addr
-          ~delegate:None
-          ~collateral:collateral
-          ~adjustment_index:fixedpoint_one
-          ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-          ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
-
-      let _ = Burrow.assert_burrow_invariants (Burrow.burrow_mint_kit Parameters.initial_parameters kit_to_mint burrow0) in
-      true
-    );
-
-    (
-      qcheck_to_ounit
-      @@ QCheck.Test.make
-        ~name:"burrow_burn_kit - returned burrow obeys burrow invariants"
-        ~count:property_test_count
-        (QCheck.pair TestArbitrary.arb_kit TestArbitrary.arb_kit)
-      @@ fun (burrow_kit, kit_to_burn) ->
-
-      (* Random kit balances which obey the burrow invariants and allow minting kit_to_mint without overburrowing *)
-      let outstanding = burrow_kit in
-      let burrow0 = Burrow.make_burrow_for_test
-          ~outstanding_kit:outstanding
-          ~active:true
-          ~address:burrow_addr
-          ~delegate:None
-          ~collateral:(Ligo.tez_from_literal "1mutez")
-          ~adjustment_index:fixedpoint_one
-          ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-          ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
-
-      let burrow, _actual_burned = Burrow.burrow_burn_kit Parameters.initial_parameters kit_to_burn burrow0 in
-      let _ = Burrow.assert_burrow_invariants burrow in
-      true
-    );
-
-    (* =========================================================================================== *)
     (* Other property tests *)
     (* =========================================================================================== *)
     (

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -43,21 +43,6 @@ let set_last_price_in_wrapper wrapper price_option =
       {wrapper with deployment_state = Sealed {state with last_price = price_option}}
   )
 
-let debug_print_all_kit_in_sealed_state msg wrapper =
-  let open CheckerTypes in
-  match wrapper.deployment_state with
-  | Unsealed _ ->
-    print_string "\nUnsealed state; no kit to show\n"
-  | Sealed state ->
-    print_string ("\n===== " ^ msg ^ " =====");
-    print_string ("\ncirculating = " ^ Kit.show_kit state.parameters.circulating_kit);
-    print_string ("\noutstanding = " ^ Kit.show_kit state.parameters.outstanding_kit);
-    print_string ("\ncfmm.kit    = " ^ Kit.show_kit state.cfmm.kit);
-    print_string "\nkit_on_ledger :\n";
-    List.iter
-      (fun (addr, amnt) -> print_string ("  " ^ Ligo.string_of_address addr ^ " : " ^ Ligo.string_of_nat amnt ^ "\n"))
-      (Fa2Interface.get_kit_credits_from_fa2_state state.fa2_state)
-
 let suite =
   "CheckerMainTests" >::: [
     (* initial_wrapper *)

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -489,13 +489,14 @@ let suite =
 
           debug_print_all_kit_in_sealed_state "after Liquidation_auction_place_bid" sealed_wrapper;
 
-          (* FIXME *)
           (* setup: make enough time pass so that the auction finishes *)
           let seconds_passed = int_of_string (Ligo.string_of_int (Ligo.add_int_int Constants.max_bid_interval_in_seconds (Ligo.int_from_literal "1"))) in
           let blocks_passed = int_of_string (Ligo.string_of_nat (Ligo.add_nat_nat Constants.max_bid_interval_in_blocks (Ligo.nat_from_literal "1n"))) in
           Ligo.Tezos.new_transaction ~seconds_passed:seconds_passed ~blocks_passed:blocks_passed ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
           let op = CheckerMain.(CheckerEntrypoint (LazyParams (Touch ()))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          debug_print_all_kit_in_sealed_state "after Touch" sealed_wrapper;
 
           (* Note: to avoid the unused variable warning. *)
           assert_equal sealed_wrapper sealed_wrapper

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -54,6 +54,8 @@ let debug_print_all_kit_in_sealed_state msg wrapper =
       print_string "\n";
       print_string ("outstanding = " ^ Kit.show_kit state.parameters.outstanding_kit);
       print_string "\n";
+      print_string ("cfmm.kit    = " ^ Kit.show_kit state.cfmm.kit);
+      print_string "\n";
       print_string "kit_on_ledger =\n";
       List.iter
         (fun (addr, amnt) ->
@@ -416,7 +418,7 @@ let suite =
           debug_print_all_kit_in_sealed_state "after setup:Mint_kit" sealed_wrapper;
 
           (* setup: increase the index significantly (emulate the effects of Receive_price) *)
-          let sealed_wrapper = set_last_price_in_wrapper sealed_wrapper (Some (Ligo.nat_from_literal "100_000_000n")) in
+          let sealed_wrapper = set_last_price_in_wrapper sealed_wrapper (Some (Ligo.nat_from_literal "1_357_906n")) in (* lowest value I could get, assuming the rest of the setting. *)
 
           debug_print_all_kit_in_sealed_state "after setup:set_last_price" sealed_wrapper;
 

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -343,74 +343,14 @@ let suite =
           debug_print_all_kit_in_sealed_state "initially" sealed_wrapper;
 
           (* Create_burrow *)
-          Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:user_addr ~amount:(Ligo.tez_from_literal "5_000_000mutez");
+          Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:user_addr ~amount:(Ligo.tez_from_literal "10_000_000mutez");
           let op = CheckerMain.(CheckerEntrypoint (LazyParams (Create_burrow (burrow_id, None)))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
           debug_print_all_kit_in_sealed_state "after Create_burrow" sealed_wrapper;
 
-          (* Deposit_tez *)
-          Ligo.Tezos.new_transaction ~seconds_passed:62 ~blocks_passed:1 ~sender:user_addr ~amount:(Ligo.tez_from_literal "6_000_000mutez");
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Deposit_tez (burrow_id)))) in
-          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
-
-          debug_print_all_kit_in_sealed_state "after Deposit_tez" sealed_wrapper;
-
-          (* Withdraw_tez *)
-          Ligo.Tezos.new_transaction ~seconds_passed:121 ~blocks_passed:2 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Withdraw_tez (Ligo.tez_from_literal "1_000_000mutez", burrow_id)))) in
-          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
-
-          debug_print_all_kit_in_sealed_state "after Withdraw_tez" sealed_wrapper;
-
-          (* Mint_kit *)
-          Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Mint_kit (burrow_id, Kit.kit_of_mukit (Ligo.nat_from_literal "1_000_000n"))))) in
-          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
-
-          debug_print_all_kit_in_sealed_state "after Mint_kit" sealed_wrapper;
-
-          (* Idea: Might want to touch checker here, before burning the kit, so that the
-           * owed kit increases (overburrowedness), but due to US touching checker there
-           * should be enough kit to pay back the burrow. *)
-
-          (* Burn_kit *)
-          Ligo.Tezos.new_transaction ~seconds_passed:200 ~blocks_passed:3 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Burn_kit (burrow_id, Kit.kit_of_mukit (Ligo.nat_from_literal "1_000_000n"))))) in
-          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
-
-          debug_print_all_kit_in_sealed_state "after Burn_kit" sealed_wrapper;
-
-          (* Set_burrow_delegate *)
-          Ligo.Tezos.new_transaction ~seconds_passed:202 ~blocks_passed:3 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Set_burrow_delegate (burrow_id, Some charles_key_hash)))) in
-          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
-
-          debug_print_all_kit_in_sealed_state "after Set_burrow_delegate" sealed_wrapper;
-
-          (* Deactivate_burrow *)
-          Ligo.Tezos.new_transaction ~seconds_passed:65 ~blocks_passed:1 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Deactivate_burrow (burrow_id, user_addr)))) in (* send it back to the user *)
-          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
-
-          debug_print_all_kit_in_sealed_state "after Deactivate_burrow" sealed_wrapper;
-
-          (* Activate_burrow *)
-          Ligo.Tezos.new_transaction ~seconds_passed:129 ~blocks_passed:2 ~sender:user_addr ~amount:(Ligo.tez_from_literal "10_000_000mutez");
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Activate_burrow (burrow_id)))) in
-          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
-
-          debug_print_all_kit_in_sealed_state "after Activate_burrow" sealed_wrapper;
-
-          (* Touch_burrow *)
-          Ligo.Tezos.new_transaction ~seconds_passed:342 ~blocks_passed:5 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Touch_burrow (user_addr, burrow_id)))) in
-          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
-
-          debug_print_all_kit_in_sealed_state "after Touch_burrow" sealed_wrapper;
-
           (* setup: mint as much kit as possible *)
-          Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          Ligo.Tezos.new_transaction ~seconds_passed:1181 ~blocks_passed:18 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
           let max_mintable_kit = CheckerEntrypoints.wrapper_view_burrow_max_mintable_kit ((user_addr, burrow_id), sealed_wrapper) in
           let op = CheckerMain.(CheckerEntrypoint (LazyParams (Mint_kit (burrow_id, max_mintable_kit)))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -63,7 +63,7 @@ let debug_print_all_kit_in_sealed_state msg wrapper =
            print_string "\n";
            ()
         )
-        (Fa2Interface.get_credits_from_fa2_state state.fa2_state);
+        (Fa2Interface.get_kit_credits_from_fa2_state state.fa2_state);
       ()
   )
 
@@ -340,6 +340,103 @@ let suite =
           let burrow_id = Ligo.nat_from_literal "199n" in
           let user_addr = alice_addr in
 
+          (* Create_burrow *)
+          Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:user_addr ~amount:(Ligo.tez_from_literal "5_000_000mutez");
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Create_burrow (burrow_id, None)))) in
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* Deposit_tez *)
+          Ligo.Tezos.new_transaction ~seconds_passed:62 ~blocks_passed:1 ~sender:user_addr ~amount:(Ligo.tez_from_literal "6_000_000mutez");
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Deposit_tez (burrow_id)))) in
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* Withdraw_tez *)
+          Ligo.Tezos.new_transaction ~seconds_passed:121 ~blocks_passed:2 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Withdraw_tez (Ligo.tez_from_literal "1_000_000mutez", burrow_id)))) in
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* Mint_kit *)
+          Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Mint_kit (burrow_id, Kit.kit_of_mukit (Ligo.nat_from_literal "1_000_000n"))))) in
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* Idea: Might want to touch checker here, before burning the kit, so that the
+           * owed kit increases (overburrowedness), but due to US touching checker there
+           * should be enough kit to pay back the burrow. *)
+
+          (* Burn_kit *)
+          Ligo.Tezos.new_transaction ~seconds_passed:200 ~blocks_passed:3 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Burn_kit (burrow_id, Kit.kit_of_mukit (Ligo.nat_from_literal "1_000_000n"))))) in
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* Set_burrow_delegate *)
+          Ligo.Tezos.new_transaction ~seconds_passed:202 ~blocks_passed:3 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Set_burrow_delegate (burrow_id, Some charles_key_hash)))) in
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* Deactivate_burrow *)
+          Ligo.Tezos.new_transaction ~seconds_passed:65 ~blocks_passed:1 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Deactivate_burrow (burrow_id, user_addr)))) in (* send it back to the user *)
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* Activate_burrow *)
+          Ligo.Tezos.new_transaction ~seconds_passed:129 ~blocks_passed:2 ~sender:user_addr ~amount:(Ligo.tez_from_literal "10_000_000mutez");
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Activate_burrow (burrow_id)))) in
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* Touch_burrow *)
+          Ligo.Tezos.new_transaction ~seconds_passed:342 ~blocks_passed:5 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Touch_burrow (user_addr, burrow_id)))) in
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* setup: mint as much kit as possible *)
+          Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          let max_mintable_kit = CheckerEntrypoints.wrapper_view_burrow_max_mintable_kit ((user_addr, burrow_id), sealed_wrapper) in
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Mint_kit (burrow_id, max_mintable_kit)))) in
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* setup: increase the index significantly (emulate the effects of Receive_price) *)
+          let sealed_wrapper = set_last_price_in_wrapper sealed_wrapper (Some (Ligo.nat_from_literal "100_000_000n")) in
+
+          (* setup: let enough time pass so that the burrow becomes liquidatable *)
+          let blocks_passed = 191 in
+          Ligo.Tezos.new_transaction ~seconds_passed:(60 * blocks_passed) ~blocks_passed:blocks_passed ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Touch ()))) in
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* Mark_for_liquidation *)
+          Ligo.Tezos.new_transaction ~seconds_passed:342 ~blocks_passed:5 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez"); (* the user themselves can mark it *)
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Mark_for_liquidation (user_addr, burrow_id)))) in
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* Note: I would have liked to be able to recollateralize the burrow and try
+           * out Cancel_liquidation_slice here, but to do that we need to be able to find
+           * th leaf_ptr of the slice, and currently that's hard to do. If/when we
+           * address #150 we should be able to do that. *)
+
+          (* setup: touch to start the auction *)
+          Ligo.Tezos.new_transaction ~seconds_passed:63 ~blocks_passed:1 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Touch ()))) in
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* Liquidation_auction_place_bid *)
+          let min_bid = CheckerEntrypoints.wrapper_view_current_liquidation_auction_minimum_bid ((), sealed_wrapper) in
+          Ligo.Tezos.new_transaction ~seconds_passed:394 ~blocks_passed:6 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Liquidation_auction_place_bid (min_bid.auction_id, min_bid.minimum_bid)))) in
+          let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
+
+          (* Note: to avoid the unused variable warning. *)
+          assert_equal sealed_wrapper sealed_wrapper
+       )
+    );
+
+    ("Regression test for #209" >::
+     with_sealed_wrapper
+       (fun sealed_wrapper ->
+          Ligo.Tezos.reset ();
+          let burrow_id = Ligo.nat_from_literal "199n" in
+          let user_addr = alice_addr in
+
           debug_print_all_kit_in_sealed_state "initially" sealed_wrapper;
 
           (* Create_burrow *)
@@ -377,11 +474,6 @@ let suite =
 
           debug_print_all_kit_in_sealed_state "after Mark_for_liquidation" sealed_wrapper;
 
-          (* Note: I would have liked to be able to recollateralize the burrow and try
-           * out Cancel_liquidation_slice here, but to do that we need to be able to find
-           * th leaf_ptr of the slice, and currently that's hard to do. If/when we
-           * address #150 we should be able to do that. *)
-
           (* setup: touch to start the auction *)
           Ligo.Tezos.new_transaction ~seconds_passed:63 ~blocks_passed:1 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
           let op = CheckerMain.(CheckerEntrypoint (LazyParams (Touch ()))) in
@@ -397,9 +489,7 @@ let suite =
 
           debug_print_all_kit_in_sealed_state "after Liquidation_auction_place_bid" sealed_wrapper;
 
-          (* FIXME: WE HAVE A PROBLEM I THINK: THE FOLLOWING RAISES AN
-           * internalError_KitSubNegative error, which I thought was impossible.
-           * Is that because of how high the index is? Is there a bug somewhere? *)
+          (* FIXME *)
           (* setup: make enough time pass so that the auction finishes *)
           let seconds_passed = int_of_string (Ligo.string_of_int (Ligo.add_int_int Constants.max_bid_interval_in_seconds (Ligo.int_from_literal "1"))) in
           let blocks_passed = int_of_string (Ligo.string_of_nat (Ligo.add_nat_nat Constants.max_bid_interval_in_blocks (Ligo.nat_from_literal "1n"))) in

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -118,3 +118,18 @@ let make_inputs_for_sell_kit_to_succeed =
        (cfmm, token, min_ctez_expected, deadline)
     )
     (arbitrary_non_empty_cfmm Common.one_ratio !Ligo.Tezos.level)
+
+let debug_print_all_kit_in_sealed_state msg wrapper =
+  let open CheckerTypes in
+  match wrapper.deployment_state with
+  | Unsealed _ ->
+    print_string "\nUnsealed state; no kit to show\n"
+  | Sealed state ->
+    print_string ("\n===== " ^ msg ^ " =====");
+    print_string ("\ncirculating = " ^ Kit.show_kit state.parameters.circulating_kit);
+    print_string ("\noutstanding = " ^ Kit.show_kit state.parameters.outstanding_kit);
+    print_string ("\ncfmm.kit    = " ^ Kit.show_kit state.cfmm.kit);
+    print_string "\nkit_on_ledger :\n";
+    List.iter
+      (fun (addr, amnt) -> print_string ("  " ^ Ligo.string_of_address addr ^ " : " ^ Ligo.string_of_nat amnt ^ "\n"))
+      (Fa2Interface.get_kit_credits_from_fa2_state state.fa2_state)

--- a/tests/testLiquidation.ml
+++ b/tests/testLiquidation.ml
@@ -60,7 +60,6 @@ let arbitrary_burrow (params: parameters) =
          ~active:true
          ~collateral:tez
          ~outstanding_kit:kit
-         ~excess_kit:kit_zero
          ~adjustment_index:(compute_adjustment_index params)
          ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
          ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -262,7 +261,6 @@ let initial_burrow =
     ~active:true
     ~collateral:(Ligo.tez_from_literal "10_000_000mutez")
     ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "20_000_000n"))
-    ~excess_kit:kit_zero
     ~adjustment_index:(compute_adjustment_index params)
     ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
     ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -277,7 +275,6 @@ let barely_not_overburrowed_test =
         ~active:true
         ~collateral:(Ligo.tez_from_literal "7_673_400mutez")
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-        ~excess_kit:kit_zero
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -303,7 +300,6 @@ let barely_overburrowed_test =
         ~active:true
         ~collateral:(Ligo.tez_from_literal "7_673_399mutez")
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-        ~excess_kit:kit_zero
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -329,7 +325,6 @@ let barely_non_liquidatable_test =
         ~active:true
         ~collateral:(Ligo.tez_from_literal "6_171_200mutez")
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-        ~excess_kit:kit_zero
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -355,7 +350,6 @@ let barely_liquidatable_test =
         ~active:true
         ~collateral:(Ligo.tez_from_literal "6_171_199mutez")
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-        ~excess_kit:kit_zero
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -376,7 +370,6 @@ let barely_liquidatable_test =
                 ~delegate:None
                 ~collateral:(Ligo.tez_from_literal "2_346_632mutez")
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-                ~excess_kit:kit_zero
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "2_818_396mutez")
                 ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -421,7 +414,6 @@ let barely_non_complete_liquidatable_test =
         ~active:true
         ~collateral:(Ligo.tez_from_literal "5_065_065mutez")
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-        ~excess_kit:kit_zero
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -442,7 +434,6 @@ let barely_non_complete_liquidatable_test =
                 ~delegate:None
                 ~collateral:(Ligo.tez_from_literal "0mutez")
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-                ~excess_kit:kit_zero
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "4_060_000mutez")
                 ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -485,7 +476,6 @@ let barely_complete_liquidatable_test =
         ~active:true
         ~collateral:(Ligo.tez_from_literal "5_065_064mutez")
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-        ~excess_kit:kit_zero
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -506,7 +496,6 @@ let barely_complete_liquidatable_test =
                 ~delegate:None
                 ~collateral:(Ligo.tez_from_literal "0mutez")
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-                ~excess_kit:kit_zero
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "4_059_999mutez")
                 ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -549,7 +538,6 @@ let barely_non_close_liquidatable_test =
         ~active:true
         ~collateral:(Ligo.tez_from_literal "1_001_001mutez")
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-        ~excess_kit:kit_zero
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -570,7 +558,6 @@ let barely_non_close_liquidatable_test =
                 ~delegate:None
                 ~collateral:(Ligo.tez_from_literal "0mutez")
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-                ~excess_kit:kit_zero
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
                 ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -610,7 +597,6 @@ let barely_close_liquidatable_test =
         ~active:true
         ~collateral:(Ligo.tez_from_literal "1_001_000mutez")
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-        ~excess_kit:kit_zero
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -631,7 +617,6 @@ let barely_close_liquidatable_test =
                 ~delegate:None
                 ~collateral:(Ligo.tez_from_literal "0mutez")
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-                ~excess_kit:kit_zero
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "999_999mutez")
                 ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -672,7 +657,6 @@ let unwarranted_liquidation_unit_test =
         ~active:true
         ~collateral:(Ligo.tez_from_literal "7_673_400mutez")
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
-        ~excess_kit:kit_zero
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -701,7 +685,6 @@ let partial_liquidation_unit_test =
                 ~active:true
                 ~collateral:(Ligo.tez_from_literal "1_847_528mutez")
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "20_000_000n"))
-                ~excess_kit:kit_zero
                 ~adjustment_index:(compute_adjustment_index params)
                 ~collateral_at_auction:(Ligo.tez_from_literal "7_142_472mutez")
                 ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -745,7 +728,6 @@ let complete_liquidation_unit_test =
         ~active:true
         ~collateral:(Ligo.tez_from_literal "10_000_000mutez")
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "100_000_000n"))
-        ~excess_kit:kit_zero
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -763,7 +745,6 @@ let complete_liquidation_unit_test =
                 ~active:true
                 ~collateral:(Ligo.tez_from_literal "0mutez")
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "100_000_000n"))
-                ~excess_kit:kit_zero
                 ~adjustment_index:(compute_adjustment_index params)
                 ~collateral_at_auction:(Ligo.tez_from_literal "8_990_000mutez")
                 ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -809,7 +790,6 @@ let complete_and_close_liquidation_test =
         ~active:true
         ~collateral:(Ligo.tez_from_literal "1_000_000mutez")
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "100_000_000n"))
-        ~excess_kit:kit_zero
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -827,7 +807,6 @@ let complete_and_close_liquidation_test =
                 ~active:false
                 ~collateral:(Ligo.tez_from_literal "0mutez")
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "100_000_000n"))
-                ~excess_kit:kit_zero
                 ~adjustment_index:(compute_adjustment_index params)
                 ~collateral_at_auction:(Ligo.tez_from_literal "999_000mutez")
                 ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
@@ -886,7 +865,6 @@ let test_burrow_request_liquidation_invariant_close =
       ~active:true
       ~collateral:collateral
       ~outstanding_kit:kit_to_allow_liquidation
-      ~excess_kit:kit_zero
       ~adjustment_index:(compute_adjustment_index params)
       ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
       ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
@@ -930,7 +908,6 @@ let test_burrow_request_liquidation_invariant_complete =
       ~active:true
       ~collateral:collateral
       ~outstanding_kit:outstanding_kit
-      ~excess_kit:kit_zero
       ~adjustment_index:(compute_adjustment_index params)
       ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
       ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
@@ -967,7 +944,6 @@ let test_burrow_request_liquidation_invariant_partial =
       ~active:true
       ~collateral:(Ligo.tez_from_literal (string_of_int collateral ^ "mutez"))
       ~outstanding_kit:outstanding_kit
-      ~excess_kit:kit_zero
       ~adjustment_index:(compute_adjustment_index params)
       ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
       ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
@@ -1014,7 +990,6 @@ let regression_test_72 =
         ~collateral:(Ligo.tez_from_literal "4369345928872593390mutez")
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "3928478924648448718n"))
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-        ~excess_kit:kit_zero
         ~active:true
         ~address:burrow_addr
         ~delegate:None
@@ -1035,7 +1010,6 @@ let regression_test_93 =
         ~collateral:(Ligo.tez_from_literal "4369345928872593390mutez")
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "3928478924648448718n"))
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-        ~excess_kit:kit_zero
         ~active:true
         ~address:burrow_addr
         ~delegate:None

--- a/tests/testLiquidation.ml
+++ b/tests/testLiquidation.ml
@@ -875,7 +875,6 @@ let test_burrow_request_liquidation_invariant_close =
     | Some (liquidation_type, _) -> failwith (Format.sprintf "liquidation_type returned by burrow_request_liquidation was %s but Close was expected" (Burrow.show_liquidation_type liquidation_type))
   in
 
-  Burrow.assert_burrow_invariants liquidation_details.burrow_state;
   assert_properties_of_close_liquidation initial_parameters burrow0 liquidation_details;
   true
 
@@ -917,7 +916,6 @@ let test_burrow_request_liquidation_invariant_complete =
     | None -> failwith "liquidation_result returned by burrow_request_liquidation was None but the test expects a value."
     | Some (liquidation_type, _) -> failwith (Format.sprintf "liquidation_type returned by burrow_request_liquidation was %s but Complete was expected" (Burrow.show_liquidation_type liquidation_type))
   in
-  Burrow.assert_burrow_invariants liquidation_details.burrow_state;
   assert_properties_of_complete_liquidation initial_parameters burrow0 liquidation_details;
   true
 
@@ -953,7 +951,6 @@ let test_burrow_request_liquidation_invariant_partial =
     | None -> failwith "liquidation_result returned by burrow_request_liquidation was None but the test expects a value."
     | Some (liquidation_type, _) -> failwith (Format.sprintf "liquidation_type returned by burrow_request_liquidation was %s but Partial was expected" (Burrow.show_liquidation_type liquidation_type))
   in
-  Burrow.assert_burrow_invariants liquidation_details.burrow_state;
   assert_properties_of_partial_liquidation initial_parameters burrow0 liquidation_details;
   true
 


### PR DESCRIPTION
This PR fixes a long-standing bug around the concept of excess kit and removes the `excess_kit` field in burrows. It's still work in progress but I thought I'd open the PR early so that perhaps you could have a look too @utdemir @dorranh; the changes are rather pervasive (though necessary, I believe) and I really could use more pairs of eyes. Let me know what you think! :slightly_smiling_face: 

Closes #209.
Closes #136.

Summary:

- [X] The `excess_kit` is removed from the representation of burrows. This means that in cases where more than `burrow.outstanding_kit` is attempted to be burned/deposited, the excess is directly credited to the burrow owner on the FA2 ledger. This applies both to explicit burns (via `burrow_burn_kit`) and implicit burns (via `burrow_return_kit_from_auction`).
- [x] `assert_burrow_invariants` now has no invariants to check. I've left it for the time being, but I think we can just get rid of it.
- [X] Some information is now "leaking" from `burrow_burn_kit` and `burrow_return_kit_from_auction`: they both need to return to the caller how much of that kit really got burned and how much did not. This is a good thing. This change allows us to remove from `parameters.circulating_kit` and the `parameters.outstanding_kit` the kit that got repaid, **but not the part that did not**. This was the source of #209: previously we would erroneously try to remove all the kit we tried to burn from the `parameters.outstanding_kit`, even if some of it really ended up in the `excess_kit` field. I left a big comment about what happens with each part of the kit to be burned (and a few assertions) in `touch_liquidation_slice` to clarify this.
- [ ] There is still a hidden assumption in this logic: by never burning more kit than is outstanding _per burrow_, my text above implies that I don't expect there to be an underflow in the _global outstanding kit_ (`parameters.outstanding_kit`), which is what #209 is about. I have not proven this yet, but I believe that the calculations imply that `parameters.outstanding_kit >= sum burrow_i.outstanding_kit`. If that is indeed the case, then sound burning per burrow implies sound burning for the total outstanding kit. I expect us to observe this inequality when we address #156, but I will try to prove it before merging this PR anyway.
   If the inequality does not hold then we can always circumvent the issue of #209 by a simple if-then-else: never try to burn more kit from `parameters.outstanding_kit` than there is. I don't like this catch-all because it could hide other bugs, but if the inequality above really does not hold at least this if-then-else works as an absorbing bound at 0, essentially showing that we have to burn more kit than we thought were outstanding. If anything, it reduces the discrepancy between `parameters.outstanding_kit` and `sum burrow_i.outstanding_kit`.
- [X] I made `touch_liquidation_slice` and friends take bigger parts of the state as arguments to be able to update the FA2 ledger when we give kit to the burrow owners. In general I wrote things having clarity in mind, but we have to make sure that the gas costs don't increase too much because of this before merging (if so, we have to re-uglify the code). 
- [x] I have not looked at the docs yet, but I am sure I'd have to update them to reflect some of these changes.
- [x] The test folder still have debugging prints in it. I'll remove the calls when done (we can still keep the functions though; very handy).