### PR TITLE
Use zero as an absorbing bound for the approximation of the total kit outstanding

### DIFF
--- a/src/checker.ml
+++ b/src/checker.ml
@@ -221,14 +221,7 @@ let entrypoint_burn_kit (state, (burrow_no, kit): checker * (Ligo.nat * kit)) : 
    * that is not owned by the sender). Either way I (George) think that this
    * assertion is only useful for our unit tests. *)
 
-  let outstanding_to_remove =
-    (* BEGIN_OCAML *)
-    let _ =
-      if gt_kit_kit actual_burned state.parameters.outstanding_kit
-      then Printf.eprintf "\nunderapproximation of total outstanding (1)!"
-      else () in
-    (* END OCAML *)
-    kit_min state.parameters.outstanding_kit actual_burned in
+  let outstanding_to_remove = actual_burned in
   let circulating_to_remove = actual_burned in
 
   assert (geq_kit_kit kit actual_burned);
@@ -424,15 +417,7 @@ let touch_liquidation_slice
   assert (eq_kit_kit (kit_add repaid_kit excess_kit) kit_to_repay);
   assert (eq_kit_kit (kit_add kit_to_repay kit_to_burn) slice_kit);
 
-  let outstanding_to_remove = (* only repaied_kit: excess_kit is returned to the owner and kit_to_burn is not included *)
-    (* BEGIN_OCAML *)
-    let _ =
-      if gt_kit_kit repaid_kit state_parameters.outstanding_kit
-      then Printf.eprintf "\nunderapproximation of total outstanding (2)!"
-      else () in
-    (* END OCAML *)
-    kit_min state_parameters.outstanding_kit repaid_kit in
-
+  let outstanding_to_remove = repaid_kit in (* excess_kit is returned to the owner and kit_to_burn is not included *)
   let circulating_to_remove = kit_add repaid_kit kit_to_burn in (* excess_kit remains in circulation *)
 
   let state_parameters =

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -221,7 +221,14 @@ let entrypoint_burn_kit (state, (burrow_no, kit): checker * (Ligo.nat * kit)) : 
    * that is not owned by the sender). Either way I (George) think that this
    * assertion is only useful for our unit tests. *)
 
-  let outstanding_to_remove = actual_burned in
+  let outstanding_to_remove =
+    (* BEGIN_OCAML *)
+    let _ =
+      if gt_kit_kit actual_burned state.parameters.outstanding_kit
+      then Printf.eprintf "\nunderapproximation of total outstanding (1)!"
+      else () in
+    (* END OCAML *)
+    kit_min state.parameters.outstanding_kit actual_burned in
   let circulating_to_remove = actual_burned in
 
   assert (geq_kit_kit kit actual_burned);
@@ -417,7 +424,15 @@ let touch_liquidation_slice
   assert (eq_kit_kit (kit_add repaid_kit excess_kit) kit_to_repay);
   assert (eq_kit_kit (kit_add kit_to_repay kit_to_burn) slice_kit);
 
-  let outstanding_to_remove = repaid_kit in (* excess_kit is returned to the owner and kit_to_burn is not included *)
+  let outstanding_to_remove = (* only repaied_kit: excess_kit is returned to the owner and kit_to_burn is not included *)
+    (* BEGIN_OCAML *)
+    let _ =
+      if gt_kit_kit repaid_kit state_parameters.outstanding_kit
+      then Printf.eprintf "\nunderapproximation of total outstanding (2)!"
+      else () in
+    (* END OCAML *)
+    kit_min state_parameters.outstanding_kit repaid_kit in
+
   let circulating_to_remove = kit_add repaid_kit kit_to_burn in (* excess_kit remains in circulation *)
 
   let state_parameters =

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -228,10 +228,19 @@ let entrypoint_burn_kit (state, (burrow_no, kit): checker * (Ligo.nat * kit)) : 
   assert (geq_kit_kit actual_burned outstanding_to_remove);
   assert (geq_kit_kit state.parameters.circulating_kit kit);
 
+  let state_parameters = remove_outstanding_and_circulating_kit state.parameters outstanding_to_remove circulating_to_remove in
+
+  (* BEGIN_OCAML *)
+  let _ =
+    if gt_kit_kit (kit_add state_parameters.outstanding_kit outstanding_to_remove) state.parameters.outstanding_kit
+    then Printf.eprintf "\nUNDERAPPROXIMATION OF TOTAL OUTSTANDING DETECTED (entrypoint_burn_kit)"
+    else () in
+  (* END_OCAML *)
+
   let state =
     {state with
      burrows = Ligo.Big_map.update burrow_id (Some burrow) state.burrows;
-     parameters = remove_outstanding_and_circulating_kit state.parameters outstanding_to_remove circulating_to_remove;
+     parameters = state_parameters;
      fa2_state = ledger_withdraw_kit (state.fa2_state, !Ligo.Tezos.sender, circulating_to_remove); (* the burrow owner keeps the rest *)
     } in
   assert_checker_invariants state;
