### PR TITLE
Add git to shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -115,7 +115,7 @@ rec
         # compile it in CI
         pkgs.lib.optionals (pkgs.stdenv.isLinux) [ ligoBinary ]
         ++ pkgs.lib.optionals (!(pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64)) [ pkgs.niv ]
-        ++ (with pkgs; [ ruby bc sphinx poetry entr nodePackages.live-server fd python3Packages.black nixpkgs-fmt jq gawk ])
+        ++ (with pkgs; [ ruby bc sphinx poetry entr nodePackages.live-server fd python3Packages.black nixpkgs-fmt jq gawk gitMinimal ])
         ++ spec.buildInputs
         ++ ocamlDeps pkgs
         ++ pythonDeps.buildInputs;


### PR DESCRIPTION
Because `mutate.py` depends on it.

I saw it on the actions log: https://github.com/tezos-checker/checker/actions/runs/1099652310

It's a bit of a shame that we don't have tests for it, but at least it is visible.