### PR TITLE
Unit tests for operations emitted by entrypoints

### DIFF
--- a/src/ligo.ml
+++ b/src/ligo.ml
@@ -100,6 +100,7 @@ let parse_int_with_suffix (expected_suffix: string) (s: string) : Z.t =
 
 type key_hash = string
 let pp_key_hash = Format.pp_print_string
+let string_of_key_hash k = k
 let key_hash_from_literal s = s
 
 (* bytes *)

--- a/src/ligo.mli
+++ b/src/ligo.mli
@@ -245,6 +245,7 @@ val string_of_nat : nat -> String.t
 val string_of_tez : tez -> String.t
 val string_of_timestamp : timestamp -> String.t
 val string_of_address : address -> String.t
+val string_of_key_hash : key_hash -> String.t
 val address_of_string : String.t -> address
 
 val pp_address : Format.formatter -> address -> unit

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -197,10 +197,32 @@ let suite =
          (fun () -> Checker.entrypoint_withdraw_tez (checker, (withdrawal, Ligo.nat_from_literal "0n")))
     );
 
-    ("add_liquidity - emits expected operations" >::
+    ("entrypoint_activate_burrow - emits expected operations" >::
      fun _ ->
-       let checker = empty_checker in
        Ligo.Tezos.reset ();
+       (* Create a burrow and deactivate it *)
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "100_000_000mutez");
+       let (_, burrow_no), checker = newly_created_burrow empty_checker "0n" in
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let _, checker = Checker.entrypoint_deactivate_burrow (checker, (Ligo.nat_from_literal "0n", alice_addr)) in
+       (* Then activate it *)
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "1_000_000mutez");
+       let ops, _ = Checker.entrypoint_activate_burrow (checker, (Ligo.nat_from_literal "0n")) in
+       let burrow = Option.get (Ligo.Big_map.find_opt (alice_addr, burrow_no) checker.burrows) in
+       let expected_ops = [
+         (LigoOp.Tezos.unit_transaction
+            ()
+            (Ligo.tez_from_literal "1_000_000mutez")
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%burrowStoreTez" (burrow_address burrow)))
+         );
+       ] in
+       assert_operation_list_equal ~expected:expected_ops ~real:ops
+    );
+
+    ("entrypoint_add_liquidity - emits expected operations" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let checker = empty_checker in
        (* Create a burrow and mint some kit *)
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "100_000_000mutez");
        let _, checker = Checker.entrypoint_create_burrow (checker, (Ligo.nat_from_literal "0n", None)) in
@@ -232,10 +254,93 @@ let suite =
        assert_operation_list_equal ~expected:expected_ops ~real:ops
     );
 
