### PR TITLE
Additional unit tests for operations returned by entrypoints

### DIFF
--- a/src/sliceList.ml
+++ b/src/sliceList.ml
@@ -215,5 +215,7 @@ let slice_list_oldest (l: slice_list) (auctions: liquidation_auctions) : slice_l
   | Some bounds -> Some (SliceListElement (bounds.slice_list_oldest_ptr, avl_read_leaf storage bounds.slice_list_oldest_ptr))
   | None -> None
 
+let slice_list_element_ptr (SliceListElement (ptr, _): slice_list_element) : leaf_ptr = ptr
+
 [@@@coverage on]
 (* END_OCAML *)

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -479,11 +479,11 @@ let suite =
 
        (* Place a bid *)
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _ops, _checker = Checker.entrypoint_liquidation_auction_place_bid
+       let ops, _checker = Checker.entrypoint_liquidation_auction_place_bid
            (checker,
             ((Option.get checker.liquidation_auctions.current_auction).contents, auction_details.minimum_bid))
        in
-       ()
+       assert_operation_list_equal ~expected:[] ~real:ops
     );
 
     ("entrypoint_mark_for_liquidation - emits expected operations" >::

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -43,6 +43,142 @@ let empty_checker_with_cfmm (cfmm: CfmmTypes.cfmm) =
   Checker.assert_checker_invariants checker;
   checker
 
+(* TODO: Test fixtures for checker with different auction states *)
+
+let checker_with_liquidatable_burrows () =
+  let checker = empty_checker in
+  (* Create some burrows and mint some kit *)
+  let alice_burrow_1 = Ligo.nat_from_literal "0n" in
+  let alice_burrow_nos = List.init 20 (fun i -> Ligo.nat_from_int64 (Int64.of_int (i+1))) in
+  let bob_burrow_1 = Ligo.nat_from_literal "0n" in
+  (* Alice burrow 1. Will NOT be liquidatable *)
+  Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:2 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "2_000_000mutez");
+  let _, checker = Checker.entrypoint_create_burrow (checker, (alice_burrow_1, None)) in
+  (* Alice burrow 2:N. Will be liquidatable *)
+  Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:3 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+  let _, checker = Checker.entrypoint_mint_kit (checker, (alice_burrow_1, (kit_of_mukit (Ligo.nat_from_literal "100n")))) in
+  let checker = List.fold_left (
+      fun checker alice_burrow_no ->
+        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "2_000_000mutez");
+        let _, checker = Checker.entrypoint_create_burrow (checker, (alice_burrow_no, None)) in
+        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+        let _, checker =
+          let max_kit = (Checker.view_burrow_max_mintable_kit ((alice_addr, alice_burrow_no), checker)) in
+          Checker.entrypoint_mint_kit (checker, (alice_burrow_no, max_kit)) in
+        checker
+    )
+      checker
+      alice_burrow_nos
+  in
+  (* Bob burrow 1. Will be liquidatable. *)
+  Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "20_000_000mutez");
+  let _, checker = Checker.entrypoint_create_burrow (checker, (bob_burrow_1, None)) in
+  Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
+  let _, checker =
+    let max_kit = (Checker.view_burrow_max_mintable_kit ((bob_addr, bob_burrow_1), checker)) in
+    Checker.entrypoint_mint_kit (checker, (bob_burrow_1, max_kit)) in
+
+  (* Increase value of kit to make some of the burrows liquidatable by touching checker *)
+  (* Note: setting the transaction to far in the future to ensure that the protected_index will become adequately high
+   * for the burrows to be liquidatable.
+  *)
+  Ligo.Tezos.new_transaction ~seconds_passed:10_000_000 ~blocks_passed:100_000 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
+  let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_100_000n") in
+  (* Touch burrows *)
+  Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
+  let _, checker = Checker.entrypoint_touch_burrow (checker, (alice_addr, alice_burrow_1)) in
+  Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
+  let _, checker = Checker.entrypoint_touch_burrow (checker, (bob_addr, bob_burrow_1)) in
+  let checker = List.fold_left (
+      fun checker alice_burrow_no ->
+        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
+        let _, checker = Checker.entrypoint_touch_burrow (checker, (alice_addr, alice_burrow_no)) in
+        checker
+    )
+      checker
+      alice_burrow_nos
+  in
+
+  (* Check the expected properties of this test fixture *)
+  assert_bool "alice_burrow_1 was liquidatable but it is expected to not be"
+    (not (Burrow.burrow_is_liquidatable checker.parameters (Option.get (Ligo.Big_map.find_opt (alice_addr, alice_burrow_1) checker.burrows))));
+  assert_bool "bob_burrow_1 was not liquidatable but it is expected to be"
+    (Burrow.burrow_is_liquidatable checker.parameters (Option.get (Ligo.Big_map.find_opt (bob_addr, bob_burrow_1) checker.burrows)));
+  List.fold_left (
+    fun _ alice_burrow_no ->
+      assert_bool ("alice_burrow_" ^ (Ligo.string_of_nat alice_burrow_no) ^ " was not liquidatable but it is expected to be")
+        (Burrow.burrow_is_liquidatable checker.parameters (Option.get (Ligo.Big_map.find_opt (alice_addr, alice_burrow_no) checker.burrows))))
+    ()
+    alice_burrow_nos;
+  Checker.assert_checker_invariants checker;
+
+  let liquidatable_burrow_ids = List.append (List.map (fun x -> (alice_addr, x)) alice_burrow_nos) [(bob_addr, bob_burrow_1)] in
+  let underburrowed_burrow_ids = [(alice_addr, alice_burrow_1)] in
+  liquidatable_burrow_ids, underburrowed_burrow_ids, checker
+
+let checker_with_queued_liquidation_slices () =
+  let liquidatable_burrow_ids, _, checker = checker_with_liquidatable_burrows () in
+  (* Mark the liquidatable burrows for liquidation. This will add slices to the queue. *)
+  let checker, close_slice_details, other_slice_details = List.fold_left
+      (fun (checker, close_liquidation_slices, other_liquidation_slices) burrow_id ->
+         Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+         let _, checker = Checker.entrypoint_mark_for_liquidation (checker, burrow_id) in
+         let new_slice = Option.get (SliceList.slice_list_youngest (SliceList.slice_list_from_auction_state checker.liquidation_auctions burrow_id) checker.liquidation_auctions) in
+         let slice_ptr = SliceList.slice_list_element_ptr new_slice in
+         let slize_tez = (SliceList.slice_list_element_contents new_slice).tez in
+         let is_burrow_now_closed = not (burrow_active (Option.get (Ligo.Big_map.find_opt burrow_id checker.burrows))) in
+         let close_liquidation_slices, other_liquidation_slices =
+           if is_burrow_now_closed then
+             (List.append close_liquidation_slices [(burrow_id, slice_ptr, slize_tez)]), other_liquidation_slices
+           else
+             close_liquidation_slices, (List.append other_liquidation_slices [(burrow_id, slice_ptr, slize_tez)])
+         in
+         checker, close_liquidation_slices, other_liquidation_slices
+      )
+      (checker, [], [])
+      liquidatable_burrow_ids
+  in
+  assert_bool
+    "liquidation auction queue was empty, but it was expected to have some slices"
+    (Option.is_some (Avl.avl_peek_front checker.liquidation_auctions.avl_storage checker.liquidation_auctions.queued_slices));
+  assert (List.length close_slice_details > 0);
+  assert (List.length other_slice_details > 0);
+  close_slice_details, other_slice_details, checker
+
+let checker_with_active_auction () =
+  let _ = Format.printf "<Tezos_time=%s>" (Ligo.string_of_timestamp (!Ligo.Tezos.now)) in
+  let _, _, checker = checker_with_queued_liquidation_slices () in
+  let _ = Format.printf "<Tezos_time=%s>" (Ligo.string_of_timestamp (!Ligo.Tezos.now)) in
+  (* Touch checker to start an auction *)
+  Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+  let _, checker = Checker.entrypoint_touch (checker, ()) in
+  assert_bool "a current liquidation auction should have been started but was not" (Option.is_some checker.liquidation_auctions.current_auction);
+  let _ = Format.printf "<Tezos_time=%s>" (Ligo.string_of_timestamp (!Ligo.Tezos.now)) in
+  checker
+
+let checker_with_completed_auction () =
+  let checker = checker_with_active_auction () in
+  (* Get the current auction minimum bid *)
+  let auction_details = Checker.view_current_liquidation_auction_minimum_bid ((), checker) in
+  (* Mint enough kit to bid *)
+  let bidder = alice_addr in
+  let new_burrow_no = Ligo.nat_from_literal "100n" in
+  Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:bidder ~amount:(Ligo.tez_from_literal "1_000_000_000mutez");
+  let _, checker = Checker.entrypoint_create_burrow (checker, (new_burrow_no, None)) in
+  Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:bidder ~amount:(Ligo.tez_from_literal "0mutez");
+  let _, checker = Checker.entrypoint_mint_kit (checker, (new_burrow_no, auction_details.minimum_bid)) in
+  (* Place a bid *)
+  Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:bidder ~amount:(Ligo.tez_from_literal "0mutez");
+  let _, checker = Checker.entrypoint_liquidation_auction_place_bid (checker, ((Option.get checker.liquidation_auctions.current_auction).contents, auction_details.minimum_bid)) in
+  (* Wait until enough time has passed for the auction to be completable then touch checker *)
+  (* Touch checker to start an auction *)
+  Ligo.Tezos.new_transaction ~seconds_passed:1202 ~blocks_passed:22 ~sender:bidder ~amount:(Ligo.tez_from_literal "0mutez");
+  let _, checker = Checker.entrypoint_touch (checker, ()) in
+  assert_bool
+    "there was not a completed liquidation auction but one should exist"
+    (Option.is_some checker.liquidation_auctions.completed_auctions);
+  checker
+
 (* Helper for creating new burrows and extracting their ID from the corresponding Ligo Ops *)
 let newly_created_burrow (checker: checker) (burrow_no: string) : burrow_id * checker =
   let _ops, checker = Checker.entrypoint_create_burrow (checker, (Ligo.nat_from_literal "0n", None)) in
