### PR TITLE
Rename Burrow.last_touched to Burrow.last_checker_timestamp

### DIFF
--- a/src/burrow.mli
+++ b/src/burrow.mli
@@ -159,7 +159,7 @@ val make_burrow_for_test :
   outstanding_kit:kit ->
   adjustment_index:fixedpoint ->
   collateral_at_auction:Ligo.tez ->
-  last_touched:Ligo.timestamp ->
+  last_checker_timestamp:Ligo.timestamp ->
   burrow
 
 val compute_tez_to_auction : parameters -> burrow -> Ligo.int

--- a/tests/testBurrow.ml
+++ b/tests/testBurrow.ml
@@ -19,7 +19,7 @@ let make_test_burrow ~outstanding_kit ~collateral ~active = Burrow.make_burrow_f
     ~collateral:collateral
     ~adjustment_index:fixedpoint_one
     ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-    ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+    ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
 
 (* A burrow with fixed parameters which was last touched at 0s. Use for tests which check
  * that functions requiring a burrow to be recently touched fail as expected. *)
@@ -449,7 +449,7 @@ let suite =
                   ~collateral:(Ligo.tez_from_literal "10mutez")
                   ~adjustment_index:fixedpoint_one
                   ~collateral_at_auction:(Ligo.tez_from_literal "1mutez")
-                  ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+                  ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
               )
          )
     );
