### PR TITLE
High-level test for outstanding_kit underapproximation

### DIFF
--- a/src/checker.ml
+++ b/src/checker.ml
@@ -20,7 +20,6 @@ open Mem
 
 (* BEGIN_OCAML *)
 [@@@coverage off]
-(*
 let compute_outstanding_dissonance (state: checker) : kit (* "real" *) * kit (* approximation *) =
   let approximation = state.parameters.outstanding_kit in
   let real =
@@ -34,24 +33,8 @@ let compute_outstanding_dissonance (state: checker) : kit (* "real" *) * kit (* 
    * (percentage), with the "real" as the base. For now just
    * return the two values. *)
   real, approximation
-*)
 
 let assert_checker_invariants (state: checker) : unit =
-(*
-  let _ =
-    let r, a = compute_outstanding_dissonance state in
-    let vals = "(" ^ show_kit r ^ "," ^ show_kit a ^ "," ^ show_kit state.parameters.circulating_kit ^ ")" in
-
-    if gt_kit_kit a r then
-      Printf.eprintf "\noverapproximation, good! %s" vals
-    else if eq_kit_kit a r then
-      Printf.eprintf "\nequal, perfection! %s" vals
-    else
-      (* failwith ("\nUNDERAPPROXIMATION " ^ vals) *)
-      Printf.eprintf "\noh, no, underapproximation! %s" vals
-  in
-*)
-
   (* Check if the auction pointerfest kind of make sense. *)
   assert_liquidation_auction_invariants state.liquidation_auctions;
   (* Check that the total kit tracked on the fa2 ledger is consistent with

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -20,7 +20,34 @@ open Mem
 
 (* BEGIN_OCAML *)
 [@@@coverage off]
+
+let compute_outstanding_dissonance (state: checker) : kit (* "real" *) * kit (* approximation *) =
+  let approximation = state.parameters.outstanding_kit in
+  let real =
+    Ligo.Big_map.fold
+      (fun sum (_, b) ->
+         kit_add sum (burrow_outstanding_kit (burrow_touch state.parameters b))
+      )
+      kit_zero
+      state.burrows in
+  (* we should probably calculate this as relative difference
+   * (percentage), with the "real" as the base. For now just
+   * return the two values. *)
+  real, approximation
+
 let assert_checker_invariants (state: checker) : unit =
+  let _ =
+    let r, a = compute_outstanding_dissonance state in
+    let vals = "(" ^ show_kit r ^ "," ^ show_kit a ^ ")" in
+
+    if gt_kit_kit a r then
+      Printf.eprintf "\noverapproximation, good! %s" vals
+    else if eq_kit_kit a r then
+      Printf.eprintf "\nequal, perfection! %s" vals
+    else
+      Printf.eprintf "\noh, no, underapproximation! %s" vals
+  in
+
   (* Check if the auction pointerfest kind of make sense. *)
   assert_liquidation_auction_invariants state.liquidation_auctions;
   (* Check that the total kit tracked on the fa2 ledger is consistent with

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -242,19 +242,10 @@ let entrypoint_burn_kit (state, (burrow_no, kit): checker * (Ligo.nat * kit)) : 
   assert (geq_kit_kit actual_burned outstanding_to_remove);
   assert (geq_kit_kit state.parameters.circulating_kit kit);
 
-  let state_parameters = remove_outstanding_and_circulating_kit state.parameters outstanding_to_remove circulating_to_remove in
-
-  (* BEGIN_OCAML *)
-  let _ =
-    if gt_kit_kit (kit_add state_parameters.outstanding_kit outstanding_to_remove) state.parameters.outstanding_kit
-    then Printf.eprintf "\nUNDERAPPROXIMATION OF TOTAL OUTSTANDING DETECTED (entrypoint_burn_kit)"
-    else () in
-  (* END_OCAML *)
-
   let state =
     {state with
      burrows = Ligo.Big_map.update burrow_id (Some burrow) state.burrows;
-     parameters = state_parameters;
+     parameters = remove_outstanding_and_circulating_kit state.parameters outstanding_to_remove circulating_to_remove;
      fa2_state = ledger_withdraw_kit (state.fa2_state, !Ligo.Tezos.sender, circulating_to_remove); (* the burrow owner keeps the rest *)
     } in
   assert_checker_invariants state;
@@ -443,20 +434,11 @@ let touch_liquidation_slice
   let outstanding_to_remove = repaid_kit in (* excess_kit is returned to the owner and kit_to_burn is not included *)
   let circulating_to_remove = kit_add repaid_kit kit_to_burn in (* excess_kit remains in circulation *)
 
-  let new_state_parameters =
+  let state_parameters =
     remove_outstanding_and_circulating_kit
       state_parameters
       outstanding_to_remove
       circulating_to_remove in
-
-  (* BEGIN_OCAML *)
-  let _ =
-    if gt_kit_kit (kit_add new_state_parameters.outstanding_kit outstanding_to_remove) state_parameters.outstanding_kit
-    then Printf.eprintf "\nUNDERAPPROXIMATION OF TOTAL OUTSTANDING DETECTED (touch_liquidation_slice)"
-    else () in
-  (* END_OCAML *)
-
-  let state_parameters = new_state_parameters in
 
   let new_state_fa2_state =
     let state_fa2_state = ledger_withdraw_kit (state_fa2_state, !Ligo.Tezos.self_address, slice_kit) in

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -20,7 +20,7 @@ open Mem
 
 (* BEGIN_OCAML *)
 [@@@coverage off]
-
+(*
 let compute_outstanding_dissonance (state: checker) : kit (* "real" *) * kit (* approximation *) =
   let approximation = state.parameters.outstanding_kit in
   let real =
@@ -34,19 +34,23 @@ let compute_outstanding_dissonance (state: checker) : kit (* "real" *) * kit (* 
    * (percentage), with the "real" as the base. For now just
    * return the two values. *)
   real, approximation
+*)
 
 let assert_checker_invariants (state: checker) : unit =
+(*
   let _ =
     let r, a = compute_outstanding_dissonance state in
-    let vals = "(" ^ show_kit r ^ "," ^ show_kit a ^ ")" in
+    let vals = "(" ^ show_kit r ^ "," ^ show_kit a ^ "," ^ show_kit state.parameters.circulating_kit ^ ")" in
 
     if gt_kit_kit a r then
       Printf.eprintf "\noverapproximation, good! %s" vals
     else if eq_kit_kit a r then
       Printf.eprintf "\nequal, perfection! %s" vals
     else
+      (* failwith ("\nUNDERAPPROXIMATION " ^ vals) *)
       Printf.eprintf "\noh, no, underapproximation! %s" vals
   in
+*)
 
   (* Check if the auction pointerfest kind of make sense. *)
   assert_liquidation_auction_invariants state.liquidation_auctions;

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -29,9 +29,9 @@ let compute_outstanding_dissonance (state: checker) : kit (* "real" *) * kit (* 
       )
       kit_zero
       state.burrows in
-  (* we should probably calculate this as relative difference
-   * (percentage), with the "real" as the base. For now just
-   * return the two values. *)
+  (* we should probably calculate this as relative difference with the "real"
+   * as the base. For now just return the two values and leave usage up to the
+   * caller. *)
   real, approximation
 
 let assert_checker_invariants (state: checker) : unit =

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -21,6 +21,7 @@ val entrypoint_touch : checker * unit -> (LigoOp.operation list * checker)
 val assert_checker_invariants : checker -> unit
 val touch_with_index : checker -> Ligo.nat -> (LigoOp.operation list * checker)
 val calculate_touch_reward : Ligo.timestamp -> kit
+val find_burrow : burrow_map -> burrow_id -> Burrow.burrow
 (**/**)
 
 (*****************************************************************************)

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -22,6 +22,7 @@ val assert_checker_invariants : checker -> unit
 val touch_with_index : checker -> Ligo.nat -> (LigoOp.operation list * checker)
 val calculate_touch_reward : Ligo.timestamp -> kit
 val find_burrow : burrow_map -> burrow_id -> Burrow.burrow
+val compute_outstanding_dissonance : checker -> kit (* "real" *) * kit (* approximation *)
 (**/**)
 
 (*****************************************************************************)

--- a/src/ligo.ml
+++ b/src/ligo.ml
@@ -47,6 +47,8 @@ module Big_map = struct
       )
       m
 
+  let mem (k: 'key) (m: ('key, 'value) big_map) = Option.is_some (find_opt k m)
+
   let get_and_update (k: 'key) (v: 'value option) (m: ('key, 'value) big_map): 'value option * ('key, 'value) big_map =
     let prev = find_opt k m in
     let m_ = update k v m in
@@ -61,7 +63,7 @@ module Big_map = struct
   let bindings i =
     IntMap.bindings i |> List.concat_map snd
 
-  let mem (k: 'key) (m: ('key, 'value) big_map) = Option.is_some (find_opt k m)
+  let fold f z m = List.fold_left f z (bindings m)
 end
 
 type ('k, 'v) map = ('k, 'v) big_map

--- a/src/ligo.mli
+++ b/src/ligo.mli
@@ -16,6 +16,7 @@ module Big_map : sig
 
   (* NON-LIGO *)
   val bindings : ('key, 'value) big_map -> ('key * 'value) list
+  val fold : ('acc -> ('key * 'value) -> 'acc) -> 'acc -> ('key, 'value) big_map -> 'acc
 end
 
 type ('key, 'value) map
@@ -24,11 +25,12 @@ module Map: sig
   val find_opt : 'key -> ('key, 'value) map -> 'value option
   val update : 'key -> 'value option -> ('key, 'value) map -> ('key, 'value) map
   val mem : 'key -> ('key, 'value) map -> bool
-  val add: 'key -> 'value -> ('key, 'value) big_map -> ('key, 'value) big_map
-  val remove: 'key -> ('key, 'value) big_map -> ('key, 'value) big_map
+  val add: 'key -> 'value -> ('key, 'value) map -> ('key, 'value) map
+  val remove: 'key -> ('key, 'value) map -> ('key, 'value) map
 
   (* NON-LIGO *)
   val bindings : ('key, 'value) map -> ('key * 'value) list
+  val fold : ('acc -> ('key * 'value) -> 'acc) -> 'acc -> ('key, 'value) map -> 'acc
 end
 (**
     The type of a map from values of type key to values of type value is map (key, value).


### PR DESCRIPTION
After some investigation I found out that underapproximations of the total outstanding kit are not all that uncommon, which justifies the need for #218. Here is a high-level example / regression test illustrating this.

Other items:
* Add `compute_outstanding_dissonance` to help identify underapproximations. This one will be useful for investigating #156 too.
* Remove the warnings on underapproximations in `checker.ml`; they are more common than I expected.
* Type signature fixes in `Ligo.Map` definitions.