### PR TITLE
Add a comment workflow

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,0 +1,93 @@
+name: Comment PR results
+
+# only run one instance at a time
+concurrency: bot-mutex
+
+on:
+  schedule:
+    - cron:  '0/10 * * * *'
+  workflow_dispatch: {}
+
+jobs:
+  mutate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cachix/install-nix-action@v13
+      - uses: actions/checkout@v2
+        with:
+           ref: 'ud/fix-bot' # TODO: remove before merging
+      - uses: cachix/cachix-action@v10
+        with:
+          name: tezos-checker
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: actions/github-script@v4.0.2
+        with:
+          script: |
+            const util = require('util');
+            const execFile = util.promisify(require('child_process').execFile);
+
+            const prs = (await github.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open"
+            })).data;
+            console.log(prs);
+
+            async function testsPassed(ref) {
+              const res = await github.request('GET /repos/{owner}/{repo}/commits/{ref}/status', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: ref
+              });
+              return res.state === "success";
+            }
+
+            async function commentExists(issue_number, marker) {
+              const cs = await github.issues.listComments({
+                owner,
+                repo,
+                issue_number,
+              })
+
+              return cs.find(comment =>
+                comment.body.includes(marker)
+              );
+            }
+
+            for (let i=0; i < prs.length; i++) {
+              const pr = prs[i];
+              console.log("Processing PR", pr.id);
+
+              const base = pr.base.sha;
+              const head = pr.head.sha;
+
+              // skip if the tests are pending or failed
+              if(!(await (testsPassed(base))) || !(await (testsPassed(head)))) {
+                console.log("Tests not successful, skipping.");
+                return;
+              }
+
+              // we append a hidden marker to the body, so the bot can recognize
+              // if it already has posted a message.
+              const marker = "bot:" + base + ":" + head;
+
+              // only run the job if there is no existing comment
+              if(await (commentExists(pr.id, marker))) {
+                console.log("Comment exists, skipping.");
+              } else {
+                const ret = await (execFile(
+                  "nix-shell",
+                  [ "--run"
+                  , "./scripts/artifacts.py compare-stats --previous " + pr.base.sha + " --next " + pr.head.sha
+                  ]
+                ));
+                console.log(ret);
+
+                github.issues.createComment({
+                  issue_number: pr.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: ret.stdout + "\n\n[hiddencomment]: " + marker
+                });
+              }
+            }

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -64,7 +64,7 @@ jobs:
               // skip if the tests are pending or failed
               if(!(await (testsPassed(base))) || !(await (testsPassed(head)))) {
                 console.log("Tests not successful, skipping.");
-                return;
+                continue;
               }
 
               // we append a hidden marker to the body, so the bot can recognize


### PR DESCRIPTION
This PR changes how our PR-commenter-bot-thing works.

Previously, it was a task running on `pull-request` events. This was causing multiple problems:

* Even though the workflow was triggered by `pull-request` events, it was looking at the artifacts of the `build` events, which was a bit unusual.
* Workflows triggered by `pull-request` events could finish before `build` events.
* There might even be cases where a previous commits finishes after a later one, which complicates things a bit.

Overall, I did not have a great experience with things happening tied to the events emitted. So I decided to follow a more declarative approach; where we have a task that:

1. Looks at open PR's
2. Checks if the tests have passed (both of the PR head and base commit)
3. Checks if it already posted a comment about that commit.
4. Otherwise calculates the diff, and sends a comment.

It'd be easy to modify the script to update/delete existing comments.

And here are some disadvantages:

1. It always runs the code on master.
2. It is a scheduled task (every 10 minutes), because the account the bot runs at does not have permission to trigger new workflows at the end of `pull-request` or `build` tasks (that was my initial plan). This is to avoid triggering recursive workflows, GitHub says. But the script does not enter our `nix-shell` unless necessary, so the frequent runs should be fast (it has to install Nix tho, so it'd still take a few minutes)

I tried it until line 68 and had to fix a ton of annoying errors in the process. Then I made it a cronjob instead, and that requires me to get the workflow in `master` in order to try the rest. So it is likely to break a few times in `master`, and then we should try to fix it there.