-    ("remove_liquidity - emits expected operations" >::
+    ("entrypoint_burn_kit - emits expected operations" >::
      fun _ ->
-       let checker = empty_checker in
        Ligo.Tezos.reset ();
+       let checker = empty_checker in
+       (* Create a burrow and mint some kit *)
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "100_000_000mutez");
+       let _, checker = Checker.entrypoint_create_burrow (checker, (Ligo.nat_from_literal "0n", None)) in
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let _, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", (kit_of_mukit (Ligo.nat_from_literal "10_000_000n")))) in
+       (* Then burn the kit *)
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let ops, _ = Checker.entrypoint_burn_kit (checker, (Ligo.nat_from_literal "0n", (kit_of_mukit (Ligo.nat_from_literal "10_000_000n")))) in
+       assert_operation_list_equal ~expected:[] ~real:ops
+    );
+
+    ("entrypoint_create_burrow - emits expected operations" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "100_000_000mutez");
+       let ops, _ = Checker.entrypoint_create_burrow (empty_checker, (Ligo.nat_from_literal "0n", None)) in
+
+       match ops with
+       (* Note: it's not really possible to check the first parameter of the contract here which is the
+        * function which defines the contract's logic.
+       *)
+       | [(CreateContract (_, delegate, tez, storage))] ->
+         assert_equal None delegate;
+         assert_tez_equal ~expected:(Ligo.tez_from_literal "100_000_000mutez") ~real:tez;
+         assert_equal BurrowTypes.({checker_address=checker_address; burrow_id=(alice_addr, (Ligo.nat_from_literal "0n"))}) storage
+       | _ -> failwith ("Expected [CreateContract (_, _, _, _)] but got " ^ show_operation_list ops)
+    );
+
+    ("entrypoint_deactivate_burrow - emits expected operations" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       (* Create a burrow and deactivate it *)
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "100_000_000mutez");
+       let (_, burrow_no), checker = newly_created_burrow empty_checker "0n" in
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let ops, checker = Checker.entrypoint_deactivate_burrow (checker, (Ligo.nat_from_literal "0n", alice_addr)) in
+       let burrow = Option.get (Ligo.Big_map.find_opt (alice_addr, burrow_no) checker.burrows) in
+       let expected_ops = [
+         (LigoOp.Tezos.tez_address_transaction
+            ((Ligo.tez_from_literal "100_000_000mutez"), alice_addr)
+            (Ligo.tez_from_literal "0mutez")
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%burrowSendTezTo" (burrow_address burrow)))
+         );
+       ] in
+       assert_operation_list_equal ~expected:expected_ops ~real:ops
+    );
+
+    ("entrypoint_deposit_tez - emits expected operations" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       (* Create the burrow *)
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "3_000_000mutez");
+       let (_, burrow_no), checker = newly_created_burrow empty_checker "0n" in
+       (* Make a deposit *)
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "3_000_000mutez");
+       let ops, checker = Checker.entrypoint_deposit_tez (checker, burrow_no) in
+       let burrow = Option.get (Ligo.Big_map.find_opt (alice_addr, burrow_no) checker.burrows) in
+       let expected_ops = [
+         (LigoOp.Tezos.unit_transaction
+            ()
+            (Ligo.tez_from_literal "3_000_000mutez")
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%burrowStoreTez" (burrow_address burrow)))
+         );
+       ] in
+       assert_operation_list_equal ~expected:expected_ops ~real:ops
+    );
+
+    ("entrypoint_mint_kit - emits expected operations" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let checker = empty_checker in
+       (* Create a burrow and mint some kit *)
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "100_000_000mutez");
+       let _, checker = Checker.entrypoint_create_burrow (checker, (Ligo.nat_from_literal "0n", None)) in
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let ops, _ = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", (kit_of_mukit (Ligo.nat_from_literal "10_000_000n")))) in
+       assert_operation_list_equal ~expected:[] ~real:ops
+    );
+
+    ("entrypoint_remove_liquidity - emits expected operations" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let checker = empty_checker in
        (* Create a burrow and mint some kit *)
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "100_000_000mutez");
        let _, checker = Checker.entrypoint_create_burrow (checker, (Ligo.nat_from_literal "0n", None)) in
@@ -278,10 +383,10 @@ let suite =
        assert_operation_list_equal ~expected:expected_ops ~real:ops
     );
 