@@ -325,6 +461,69 @@ let suite =
        assert_operation_list_equal ~expected:expected_ops ~real:ops
     );
 
+    ("entrypoint_liquidation_auction_place_bid - emits expected operations" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let checker = checker_with_active_auction () in
+       (* Lookup the current minimum bid *)
+       let auction_details = Checker.view_current_liquidation_auction_minimum_bid ((), checker) in
+       (* Mint some kit to be able to bid *)
+       let new_burrow_no = Ligo.nat_from_literal "100n" in
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "1_000_000_000mutez");
+       let _, checker = Checker.entrypoint_create_burrow (checker, (new_burrow_no, None)) in
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let _, checker = Checker.entrypoint_mint_kit (checker, (new_burrow_no, auction_details.minimum_bid)) in
+
+       (* Place a bid *)
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let _ops, _checker = Checker.entrypoint_liquidation_auction_place_bid
+           (checker,
+            ((Option.get checker.liquidation_auctions.current_auction).contents, auction_details.minimum_bid))
+       in
+       ()
+    );
+
+    ("entrypoint_mark_for_liquidation - emits expected operations" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       (* Use a checker state already containing some liquidatable burrows *)
+       let liquidatable_burrow_ids, _, checker = checker_with_liquidatable_burrows () in
+       let burrow_id = List.nth liquidatable_burrow_ids 0 in
+       let sender = bob_addr in
+
+       (* Mark one of the liquidatable burrows for liquidation *)
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:sender ~amount:(Ligo.tez_from_literal "0mutez");
+       let ops, _ = Checker.entrypoint_mark_for_liquidation (checker, burrow_id) in
+
+       let burrow = Option.get (Ligo.Big_map.find_opt burrow_id checker.burrows) in
+       let expected_ops = [
+         (LigoOp.Tezos.tez_address_transaction
+            ((Ligo.tez_from_literal "1_001_000mutez"), sender)
+            (Ligo.tez_from_literal "0mutez")
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%burrowSendTezTo" (burrow_address burrow)))
+         );
+       ] in
+       assert_operation_list_equal ~expected:expected_ops ~real:ops
+    );
+
+    ("entrypoint_cancel_liquidation_slice - emits expected operations" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       (* Use a checker state already containing some liquidatable burrows *)
+       (* Note: using a non-closed burrow for this test so we don't have to also re-activate the burrow *)
+       let _, slice_details, checker = checker_with_queued_liquidation_slices () in
+       let ((burrow_owner, burrow_no), slice_ptr, _) = List.nth slice_details 0 in
+
+       (* Deposit some extra collateral to one of the burrows with slices in the auction queue *)
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:burrow_owner ~amount:(Ligo.tez_from_literal "4_000_000mutez");
+       let _, checker = Checker.entrypoint_deposit_tez (checker, burrow_no) in
+
+       (* Now cancel one of the burrow's liquidation slices *)
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:burrow_owner ~amount:(Ligo.tez_from_literal "0mutez");
+       let ops, _ = Checker.entrypoint_cancel_liquidation_slice (checker, slice_ptr) in
+       assert_operation_list_equal ~expected:[] ~real:ops
+    );
+
     ("entrypoint_mint_kit - emits expected operations" >::
      fun _ ->
        Ligo.Tezos.reset ();
@@ -436,6 +635,33 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let ops, _ = Checker.entrypoint_touch (checker, ()) in
        assert_operation_list_equal ~expected:[] ~real:ops
+    );
+
+    ("entrypoint_touch_liquidation_slices - emits expected operations" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let checker = checker_with_completed_auction () in
+       let auction_ptr = (Option.get checker.liquidation_auctions.completed_auctions).oldest in
+       let slice_ptrs = avl_leaves_to_list checker.liquidation_auctions.avl_storage auction_ptr in
+       let slices = List.map (fun ptr -> Avl.avl_read_leaf checker.liquidation_auctions.avl_storage ptr) slice_ptrs in
+
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
+       let ops, _ = Checker.entrypoint_touch_liquidation_slices (checker, slice_ptrs) in
+       (* Note: opening LiquidationAuctionPrimitiveTypes locally here since we have overloaded
+        * the "contents" record accessor in LiquidationAuctionTypes
+       *)
+       let expected_ops = let open LiquidationAuctionPrimitiveTypes in
+         List.rev (List.map (
+             fun slice ->
+               let burrow = Option.get (Ligo.Big_map.find_opt slice.contents.burrow checker.burrows) in
+               (* TODO: Construct operations here *)
+               LigoOp.Tezos.tez_transaction
+                 slice.contents.tez
+                 (Ligo.tez_from_literal "0mutez")
+                 (Option.get (LigoOp.Tezos.get_entrypoint_opt "%burrowSendSliceToChecker" (burrow_address burrow))
+                 )
+           ) slices) in
+       assert_operation_list_equal ~expected:expected_ops ~real:ops
     );
 
     ("entrypoint_touch_burrow - emits expected operations" >::

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -681,7 +681,6 @@ let suite =
          List.rev (List.map (
              fun slice ->
                let burrow = Option.get (Ligo.Big_map.find_opt slice.contents.burrow checker.burrows) in
-               (* TODO: Construct operations here *)
                LigoOp.Tezos.tez_transaction
                  slice.contents.tez
                  (Ligo.tez_from_literal "0mutez")

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -1,3 +1,5 @@
+open LiquidationAuctionPrimitiveTypes
+
 let alice_addr = Ligo.address_from_literal "alice_addr"
 let bob_addr = Ligo.address_from_literal "bob_addr"
 let leena_addr = Ligo.address_from_literal "leena_addr"
@@ -134,3 +136,15 @@ let debug_print_all_kit_in_sealed_state msg wrapper =
     List.iter
       (fun (addr, amnt) -> print_string ("  " ^ Ligo.string_of_address addr ^ " : " ^ Ligo.string_of_nat amnt ^ "\n"))
       (Fa2Interface.get_kit_credits_from_fa2_state state.fa2_state)
+
+(* Extracts the pointers to all of a given AVL tree's leaves *)
+let avl_leaves_to_list (mem: Mem.mem) (AVLPtr ptr) : leaf_ptr list =
+  let rec go ptr: leaf_ptr list =
+    match Mem.mem_get mem ptr with
+    | Root (None, _) -> []
+    | Root (Some ptr, _) -> go ptr
+    | Leaf _ ->
+      [LeafPtr ptr]
+    | Branch branch ->
+      List.append (go branch.left) (go branch.right) in
+  go ptr


### PR DESCRIPTION
Similar to #214, this PR adds unit tests for operations emitted by entrypoints in `checker.ml`. Some of these tests also overlap with assertions in the `can complete a liquidation auction` test, but I think it is cleaner to have individual unit tests for them as well.

To be able to efficiently write these, I ended up adding a group of test fixture-like functions in testChecker.ml for producing instances of checker with different liquidation auction states. I think these will prove more generally useful as we add more unit tests related to liquidation auctions.

Entrypoints covered include:
- entrypoint_set_burrow_delegate
- entrypoint_receive_price
- entrypoint_mark_for_liquidation
- entrypoint_cancel_liquidation_slice
- entrypoint_liquidation_auction_place_bid
- entrypoint_touch_liquidation_slices
- entrypoint_liquidation_auction_claim_win