@@ -420,11 +429,20 @@ let touch_liquidation_slice
   let outstanding_to_remove = repaid_kit in (* excess_kit is returned to the owner and kit_to_burn is not included *)
   let circulating_to_remove = kit_add repaid_kit kit_to_burn in (* excess_kit remains in circulation *)
 
-  let state_parameters =
+  let new_state_parameters =
     remove_outstanding_and_circulating_kit
       state_parameters
       outstanding_to_remove
       circulating_to_remove in
+
+  (* BEGIN_OCAML *)
+  let _ =
+    if gt_kit_kit (kit_add new_state_parameters.outstanding_kit outstanding_to_remove) state_parameters.outstanding_kit
+    then Printf.eprintf "\nUNDERAPPROXIMATION OF TOTAL OUTSTANDING DETECTED (touch_liquidation_slice)"
+    else () in
+  (* END_OCAML *)
+
+  let state_parameters = new_state_parameters in
 
   let new_state_fa2_state =
     let state_fa2_state = ledger_withdraw_kit (state_fa2_state, !Ligo.Tezos.self_address, slice_kit) in

--- a/src/parameters.ml
+++ b/src/parameters.ml
@@ -500,12 +500,12 @@ let[@inline] remove_outstanding_and_circulating_kit
    * kit outstanding. If anything, by doing so the gap between the real value
    * and the approximation decreases (however, this catch-all could hide other
    * bugs). *)