-    ("touch - emits expected operations when checker needs to be touched" >::
+    ("entrypoint_touch - emits expected operations when checker needs to be touched" >::
      fun _ ->
-       let checker = empty_checker in
        Ligo.Tezos.reset ();
+       let checker = empty_checker in
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let ops, _ = Checker.entrypoint_touch (checker, ()) in
 
@@ -295,13 +400,45 @@ let suite =
        assert_operation_list_equal ~expected:expected_ops ~real:ops
     );
 
-    ("touch - emits expected operations when checker has already been touched" >::
+    ("entrypoint_touch - emits expected operations when checker has already been touched" >::
      fun _ ->
-       let checker = empty_checker in
        Ligo.Tezos.reset ();
+       let checker = empty_checker in
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let ops, _ = Checker.entrypoint_touch (checker, ()) in
        assert_operation_list_equal ~expected:[] ~real:ops
+    );
+
+    ("entrypoint_touch_burrow - emits expected operations" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       (* Create the burrow *)
+       Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "100_000_000mutez");
+       let _, checker = Checker.entrypoint_create_burrow (empty_checker, (Ligo.nat_from_literal "0n", None)) in
+       (* Then touch it *)
+       Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let ops, _ = Checker.entrypoint_touch_burrow (checker, (alice_addr, Ligo.nat_from_literal "0n")) in
+       assert_operation_list_equal ~expected:[] ~real:ops
+    );
+
+    ("entrypoint_withdraw_tez - emits expected operations" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       (* Create a burrow *)
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "3_000_000mutez");
+       let (_, burrow_no), checker = newly_created_burrow empty_checker "0n" in
+       (* Try to withdraw some tez from the untouched burrow *)
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let ops, checker = Checker.entrypoint_withdraw_tez (checker, ((Ligo.tez_from_literal "1_000_000mutez"), Ligo.nat_from_literal "0n")) in
+       let burrow = Option.get (Ligo.Big_map.find_opt (alice_addr, burrow_no) checker.burrows) in
+       let expected_ops = [
+         (LigoOp.Tezos.tez_address_transaction
+            ((Ligo.tez_from_literal "1_000_000mutez"), alice_addr)
+            (Ligo.tez_from_literal "0mutez")
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%burrowSendTezTo" (burrow_address burrow)))
+         );
+       ] in
+       assert_operation_list_equal ~expected:expected_ops ~real:ops
     );
 
     ("calculate_touch_reward - expected result for last_touched 2s ago" >::

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -7,6 +7,9 @@ let ctez_addr = Ligo.address_of_string "ctez_addr"
 let oracle_addr = Ligo.address_of_string "oracle_addr"
 
 let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
+let show_key_hash_option (key_hash: Ligo.key_hash option) = match key_hash with
+  | None -> "None"
+  | Some kh -> "Some " ^ (Ligo.string_of_key_hash kh)
 
 let assert_stdlib_int_equal ~expected ~real = OUnit2.assert_equal ~printer:string_of_int expected real
 let assert_string_equal ~expected ~real = OUnit2.assert_equal ~printer:(fun x -> x) expected real
@@ -17,6 +20,7 @@ let assert_int_equal ~expected ~real = OUnit2.assert_equal ~printer:Ligo.string_
 let assert_kit_equal ~expected ~real = OUnit2.assert_equal ~printer:Kit.show_kit expected real
 let assert_lqt_equal ~expected ~real = OUnit2.assert_equal ~printer:Lqt.show_lqt expected real
 let assert_ratio_equal ~expected ~real = OUnit2.assert_equal ~printer:Common.show_ratio ~cmp:Ratio.eq_ratio_ratio expected real
+let assert_key_hash_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_key_hash_option expected real
 let assert_address_equal ~expected ~real = OUnit2.assert_equal ~printer:Ligo.string_of_address expected real
 let assert_fixedpoint_equal ~expected ~real = OUnit2.assert_equal ~printer:FixedPoint.show_fixedpoint_raw expected real
 let assert_liquidation_result_equal ~expected ~real = OUnit2.assert_equal ~printer:Burrow.show_liquidation_result expected real

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -7,10 +7,6 @@ let ctez_addr = Ligo.address_of_string "ctez_addr"
 let oracle_addr = Ligo.address_of_string "oracle_addr"
 
 let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
-let show_key_hash_option (key_hash: Ligo.key_hash option) = match key_hash with
-  | None -> "None"
-  | Some kh -> "Some " ^ (Ligo.string_of_key_hash kh)
-
 let assert_stdlib_int_equal ~expected ~real = OUnit2.assert_equal ~printer:string_of_int expected real
 let assert_string_equal ~expected ~real = OUnit2.assert_equal ~printer:(fun x -> x) expected real
 
@@ -20,6 +16,7 @@ let assert_int_equal ~expected ~real = OUnit2.assert_equal ~printer:Ligo.string_
 let assert_kit_equal ~expected ~real = OUnit2.assert_equal ~printer:Kit.show_kit expected real
 let assert_lqt_equal ~expected ~real = OUnit2.assert_equal ~printer:Lqt.show_lqt expected real
 let assert_ratio_equal ~expected ~real = OUnit2.assert_equal ~printer:Common.show_ratio ~cmp:Ratio.eq_ratio_ratio expected real
+type key_hash_option = Ligo.key_hash option [@@deriving show]
 let assert_key_hash_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_key_hash_option expected real
 let assert_address_equal ~expected ~real = OUnit2.assert_equal ~printer:Ligo.string_of_address expected real
 let assert_fixedpoint_equal ~expected ~real = OUnit2.assert_equal ~printer:FixedPoint.show_fixedpoint_raw expected real


### PR DESCRIPTION
While reviewing the latest mutation test reports I found some mutations in `checker.ml` which weren't caught by our tests since they mutate the contents of operations emitted our entrypoints. When reviewing the existing tests, I realized that while we have some assertions for operations scattered throughout the suite, we don't really have unit tests checking the emitted operations. This PR adds unit tests for approximately half of the entrypoints in `checker.ml` (to keep the PR size manageable). Some of these tests overlap with assertions in the `"can complete a liquidation auction"` test, but I figured it was a bit cleaner to have separate unit tests for these as well.

Covers:
  -  entrypoint_sell_kit 
  -  entrypoint_buy_kit
  -  entrypoint_add_liquidity
  -  entrypoint_remove_liquidity
  -  entrypoint_touch
  - entrypoint_create_burrow
  - entrypoint_touch_burrow
  - entrypoint_deposit_tez
  - entrypoint_mint_kit
  - entrypoint_withdraw_tez
  - entrypoint_burn_kit
  - entrypoint_activate_burrow
  - entrypoint_deactivate_burrow