@@ -536,7 +536,7 @@ let suite =
            ~collateral:(Ligo.tez_from_literal "0mutez")
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(Ligo.tez_from_literal "1mutez")
-           ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+           ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
        let slice = LiquidationAuctionPrimitiveTypes.{
            burrow=(Ligo.address_from_literal "12345", Ligo.nat_from_literal "0n");
            tez=Ligo.tez_from_literal "1mutez";
@@ -560,7 +560,7 @@ let suite =
            ~collateral:(Ligo.tez_from_literal "2mutez")
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(Ligo.tez_from_literal "3mutez")
-           ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+           ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
        let slice = let open LiquidationAuctionPrimitiveTypes in {
            burrow=(burrow_addr, Ligo.nat_from_literal "0n");
            tez=Ligo.tez_from_literal "1mutez";
@@ -575,7 +575,7 @@ let suite =
            ~collateral:(Ligo.tez_from_literal "3mutez")
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(Ligo.tez_from_literal "2mutez")
-           ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+           ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
        let burrow = Burrow.burrow_return_slice_from_auction slice burrow0 in
 
        assert_burrow_equal
@@ -593,7 +593,7 @@ let suite =
            ~collateral:(Ligo.tez_from_literal "0mutez")
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(Ligo.tez_from_literal "1mutez")
-           ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+           ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
        let slice = let open LiquidationAuctionPrimitiveTypes in {
            burrow=(Ligo.address_from_literal "12345", Ligo.nat_from_literal "0n");
            tez=Ligo.tez_from_literal "1mutez";
@@ -673,7 +673,7 @@ let suite =
            ~collateral:(Ligo.tez_from_literal "2mutez")
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(Ligo.tez_from_literal "2mutez")
-           ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+           ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
        let tez_to_auction = Ligo.tez_from_literal "2mutez" in
        let min_kit_for_unwarranted = Burrow.compute_min_kit_for_unwarranted Parameters.initial_parameters burrow0 tez_to_auction in
 
@@ -711,7 +711,7 @@ let suite =
            ~collateral:(Ligo.tez_from_literal "3mutez")
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(Ligo.tez_from_literal "3mutez")
-           ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+           ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
        (* Note: cranking up the index to make test more sensitive to small changes
         *  potentially obscured by rounding. This high of a difference between the
         *  index and protected index is unlikely to occur in real-world scenarios.
@@ -732,7 +732,7 @@ let suite =
            ~collateral:(Ligo.tez_from_literal "3mutez")
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(Ligo.tez_from_literal "3mutez")
-           ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+           ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
        assert_int_equal
          ~expected:(Ligo.int_from_literal "-2")
@@ -750,7 +750,7 @@ let suite =
               ~collateral:(Ligo.tez_from_literal "0mutez")
               ~adjustment_index:fixedpoint_one
               ~collateral_at_auction:(Ligo.tez_from_literal "3mutez")
-              ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+              ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
           let slice = let open LiquidationAuctionPrimitiveTypes in
             {
@@ -769,7 +769,7 @@ let suite =
               ~collateral:(Ligo.tez_from_literal "0mutez")
               ~adjustment_index:fixedpoint_one
               ~collateral_at_auction:(Ligo.tez_from_literal "1mutez")
-              ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+              ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
           assert_burrow_equal
             ~expected:burrow_expected
@@ -787,7 +787,7 @@ let suite =
               ~collateral:(Ligo.tez_from_literal "5_000_000mutez")
               ~adjustment_index:fixedpoint_one
               ~collateral_at_auction:(Ligo.tez_from_literal "3_000_000mutez")
-              ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+              ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
           let cancelled_slice_tez = Ligo.tez_from_literal "1_000_000mutez" in
 
           assert_bool
@@ -806,7 +806,7 @@ let suite =
             ~collateral:(Ligo.tez_from_literal "5_000_000mutez")
             ~adjustment_index:fixedpoint_one
             ~collateral_at_auction:(Ligo.tez_from_literal "3_000_000mutez")
-            ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+            ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
         let cancelled_slice_tez = Ligo.tez_from_literal "1_000_000mutez" in
 
         assert_bool
@@ -825,7 +825,7 @@ let suite =
             ~collateral:(Ligo.tez_from_literal "2_469_999mutez")
             ~adjustment_index:fixedpoint_one
             ~collateral_at_auction:(Ligo.tez_from_literal "3_000_000mutez")
-            ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+            ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
         assert_bool
           "burrow_is_liquidatable returned false, but the burrow is expected to be liquidatable"
@@ -843,7 +843,7 @@ let suite =
             ~collateral:(Ligo.tez_from_literal "2_470_000mutez")
             ~adjustment_index:fixedpoint_one
             ~collateral_at_auction:(Ligo.tez_from_literal "3_000_000mutez")
-            ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+            ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
         assert_bool
           "burrow_is_liquidatable returned true, but the burrow is expected to be non-liquidatable"
@@ -861,7 +861,7 @@ let suite =
             ~collateral:(Ligo.tez_from_literal "2_000_000mutez")
             ~adjustment_index:fixedpoint_one
             ~collateral_at_auction:(Ligo.tez_from_literal "3_000_000mutez")
-            ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+            ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
         assert_tez_equal
           ~expected:(Ligo.tez_from_literal "6_000_000mutez")
@@ -879,7 +879,7 @@ let suite =
             ~collateral:(Ligo.tez_from_literal "2_000_000mutez")
             ~adjustment_index:fixedpoint_one
             ~collateral_at_auction:(Ligo.tez_from_literal "3_000_000mutez")
-            ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+            ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
         assert_tez_equal
           ~expected:(Ligo.tez_from_literal "5_000_000mutez")
@@ -1034,7 +1034,7 @@ let suite =
           ~collateral:(Ligo.tez_from_literal "1mutez")
           ~adjustment_index:fixedpoint_one
           ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-          ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+          ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
       let parameters = {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)} in
 
       let burrow = Burrow.burrow_touch parameters burrow0 in
@@ -1062,7 +1062,7 @@ let suite =
           ~collateral:collateral
           ~adjustment_index:fixedpoint_one
           ~collateral_at_auction:collateral_at_auction
-          ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+          ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
       let _ = Burrow.compute_tez_to_auction Parameters.initial_parameters burrow0 in
       true

--- a/tests/testLiquidation.ml
+++ b/tests/testLiquidation.ml
@@ -62,7 +62,7 @@ let arbitrary_burrow (params: parameters) =
          ~outstanding_kit:kit
          ~adjustment_index:(compute_adjustment_index params)
          ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-         ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
     )
     arb_smart_tez_kit
 
@@ -263,7 +263,7 @@ let initial_burrow =
     ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "20_000_000n"))
     ~adjustment_index:(compute_adjustment_index params)
     ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-    ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+    ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
 
 (* Minimum amount of collateral for the burrow to be considered collateralized. *)
 let barely_not_overburrowed_test =
@@ -277,7 +277,7 @@ let barely_not_overburrowed_test =
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-        ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+        ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
     in
     assert_bool "is not overburrowed" (not (burrow_is_overburrowed params burrow));
     assert_bool "is not optimistically overburrowed" (not (burrow_is_optimistically_overburrowed params burrow));
@@ -302,7 +302,7 @@ let barely_overburrowed_test =
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-        ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+        ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
     in
     assert_bool "is overburrowed" (burrow_is_overburrowed params burrow);
     assert_bool "is optimistically overburrowed" (burrow_is_optimistically_overburrowed params burrow);
@@ -327,7 +327,7 @@ let barely_non_liquidatable_test =
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-        ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+        ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
     in
     assert_bool "is overburrowed" (burrow_is_overburrowed params burrow);
     assert_bool "is optimistically overburrowed" (burrow_is_optimistically_overburrowed params burrow);
@@ -352,7 +352,7 @@ let barely_liquidatable_test =
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-        ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+        ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
     in
     assert_bool "is overburrowed" (burrow_is_overburrowed params burrow);
     assert_bool "is optimistically overburrowed" (burrow_is_optimistically_overburrowed params burrow);
@@ -372,7 +372,7 @@ let barely_liquidatable_test =
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "2_818_396mutez")
-                ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+                ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
           }
         ) in
     let liquidation_result = burrow_request_liquidation params burrow in
@@ -416,7 +416,7 @@ let barely_non_complete_liquidatable_test =
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-        ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+        ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
     in
     assert_bool "is overburrowed" (burrow_is_overburrowed params burrow);
     assert_bool "is optimistically overburrowed" (burrow_is_optimistically_overburrowed params burrow);
@@ -436,7 +436,7 @@ let barely_non_complete_liquidatable_test =
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "4_060_000mutez")
-                ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+                ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
           }
         ) in
     let liquidation_result = burrow_request_liquidation params burrow in