-  (* (* BEGIN_OCAML *)
+  (*
      let _ =
        if gt_kit_kit outstanding_to_remove parameters.outstanding_kit
        then Printf.eprintf "\nunderapproximation of total outstanding"
        else () in
-     (* END OCAML *) *)
+  *)
   let outstanding_to_remove =
     kit_min parameters.outstanding_kit outstanding_to_remove in
   { parameters with

--- a/src/parameters.ml
+++ b/src/parameters.ml
@@ -483,10 +483,14 @@ let[@inline] add_outstanding_and_circulating_kit (parameters: parameters) (kit: 
 
 (** Remove some kit from the total amount of kit required to close all burrows
     and the kit in circulation. This is the case when a burrow owner burns kit. *)
-let[@inline] remove_outstanding_and_circulating_kit (parameters: parameters) (kit: kit) : parameters =
-  assert (geq_kit_kit parameters.outstanding_kit kit);
-  assert (geq_kit_kit parameters.circulating_kit kit);
+let[@inline] remove_outstanding_and_circulating_kit
+    (parameters: parameters)
+    (outstanding_to_remove: kit)
+    (circulating_to_remove: kit)
+  : parameters =
+  assert (geq_kit_kit parameters.outstanding_kit outstanding_to_remove);
+  assert (geq_kit_kit parameters.circulating_kit circulating_to_remove);
   { parameters with
-    outstanding_kit = kit_sub parameters.outstanding_kit kit;
-    circulating_kit = kit_sub parameters.circulating_kit kit;
+    outstanding_kit = kit_sub parameters.outstanding_kit outstanding_to_remove;
+    circulating_kit = kit_sub parameters.circulating_kit circulating_to_remove;
   }

--- a/src/parameters.ml
+++ b/src/parameters.ml
@@ -488,8 +488,14 @@ let[@inline] remove_outstanding_and_circulating_kit
     (outstanding_to_remove: kit)
     (circulating_to_remove: kit)
   : parameters =
-  assert (geq_kit_kit parameters.outstanding_kit outstanding_to_remove);
-  assert (geq_kit_kit parameters.circulating_kit circulating_to_remove);
+  (* BEGIN_OCAML *)
+  if geq_kit_kit parameters.outstanding_kit outstanding_to_remove
+  then ()
+  else failwith "remove_outstanding_and_circulating_kit: outstanding underflow";
+  if geq_kit_kit parameters.circulating_kit circulating_to_remove
+  then ()
+  else failwith "remove_outstanding_and_circulating_kit: circulating underflow";
+  (* END_OCAML *)
   { parameters with
     outstanding_kit = kit_sub parameters.outstanding_kit outstanding_to_remove;
     circulating_kit = kit_sub parameters.circulating_kit circulating_to_remove;

--- a/src/parameters.ml
+++ b/src/parameters.ml
@@ -489,13 +489,24 @@ let[@inline] remove_outstanding_and_circulating_kit
     (circulating_to_remove: kit)
   : parameters =
   assert (geq_kit_kit parameters.circulating_kit circulating_to_remove);
+
+  (* It is currently unclear whether the way we approximate the total
+   * outstanding kit is an over- or an under- approximation of the real total
+   * outstanding kit (i.e., the sum of b.outstanding_kit for every burrow b).
+   * As illustrated in #209 (whose source was another issue, but still), if we
+   * are not careful when reducing our approximation of the total outstanding
+   * kit checker could potentially get stuck and become untouchable. To avoid
+   * that, we use zero as an absorbing bound for the approximation of the total
+   * kit outstanding. If anything, by doing so the gap between the real value
+   * and the approximation decreases (however, this catch-all could hide other
+   * bugs). *)
+  (* (* BEGIN_OCAML *)
+     let _ =
+       if gt_kit_kit outstanding_to_remove parameters.outstanding_kit
+       then Printf.eprintf "\nunderapproximation of total outstanding"
+       else () in
+     (* END OCAML *) *)
   let outstanding_to_remove =
-    (* BEGIN_OCAML *)
-    let _ =
-      if gt_kit_kit outstanding_to_remove parameters.outstanding_kit
-      then Printf.eprintf "\nunderapproximation of total outstanding"
-      else () in
-    (* END OCAML *)
     kit_min parameters.outstanding_kit outstanding_to_remove in
   { parameters with
     outstanding_kit = kit_sub parameters.outstanding_kit outstanding_to_remove;

--- a/src/parameters.ml
+++ b/src/parameters.ml
@@ -488,11 +488,7 @@ let[@inline] remove_outstanding_and_circulating_kit
     (outstanding_to_remove: kit)
     (circulating_to_remove: kit)
   : parameters =
-  (* BEGIN_OCAML *)
-  if geq_kit_kit parameters.circulating_kit circulating_to_remove
-  then ()
-  else failwith "remove_outstanding_and_circulating_kit: circulating underflow";
-  (* END_OCAML *)
+  assert (geq_kit_kit parameters.circulating_kit circulating_to_remove);
   let outstanding_to_remove =
     (* BEGIN_OCAML *)
     let _ =

--- a/src/parameters.ml
+++ b/src/parameters.ml
@@ -500,12 +500,6 @@ let[@inline] remove_outstanding_and_circulating_kit
    * kit outstanding. If anything, by doing so the gap between the real value
    * and the approximation decreases (however, this catch-all could hide other
    * bugs). *)
-  (*
-     let _ =
-       if gt_kit_kit outstanding_to_remove parameters.outstanding_kit
-       then Printf.eprintf "\nunderapproximation of total outstanding"
-       else () in
-  *)
   let outstanding_to_remove =
     kit_min parameters.outstanding_kit outstanding_to_remove in
   { parameters with

--- a/src/parameters.ml
+++ b/src/parameters.ml
@@ -489,13 +489,18 @@ let[@inline] remove_outstanding_and_circulating_kit
     (circulating_to_remove: kit)
   : parameters =
   (* BEGIN_OCAML *)
-  if geq_kit_kit parameters.outstanding_kit outstanding_to_remove
-  then ()
-  else failwith "remove_outstanding_and_circulating_kit: outstanding underflow";
   if geq_kit_kit parameters.circulating_kit circulating_to_remove
   then ()
   else failwith "remove_outstanding_and_circulating_kit: circulating underflow";
   (* END_OCAML *)
+  let outstanding_to_remove =
+    (* BEGIN_OCAML *)
+    let _ =
+      if gt_kit_kit outstanding_to_remove parameters.outstanding_kit
+      then Printf.eprintf "\nunderapproximation of total outstanding"
+      else () in
+    (* END OCAML *)
+    kit_min parameters.outstanding_kit outstanding_to_remove in
   { parameters with
     outstanding_kit = kit_sub parameters.outstanding_kit outstanding_to_remove;
     circulating_kit = kit_sub parameters.circulating_kit circulating_to_remove;

--- a/tests/testParameters.ml
+++ b/tests/testParameters.ml
@@ -777,31 +777,6 @@ let test_remove_outstanding_and_circulating_kit_effect_no_underflows =
   true
 
 (* remove_outstanding_and_circulating_kit has the expected effect when the
- * circulating kit underflows (should fail) *)
-let test_remove_outstanding_and_circulating_kit_effect_circulating_underflow =
-  qcheck_to_ounit
-  @@ QCheck.Test.make
-    ~name:"test_remove_outstanding_and_circulating_kit_effect_circulating_underflow"
-    ~count:property_test_count
-    (QCheck.quad TestArbitrary.arb_kit TestArbitrary.arb_kit TestArbitrary.arb_kit TestArbitrary.arb_kit)
-  @@ fun (kit1, kit2, kit3, kit4) ->
-
-  (* successful cases (no underflows) *)
-  let outstanding_to_remove, outstanding = kit_min kit1 kit2, kit_max kit1 kit2 in                (* to avoid underflows *)
-  let circulating_to_remove, circulating =
-    kit_add (kit_max kit3 kit4) (kit_of_mukit (Ligo.nat_from_literal "1n")), kit_min kit3 kit4 in (* to induce underflow *)
-
-  let params1 =
-    { initial_parameters with
-      outstanding_kit = outstanding;
-      circulating_kit = circulating;
-    } in
-  assert_raises
-    (Failure "remove_outstanding_and_circulating_kit: circulating underflow")
-    (fun () -> remove_outstanding_and_circulating_kit params1 outstanding_to_remove circulating_to_remove);
-  true
-
-(* remove_outstanding_and_circulating_kit has the expected effect when the
  * outstanding kit underflows (should succeed) *)
 let test_remove_outstanding_and_circulating_kit_effect_outstanding_underflow =
   qcheck_to_ounit
@@ -1028,7 +1003,6 @@ let suite =
     test_add_outstanding_and_circulating_kit_effect;
     test_remove_circulating_kit_effect;
     test_remove_outstanding_and_circulating_kit_effect_no_underflows;
-    test_remove_outstanding_and_circulating_kit_effect_circulating_underflow;
     test_remove_outstanding_and_circulating_kit_effect_outstanding_underflow;
 
     (* add/remove circulating_kit/outstanding_kit (unit tests) *)

--- a/tests/testParameters.ml
+++ b/tests/testParameters.ml
@@ -739,16 +739,15 @@ let test_remove_circulating_kit_effect =
     ~real:{ params2 with circulating_kit = params1.circulating_kit };
   true
 
-(* remove_outstanding_and_circulating_kit has the expected effect *)
-let test_remove_outstanding_and_circulating_kit_effect =
+(* remove_outstanding_and_circulating_kit has the expected effect when there are no underflows *)
+let test_remove_outstanding_and_circulating_kit_effect_no_underflows =
   qcheck_to_ounit
   @@ QCheck.Test.make
-    ~name:"remove_outstanding_and_circulating_kit"
+    ~name:"test_remove_outstanding_and_circulating_kit_effect_no_underflows"
     ~count:property_test_count
     (QCheck.quad TestArbitrary.arb_kit TestArbitrary.arb_kit TestArbitrary.arb_kit TestArbitrary.arb_kit)
   @@ fun (kit1, kit2, kit3, kit4) ->
 
-  (* successful cases (no underflows) *)
   let outstanding_to_remove, outstanding = kit_min kit1 kit2, kit_max kit1 kit2 in (* to avoid underflows *)
   let circulating_to_remove, circulating = kit_min kit3 kit4, kit_max kit3 kit4 in (* to avoid underflows *)
 
@@ -775,6 +774,55 @@ let test_remove_outstanding_and_circulating_kit_effect =
       outstanding_kit = params1.outstanding_kit;
       circulating_kit = params1.circulating_kit;
     };
+  true
+
+(* remove_outstanding_and_circulating_kit has the expected effect when the
+ * circulating kit underflows (should fail) *)
+let test_remove_outstanding_and_circulating_kit_effect_circulating_underflow =
+  qcheck_to_ounit
+  @@ QCheck.Test.make
+    ~name:"test_remove_outstanding_and_circulating_kit_effect_circulating_underflow"
+    ~count:property_test_count
+    (QCheck.quad TestArbitrary.arb_kit TestArbitrary.arb_kit TestArbitrary.arb_kit TestArbitrary.arb_kit)
+  @@ fun (kit1, kit2, kit3, kit4) ->
+
+  (* successful cases (no underflows) *)
+  let outstanding_to_remove, outstanding = kit_min kit1 kit2, kit_max kit1 kit2 in                (* to avoid underflows *)
+  let circulating_to_remove, circulating =
+    kit_add (kit_max kit3 kit4) (kit_of_mukit (Ligo.nat_from_literal "1n")), kit_min kit3 kit4 in (* to induce underflow *)
+
+  let params1 =
+    { initial_parameters with
+      outstanding_kit = outstanding;
+      circulating_kit = circulating;
+    } in
+  assert_raises
+    (Failure "remove_outstanding_and_circulating_kit: circulating underflow")
+    (fun () -> remove_outstanding_and_circulating_kit params1 outstanding_to_remove circulating_to_remove);
+  true
+
+(* remove_outstanding_and_circulating_kit has the expected effect when the
+ * outstanding kit underflows (should succeed) *)
+let test_remove_outstanding_and_circulating_kit_effect_outstanding_underflow =
+  qcheck_to_ounit
+  @@ QCheck.Test.make
+    ~name:"test_remove_outstanding_and_circulating_kit_effect_outstanding_underflow"
+    ~count:property_test_count
+    (QCheck.quad TestArbitrary.arb_kit TestArbitrary.arb_kit TestArbitrary.arb_kit TestArbitrary.arb_kit)
+  @@ fun (kit1, kit2, kit3, kit4) ->
+
+  let outstanding_to_remove, outstanding =
+    kit_add (kit_max kit1 kit2) (kit_of_mukit (Ligo.nat_from_literal "1n")), kit_min kit1 kit2 in (* to induce underflow *)
+  let circulating_to_remove, circulating = kit_min kit3 kit4, kit_max kit3 kit4 in                (* to avoid underflows *)
+
+  let params1 =
+    { initial_parameters with
+      outstanding_kit = outstanding;
+      circulating_kit = circulating;
+    } in
+  assert_raises
+    (Failure "remove_outstanding_and_circulating_kit: outstanding underflow")
+    (fun () -> remove_outstanding_and_circulating_kit params1 outstanding_to_remove circulating_to_remove);
   true
 
 (* Just a simple unit test, more tightly testing the changes when updating the
@@ -964,7 +1012,9 @@ let suite =
     test_add_circulating_kit_effect;
     test_add_outstanding_and_circulating_kit_effect;
     test_remove_circulating_kit_effect;
-    test_remove_outstanding_and_circulating_kit_effect; (* FIXME: test failure for circulating underflow, FIXME: test success for outstanding underflow *)
+    test_remove_outstanding_and_circulating_kit_effect_no_underflows;
+    test_remove_outstanding_and_circulating_kit_effect_circulating_underflow;
+    test_remove_outstanding_and_circulating_kit_effect_outstanding_underflow;
 
     (* add/remove circulating_kit/outstanding_kit (unit tests) *)
     test_add_remove_outstanding_circulating_kit_unit;

--- a/tests/testParameters.ml
+++ b/tests/testParameters.ml
@@ -820,9 +820,24 @@ let test_remove_outstanding_and_circulating_kit_effect_outstanding_underflow =
       outstanding_kit = outstanding;
       circulating_kit = circulating;
     } in
-  assert_raises
-    (Failure "remove_outstanding_and_circulating_kit: outstanding underflow")
-    (fun () -> remove_outstanding_and_circulating_kit params1 outstanding_to_remove circulating_to_remove);
+  let params2 = remove_outstanding_and_circulating_kit params1 outstanding_to_remove circulating_to_remove in
+
+  (* remove_outstanding_and_circulating_kit should bring the outstanding kit to zero *)
+  assert_kit_equal
+    ~expected:Kit.kit_zero
+    ~real:params2.outstanding_kit;
+  (* remove_outstanding_and_circulating_kit should decrease the circulating kit *)
+  assert_kit_equal
+    ~expected:(Kit.kit_add params2.circulating_kit circulating_to_remove)
+    ~real:params1.circulating_kit;
+  (* remove_outstanding_and_circulating_kit should not affect other fields *)
+  assert_parameters_equal
+    ~expected:params1
+    ~real:{
+      params2 with
+      outstanding_kit = params1.outstanding_kit;
+      circulating_kit = params1.circulating_kit;
+    };
   true
 
 (* Just a simple unit test, more tightly testing the changes when updating the


### PR DESCRIPTION
Since I've been unable to prove that our approximation of outstanding kit (i.e., `parameters.outstanding_kit`) overapproximates the real value (i.e., the sum of `burrow.outstanding_kit` for all burrows `burrow`), it is theoretically possible that checker can get stuck, along the lines of #209.

To avoid that, this PR makes sure that we never force `parameters.outstanding_kit` below zero.
- Disadvantage: this catch-all behavior could potentially hide other bugs.
- Advantage: if indeed this case is triggered, keeping `parameters.outstanding_kit` at zero while `burrow.outstanding_kit` gets decreased actually decreases the discrepancy between the real value and the approximation.

Also it adds a unit test to check the new behavior (I don't know how / if it is possible to trigger this execution path using a real-life scenario).