@@ -478,7 +478,7 @@ let barely_complete_liquidatable_test =
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-        ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+        ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
     in
     assert_bool "is overburrowed" (burrow_is_overburrowed params burrow);
     assert_bool "is optimistically overburrowed" (burrow_is_optimistically_overburrowed params burrow);
@@ -498,7 +498,7 @@ let barely_complete_liquidatable_test =
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "4_059_999mutez")
-                ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+                ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
           }
         ) in
     let liquidation_result = burrow_request_liquidation params burrow in
@@ -540,7 +540,7 @@ let barely_non_close_liquidatable_test =
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-        ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+        ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
     in
     assert_bool "is overburrowed" (burrow_is_overburrowed params burrow);
     assert_bool "is optimistically overburrowed" (burrow_is_optimistically_overburrowed params burrow);
@@ -560,7 +560,7 @@ let barely_non_close_liquidatable_test =
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-                ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+                ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
           }
         ) in
     let liquidation_result = burrow_request_liquidation params burrow in
@@ -599,7 +599,7 @@ let barely_close_liquidatable_test =
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-        ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+        ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
     in
     assert_bool "is overburrowed" (burrow_is_overburrowed params burrow);
     assert_bool "is optimistically overburrowed" (burrow_is_optimistically_overburrowed params burrow);
@@ -619,7 +619,7 @@ let barely_close_liquidatable_test =
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "999_999mutez")
-                ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+                ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
           }
         ) in
     let liquidation_result = burrow_request_liquidation params burrow in
@@ -659,7 +659,7 @@ let unwarranted_liquidation_unit_test =
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-        ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+        ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
     in
 
     assert_bool "is not overburrowed" (not (burrow_is_overburrowed params burrow));
@@ -687,7 +687,7 @@ let partial_liquidation_unit_test =
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "20_000_000n"))
                 ~adjustment_index:(compute_adjustment_index params)
                 ~collateral_at_auction:(Ligo.tez_from_literal "7_142_472mutez")
-                ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+                ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
           }
         ) in
 
@@ -730,7 +730,7 @@ let complete_liquidation_unit_test =
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "100_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-        ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+        ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
     in
 
     let expected_liquidation_result =
@@ -747,7 +747,7 @@ let complete_liquidation_unit_test =
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "100_000_000n"))
                 ~adjustment_index:(compute_adjustment_index params)
                 ~collateral_at_auction:(Ligo.tez_from_literal "8_990_000mutez")
-                ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+                ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
           }
         ) in
 
@@ -792,7 +792,7 @@ let complete_and_close_liquidation_test =
         ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "100_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-        ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+        ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
     in
 
     let expected_liquidation_result =
@@ -809,7 +809,7 @@ let complete_and_close_liquidation_test =
                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "100_000_000n"))
                 ~adjustment_index:(compute_adjustment_index params)
                 ~collateral_at_auction:(Ligo.tez_from_literal "999_000mutez")
-                ~last_touched:(Ligo.timestamp_from_seconds_literal 0)
+                ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
           }
         ) in
 
@@ -867,7 +867,7 @@ let test_burrow_request_liquidation_invariant_close =
       ~outstanding_kit:kit_to_allow_liquidation
       ~adjustment_index:(compute_adjustment_index params)
       ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-      ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+      ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
   let liquidation_details = match Burrow.burrow_request_liquidation initial_parameters burrow0 with
     | Some (Burrow.Close, liquidation_details) -> liquidation_details
@@ -909,7 +909,7 @@ let test_burrow_request_liquidation_invariant_complete =
       ~outstanding_kit:outstanding_kit
       ~adjustment_index:(compute_adjustment_index params)
       ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-      ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+      ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
   let liquidation_details = match Burrow.burrow_request_liquidation initial_parameters burrow0 with
     | Some (Burrow.Complete, liquidation_details) -> liquidation_details
@@ -944,7 +944,7 @@ let test_burrow_request_liquidation_invariant_partial =
       ~outstanding_kit:outstanding_kit
       ~adjustment_index:(compute_adjustment_index params)
       ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
-      ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+      ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
   let liquidation_details = match Burrow.burrow_request_liquidation initial_parameters burrow0 with
     | Some (Burrow.Partial, liquidation_details) -> liquidation_details
@@ -991,7 +991,7 @@ let regression_test_72 =
         ~address:burrow_addr
         ~delegate:None
         ~adjustment_index:fixedpoint_one
-        ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+        ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
     let liquidation_details = match Burrow.burrow_request_liquidation Parameters.initial_parameters burrow0 with
       | Some (Burrow.Complete, liquidation_details) -> liquidation_details
@@ -1011,7 +1011,7 @@ let regression_test_93 =
         ~address:burrow_addr
         ~delegate:None
         ~adjustment_index:fixedpoint_one
-        ~last_touched:(Ligo.timestamp_from_seconds_literal 0) in
+        ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
     (* First liquidation must be complete *)
     let liquidation_details = match Burrow.burrow_request_liquidation Parameters.initial_parameters burrow_in with


### PR DESCRIPTION
Since it's original name and description were incorrect.