### PR TITLE
Remove references to mukit and mulqt 

### DIFF
--- a/docs/spec/cfmm.rst
+++ b/docs/spec/cfmm.rst
@@ -12,9 +12,9 @@ checker contract, and operations on it.
 State
 -----
 
--  ``ctez``: the total amount of ctez currently held by the cfmm contract (in muctez).
--  ``kit``: the total amount of kit currently held by the cfmm contract (in mukit).
--  ``lqt``: the total amount of liquidity held by the cfmm contract (in mulqt).
+-  ``ctez``: the total amount of ctez currently held by the cfmm contract.
+-  ``kit``: the total amount of kit currently held by the cfmm contract.
+-  ``lqt``: the total amount of liquidity held by the cfmm contract.
 
 Additional fields:
 
@@ -40,15 +40,15 @@ representation.
 Initialization
 --------------
 
-When the system starts, all parameters are set to one. Given that
-Checker gets deployed on the chain at level ``lvl``, we initialize the
-parameters thus:
+When the system starts, all parameters are set to the lowest non-zero amount.
+Given that Checker gets deployed on the chain at level ``lvl``, we initialize
+the parameters thus:
 
 ::
 
-   ctez                      = 1muctez
-   kit                       = 1mukit
-   lqt                       = 1mulqt
+   ctez                      = 1
+   kit                       = 1
+   lqt                       = 1
    kit_in_ctez_in_prev_block = 1     # same as kit/ctez now
    last_level                = lvl
 

--- a/docs/spec/functional_spec.rst
+++ b/docs/spec/functional_spec.rst
@@ -73,7 +73,7 @@ there is not enough collateral, or if the sender is not the burrow owner.
 +===============+=======================+=========================================================================+
 | id            | nat                   | The caller's ID for the burrow in which to mint the kit                 |
 +---------------+-----------------------+-------------------------------------------------------------------------+
-| amount        | nat                   | The amount of kit to mint, in mukit                                     |
+| amount        | nat                   | The amount of kit to mint                                               |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 
 
@@ -91,7 +91,7 @@ or if the sender is not the burrow owner.
 +===============+=======================+=========================================================================+
 | id            | nat                   | The caller's ID for the burrow in which to burn the kit                 |
 +---------------+-----------------------+-------------------------------------------------------------------------+
-| amount        | nat                   | The amount of kit to burn, in mukit                                     |
+| amount        | nat                   | The amount of kit to burn                                               |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 
 
@@ -169,7 +169,7 @@ desired amount of kit cannot be bought or if the deadline has passed.
 +===============+=======================+=========================================================================+
 | ctez          | nat                   | An amount of ctez to be sold for kit, in muctez                         |
 +---------------+-----------------------+-------------------------------------------------------------------------+
-| kit           | nat                   | The minimum amount of kit expected to be bought, in mukit               |
+| kit           | nat                   | The minimum amount of kit expected to be bought                         |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | deadline      | timestamp             | The deadline for the transaction to be valid                            |
 +---------------+-----------------------+-------------------------------------------------------------------------+
@@ -186,7 +186,7 @@ cannot be bought or if the deadline has passed.
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
 +===============+=======================+=========================================================================+
-| kit           | nat                   | The amount of kit to be sold, in mukit                                  |
+| kit           | nat                   | The amount of kit to be sold                                            |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | ctez          | nat                   | The minimum amount of ctez expected to be bought, in muctez             |
 +---------------+-----------------------+-------------------------------------------------------------------------+
@@ -209,7 +209,7 @@ liquidity tokens.
 +===============+=======================+=========================================================================+
 | ctez          | nat                   | The amount of ctez to supply as liquidity, in muctez                    |
 +---------------+-----------------------+-------------------------------------------------------------------------+
-| kit           | nat                   | The maximum amount of kit to supply as liquidity, in mukit              |
+| kit           | nat                   | The maximum amount of kit to supply as liquidity                        |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | min_tokens    | nat                   | The minimum number of liquidity tokens expected to be bought, in mulqt  |
 +---------------+-----------------------+-------------------------------------------------------------------------+
@@ -232,7 +232,7 @@ ratio.
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | ctez          | nat                   | The minimum amount of ctez expected, in muctez                          |
 +---------------+-----------------------+-------------------------------------------------------------------------+
-| kit           | nat                   | The minimum amount of kit expected, in mukit                            |
+| kit           | nat                   | The minimum amount of kit expected                                      |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | deadline      | timestamp             | The deadline for the transaction to be valid                            |
 +---------------+-----------------------+-------------------------------------------------------------------------+
@@ -329,7 +329,7 @@ Estimate yield when buying kit with ctez
 
 ``buy_kit_min_kit_expected : nat -> nat``
 
-Get the maximum amount (in ``mukit``) that can be expected for the given amount of ctez, based on the current market price
+Get the maximum amount of kit that can be expected for the given amount of ctez, based on the current market price
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
@@ -347,7 +347,7 @@ Get the maximum amount (in ``muctez``) that can be expected for the given amount
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
 +===============+=======================+=========================================================================+
-| kit           | nat                   | The amount of kit, in mukit                                             |
+| kit           | nat                   | The amount of kit                                                       |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 
 Estimate kit requirements when adding liquidity
@@ -355,7 +355,7 @@ Estimate kit requirements when adding liquidity
 
 ``add_liquidity_max_kit_deposited : nat -> nat``
 
-Get the minimum amount (in ``mukit``) that needs to be deposited when adding liquidity for the given amount of ctez, based on the current market price
+Get the minimum amount of kit that needs to be deposited when adding liquidity for the given amount of ctez, based on the current market price
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
@@ -394,7 +394,7 @@ Estimate kit yield when removing liquidity
 
 ``remove_liquidity_min_kit_withdrawn : nat -> nat``
 
-Get the maximum amount of kit (in ``mukit``) that can be expected for the given amount of liquidity token, based on the current market price
+Get the maximum amount of kit that can be expected for the given amount of liquidity token, based on the current market price
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
@@ -408,7 +408,7 @@ Find maximum kit that can be minted
 
 ``burrow_max_mintable_kit : nat -> nat``
 
-Returns the maximum amount (in ``mukit``) that can be minted from the given burrow.
+Returns the maximum amount of kit that can be minted from the given burrow.
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
@@ -443,7 +443,7 @@ Minimum bid for the current liquidation auction (if exists)
 
 ``current_liquidation_auction_minimum_bid : unit -> pair nat nat``
 
-Returns a pair of an identifier to the current auction and a `mukit` amount.
+Returns a pair of an identifier to the current auction and an amount of kit.
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |

--- a/docs/spec/functional_spec.rst
+++ b/docs/spec/functional_spec.rst
@@ -211,7 +211,7 @@ liquidity tokens.
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | kit           | nat                   | The maximum amount of kit to supply as liquidity                        |
 +---------------+-----------------------+-------------------------------------------------------------------------+
-| min_tokens    | nat                   | The minimum number of liquidity tokens expected to be bought, in mulqt  |
+| min_tokens    | nat                   | The minimum number of liquidity tokens expected to be bought            |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | deadline      | timestamp             | The deadline for the transaction to be valid                            |
 +---------------+-----------------------+-------------------------------------------------------------------------+
@@ -228,7 +228,7 @@ ratio.
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
 +===============+=======================+=========================================================================+
-| amount        | nat                   | The number of liquidity tokens to redeem, in mulqt                      |
+| amount        | nat                   | The number of liquidity tokens to redeem                                |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | ctez          | nat                   | The minimum amount of ctez expected, in muctez                          |
 +---------------+-----------------------+-------------------------------------------------------------------------+
@@ -368,7 +368,7 @@ Estimate yield when adding liquidity
 
 ``add_liquidity_min_lqt_minted : nat -> nat``
 
-Get the maximum amount of the liquidity token (in ``mulqt``) that can be expected for the given amount of ctez, based on the current market price
+Get the maximum amount of the liquidity token that can be expected for the given amount of ctez, based on the current market price
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
@@ -386,7 +386,7 @@ Get the maximum amount of ctez (in ``muctez``) that can be expected for the give
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
 +===============+=======================+=========================================================================+
-| liquidity     | nat                   | The amount of liquidity token, in mulqt                                 |
+| liquidity     | nat                   | The amount of liquidity token                                           |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 
 Estimate kit yield when removing liquidity
@@ -399,7 +399,7 @@ Get the maximum amount of kit that can be expected for the given amount of liqui
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
 +===============+=======================+=========================================================================+
-| liquidity     | nat                   | The amount of liquidity token, in mulqt                                 |
+| liquidity     | nat                   | The amount of liquidity token                                           |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 
 

--- a/docs/spec/system-parameters.rst
+++ b/docs/spec/system-parameters.rst
@@ -41,8 +41,8 @@ We currently initialize checker with the following parameters:
    target = 1
    drift = 0
    drift_derivative = 0
-   outstanding_kit = 0mukit
-   circulating_kit = 0mukit
+   outstanding_kit = 0kit
+   circulating_kit = 0kit
    last_touched = now
    burrow_fee_index = 1
    imbalance_index  = 1

--- a/src/burrow.ml
+++ b/src/burrow.ml
@@ -67,7 +67,7 @@ let burrow_touch (p: parameters) (burrow: burrow) : burrow =
         outstanding_kit =
           kit_of_fraction_floor
             (Ligo.mul_nat_int
-               (kit_to_mukit_nat burrow.outstanding_kit)
+               (kit_to_denomination_nat burrow.outstanding_kit)
                (fixedpoint_to_raw current_adjustment_index)
             )
             (Ligo.mul_int_int
@@ -314,7 +314,7 @@ let compute_tez_to_auction (p: parameters) (b: burrow) : Ligo.int =
                num_fm
                (Ligo.mul_int_nat
                   num_mp
-                  (kit_to_mukit_nat b.outstanding_kit)
+                  (kit_to_denomination_nat b.outstanding_kit)
                )
             )
          )
@@ -381,7 +381,7 @@ let burrow_is_liquidatable (p: parameters) (b: burrow) : bool =
     let { num = num_ek; den = den_ek; } = compute_expected_kit p b.collateral_at_auction in
     { num =
         Ligo.sub_int_int
-          (Ligo.mul_nat_int (kit_to_mukit_nat b.outstanding_kit) den_ek)
+          (Ligo.mul_nat_int (kit_to_denomination_nat b.outstanding_kit) den_ek)
           (Ligo.mul_int_int kit_scaling_factor_int num_ek);
       den = Ligo.mul_int_int kit_scaling_factor_int den_ek;
     } in
@@ -411,7 +411,7 @@ let burrow_is_cancellation_warranted (p: parameters) (b: burrow) (slice_tez: Lig
       compute_expected_kit p (Ligo.sub_tez_tez b.collateral_at_auction slice_tez) in
     { num =
         Ligo.sub_int_int
-          (Ligo.mul_nat_int (kit_to_mukit_nat b.outstanding_kit) den_ek)
+          (Ligo.mul_nat_int (kit_to_denomination_nat b.outstanding_kit) den_ek)
           (Ligo.mul_int_int kit_scaling_factor_int num_ek);
       den = Ligo.mul_int_int kit_scaling_factor_int den_ek;
     } in
@@ -452,7 +452,7 @@ let[@inline] compute_min_kit_for_unwarranted (p: parameters) (b: burrow) (tez_to
         Ligo.mul_int_int
           (Ligo.mul_int_int (tez_to_mutez tez_to_auction) num_fl)
           (Ligo.sub_int_int
-             (Ligo.mul_int_nat den_ek (kit_to_mukit_nat b.outstanding_kit))
+             (Ligo.mul_int_nat den_ek (kit_to_denomination_nat b.outstanding_kit))
              (Ligo.mul_int_int kit_scaling_factor_int num_ek)
           ) in
       max_int (Ligo.int_from_literal "0") numerator in
@@ -607,7 +607,7 @@ let burrow_is_optimistically_overburrowed (p: parameters) (b: burrow) : bool =
       num_fm
       (Ligo.mul_int_int
          (Ligo.sub_int_int
-            (Ligo.mul_nat_int (kit_to_mukit_nat b.outstanding_kit) den_ek)
+            (Ligo.mul_nat_int (kit_to_denomination_nat b.outstanding_kit) den_ek)
             (Ligo.mul_int_int kit_scaling_factor_int num_ek)
          )
          (Ligo.mul_int_int num_mp (Ligo.int_from_literal "1_000_000"))

--- a/src/burrow.ml
+++ b/src/burrow.ml
@@ -124,7 +124,7 @@ let[@inline] undercollateralization_condition (f: ratio) (price: ratio) (tez: ra
 let burrow_is_overburrowed (p: parameters) (b: burrow) : bool =
   assert (p.last_touched = b.last_checker_timestamp);
   let tez = { num = tez_to_mutez b.collateral; den = Ligo.int_from_literal "1_000_000"; } in
-  let kit = { num = kit_to_mukit_int b.outstanding_kit; den = kit_scaling_factor_int; } in
+  let kit = { num = kit_to_denomination_int b.outstanding_kit; den = kit_scaling_factor_int; } in
   undercollateralization_condition fminting (minting_price p) tez kit
 
 (*  max_kit_outstanding = FLOOR (tez_collateral / (fminting * minting_price)) *)

--- a/src/burrow.ml
+++ b/src/burrow.ml
@@ -439,7 +439,7 @@ let[@inline] compute_min_kit_for_unwarranted (p: parameters) (b: burrow) (tez_to
 
   if b.collateral = Ligo.tez_from_literal "0mutez" (* NOTE: division by zero. *)
   then
-    if not (eq_kit_kit b.outstanding_kit (kit_of_mukit (Ligo.nat_from_literal "0n")))
+    if not (eq_kit_kit b.outstanding_kit (kit_of_denomination (Ligo.nat_from_literal "0n")))
     then (None: kit option) (* (a): infinity, basically *)
     else (Some kit_zero) (* (b): zero *)
   else

--- a/src/cfmm.ml
+++ b/src/cfmm.ml
@@ -172,7 +172,7 @@ let cfmm_view_max_kit_deposited_min_lqt_minted_cfmm_add_liquidity
         (Ligo.mul_int_nat lqt_scaling_factor_int cfmm_ctez) in
     let kit_deposited =
       kit_of_fraction_ceil
-        (Ligo.mul_int_nat (kit_to_mukit_int cfmm.kit) (ctez_to_muctez_nat ctez_amount))
+        (Ligo.mul_int_nat (kit_to_denomination_int cfmm.kit) (ctez_to_muctez_nat ctez_amount))
         (Ligo.mul_int_nat kit_scaling_factor_int cfmm_ctez) in
     (* Since (a) ctez_amount > 0, (b) cfmm.kit > 0, and (c) we ceil when
      * computing kit_deposited, it should be impossible to trigger the
@@ -246,7 +246,7 @@ let cfmm_view_min_ctez_withdrawn_min_kit_withdrawn_cfmm_remove_liquidity
     in
     let kit_withdrawn =
       kit_of_fraction_floor
-        (Ligo.mul_int_nat (kit_to_mukit_int cfmm.kit) (lqt_to_denomination_nat lqt_burned))
+        (Ligo.mul_int_nat (kit_to_denomination_int cfmm.kit) (lqt_to_denomination_nat lqt_burned))
         (Ligo.mul_int_nat kit_scaling_factor_int (lqt_to_denomination_nat cfmm.lqt))
     in
     (* Since (a) 0 < lqt_burned < cfmm.lqt, and (b) we floor for both the kit

--- a/src/cfmm.ml
+++ b/src/cfmm.ml
@@ -37,7 +37,7 @@ let cfmm_sync_last_observed (cfmm: cfmm) : cfmm =
       kit_in_ctez_in_prev_block =
         make_ratio
           (Ligo.mul_nat_int (ctez_to_muctez_nat cfmm.ctez) kit_scaling_factor_int)
-          (Ligo.mul_nat_int (kit_to_mukit_nat cfmm.kit) (Ligo.int_from_literal "1_000_000"));
+          (Ligo.mul_nat_int (kit_to_denomination_nat cfmm.kit) (Ligo.int_from_literal "1_000_000"));
       last_level = !Ligo.Tezos.level;
     }
 
@@ -60,7 +60,7 @@ let cfmm_view_min_kit_expected_buy_kit
     let numerator =
       Ligo.mul_nat_int
         (ctez_to_muctez_nat ctez_amount)
-        (Ligo.mul_nat_int (kit_to_mukit_nat cfmm.kit) num_uf) in
+        (Ligo.mul_nat_int (kit_to_denomination_nat cfmm.kit) num_uf) in
     let denominator =
       Ligo.mul_int_int
         kit_scaling_factor_int
@@ -116,12 +116,12 @@ let cfmm_view_min_ctez_expected_cfmm_sell_kit
     let new_cfmm_kit = kit_add cfmm.kit kit_amount in
     let numerator =
       Ligo.mul_nat_int
-        (kit_to_mukit_nat kit_amount)
+        (kit_to_denomination_nat kit_amount)
         (Ligo.mul_nat_int (ctez_to_muctez_nat cfmm.ctez) num_uf) in
     let denominator =
       Ligo.mul_int_int
         (Ligo.int_from_literal "1_000_000")
-        (Ligo.mul_nat_int (kit_to_mukit_nat new_cfmm_kit) den_uf) in
+        (Ligo.mul_nat_int (kit_to_denomination_nat new_cfmm_kit) den_uf) in
     let bought_ctez = ctez_of_fraction_floor numerator denominator in
 
     (* Due to (a) the constant-factor calculation (which means that to deplete

--- a/src/cfmmTypes.ml
+++ b/src/cfmmTypes.ml
@@ -23,7 +23,7 @@ type cfmm =
     all division-by-zero checks. *)
 let initial_cfmm () : cfmm =
   { ctez = ctez_of_muctez (Ligo.nat_from_literal "1n");
-    kit = kit_of_mukit (Ligo.nat_from_literal "1n");
+    kit = kit_of_denomination (Ligo.nat_from_literal "1n");
     lqt = lqt_of_denomination (Ligo.nat_from_literal "1n");
     kit_in_ctez_in_prev_block = one_ratio; (* Same as ctez/kit now. *)
     last_level = !Ligo.Tezos.level;

--- a/src/cfmmTypes.ml
+++ b/src/cfmmTypes.ml
@@ -16,11 +16,11 @@ type cfmm =
 
 [@@@coverage on]
 
-(** The initial state of the cfmm contract. We always start with 1mukit,
-    1muctez, and 1lqt token (effectively setting the starting price to 1
-    ctez/kit). The price will eventually reach the value it should, but this
-    saves us from having the first/non-first liquidity provider separation, and
-    all division-by-zero checks. *)
+(** The initial state of the cfmm contract. We always start with the lowest
+    denomination of kit, ctez, and liquidity tokens (effectively setting the
+    starting price to 1 ctez/kit). The price will eventually reach the value it
+    should, but this saves us from having the first/non-first liquidity
+    provider separation, and all division-by-zero checks. *)
 let initial_cfmm () : cfmm =
   { ctez = ctez_of_muctez (Ligo.nat_from_literal "1n");
     kit = kit_of_denomination (Ligo.nat_from_literal "1n");

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -391,7 +391,7 @@ let touch_liquidation_slice
   let slice_kit, kit_to_repay, kit_to_burn =
     let corresponding_kit =
       kit_of_fraction_floor
-        (Ligo.mul_int_nat (tez_to_mutez slice.tez) (kit_to_mukit_nat outcome.winning_bid.kit))
+        (Ligo.mul_int_nat (tez_to_mutez slice.tez) (kit_to_denomination_nat outcome.winning_bid.kit))
         (Ligo.mul_int_int (tez_to_mutez outcome.sold_tez) kit_scaling_factor_int)
     in
     let penalty =
@@ -402,7 +402,7 @@ let touch_liquidation_slice
         | Some min_kit_for_unwarranted -> lt_kit_kit corresponding_kit min_kit_for_unwarranted in
       if liquidation_was_warranted then
         kit_of_fraction_ceil
-          (Ligo.mul_nat_int (kit_to_mukit_nat corresponding_kit) num_lp)
+          (Ligo.mul_nat_int (kit_to_denomination_nat corresponding_kit) num_lp)
           (Ligo.mul_int_int kit_scaling_factor_int den_lp)
       else
         kit_zero
@@ -979,7 +979,7 @@ let view_get_balance ((owner, token_id), state: (Ligo.address * fa2_token_id) * 
 let view_total_supply (token_id, state: fa2_token_id * checker) : Ligo.nat =
   assert_checker_invariants state;
   if token_id = kit_token_id then
-    kit_to_mukit_nat state.parameters.circulating_kit
+    kit_to_denomination_nat state.parameters.circulating_kit
   else if token_id = lqt_token_id then
     lqt_to_denomination_nat (lqt_sub state.cfmm.lqt (lqt_of_denomination (Ligo.nat_from_literal "1n")))
   else

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -44,7 +44,7 @@ let assert_checker_invariants (state: checker) : unit =
    * phantom kit token in the cfmm) is at least as much as the total kit in the
    * cfmm. Of course there can be more, e.g., from pending bids, or because of
    * imperfect liquidations. *)
-  assert (geq_kit_kit (kit_add (kit_of_mukit (fa2_get_balance (state.fa2_state, !Ligo.Tezos.self_address, kit_token_id))) (kit_of_mukit (Ligo.nat_from_literal "1n"))) state.cfmm.kit);
+  assert (geq_kit_kit (kit_add (kit_of_denomination (fa2_get_balance (state.fa2_state, !Ligo.Tezos.self_address, kit_token_id))) (kit_of_denomination (Ligo.nat_from_literal "1n"))) state.cfmm.kit);
   (* Check that the total number of liquidity tokens tracked on the fa2 ledger
    * is consistent with (i.e., 1 token less than - because of the phantom lqt
    * token in the cfmm) the total number of liquidity tokens in the cfmm. *)

--- a/src/fa2Interface.ml
+++ b/src/fa2Interface.ml
@@ -348,7 +348,7 @@ let fa2_get_token_balance (st: fa2_state) (token_id: fa2_token_id): Ligo.nat =
   |> List.map (fun ((_id, _owner), amnt) -> amnt)
   |> List.fold_left (fun x y -> Ligo.add_nat_nat x y) (Ligo.nat_from_literal "0n")
 
-let fa2_get_total_kit_balance (st: fa2_state) : kit = kit_of_mukit (fa2_get_token_balance st kit_token_id)
+let fa2_get_total_kit_balance (st: fa2_state) : kit = kit_of_denomination (fa2_get_token_balance st kit_token_id)
 let fa2_get_total_lqt_balance (st: fa2_state) : lqt = lqt_of_denomination (fa2_get_token_balance st lqt_token_id)
 
 let get_kit_credits_from_fa2_state (st: fa2_state) : ((Ligo.address * Ligo.nat) list) =

--- a/src/fa2Interface.ml
+++ b/src/fa2Interface.ml
@@ -318,15 +318,15 @@ let[@inline] fa2_run_transfer
 
 let[@inline] ledger_issue_kit
     (st, addr, amnt: fa2_state * Ligo.address * kit) : fa2_state =
-  ledger_issue (st, kit_token_id, addr, kit_to_mukit_nat amnt)
+  ledger_issue (st, kit_token_id, addr, kit_to_denomination_nat amnt)
 
 let[@inline] ledger_withdraw_kit
     (st, addr, amnt: fa2_state * Ligo.address * kit) : fa2_state =
-  ledger_withdraw (st, kit_token_id, addr, kit_to_mukit_nat amnt)
+  ledger_withdraw (st, kit_token_id, addr, kit_to_denomination_nat amnt)
 
 let[@inline] ledger_issue_then_withdraw_kit
     (st, addr, amnt_to_issue, amnt_to_withdraw: fa2_state * Ligo.address * kit * kit) : fa2_state =
-  ledger_issue_then_withdraw (st, kit_token_id, addr, kit_to_mukit_nat amnt_to_issue, kit_to_mukit_nat amnt_to_withdraw)
+  ledger_issue_then_withdraw (st, kit_token_id, addr, kit_to_denomination_nat amnt_to_issue, kit_to_denomination_nat amnt_to_withdraw)
 
 let[@inline] ledger_issue_lqt
     (st, addr, amnt: fa2_state * Ligo.address * lqt) : fa2_state =

--- a/src/kit.ml
+++ b/src/kit.ml
@@ -23,7 +23,7 @@ let[@inline] kit_one = kit_scaling_factor_nat
 
 (* Conversions to/from other types. *)
 let[@inline] kit_of_mukit (amnt: Ligo.nat) : kit = amnt
-let[@inline] kit_to_mukit_int (amnt: kit) : Ligo.int = Ligo.int amnt
+let[@inline] kit_to_denomination_int (amnt: kit) : Ligo.int = Ligo.int amnt
 let[@inline] kit_to_denomination_nat (amnt: kit) : Ligo.nat = amnt
 
 let kit_of_fraction_ceil (x_num: Ligo.int) (x_den: Ligo.int) : kit =

--- a/src/kit.ml
+++ b/src/kit.ml
@@ -56,7 +56,20 @@ let[@inline] kit_to_ratio (amnt: kit) : ratio = make_ratio (Ligo.int amnt) kit_s
 
 let kit_compare x y = compare_nat x y
 
-let show_kit amnt = Ligo.string_of_nat amnt ^ "mukit"
+let show_kit amnt =
+  let zfill s width = match Stdlib.(width - (String.length s)) with
+    | to_fill when to_fill <= 0 -> s
+    | to_fill -> (String.make to_fill '0') ^ s
+  in
+  let as_string =
+    if kit_decimal_digits = Ligo.nat_from_literal "0n" then
+      Ligo.string_of_nat amnt
+    else
+      let d, r = Option.get (Ligo.ediv_nat_nat amnt kit_scaling_factor_nat) in
+      let kit_decimal_digits = Stdlib.int_of_string (Ligo.string_of_nat kit_decimal_digits) in (* little hacky *)
+      (Ligo.string_of_nat d) ^ "." ^ zfill (Ligo.string_of_nat r) kit_decimal_digits
+  in as_string ^ "kit"
+
 let pp_kit ppf amnt = Format.fprintf ppf "%s" (show_kit amnt)
 
 [@@@coverage on]

--- a/src/kit.ml
+++ b/src/kit.ml
@@ -24,7 +24,7 @@ let[@inline] kit_one = kit_scaling_factor_nat
 (* Conversions to/from other types. *)
 let[@inline] kit_of_mukit (amnt: Ligo.nat) : kit = amnt
 let[@inline] kit_to_mukit_int (amnt: kit) : Ligo.int = Ligo.int amnt
-let[@inline] kit_to_mukit_nat (amnt: kit) : Ligo.nat = amnt
+let[@inline] kit_to_denomination_nat (amnt: kit) : Ligo.nat = amnt
 
 let kit_of_fraction_ceil (x_num: Ligo.int) (x_den: Ligo.int) : kit =
   assert (Ligo.gt_int_int x_den (Ligo.int_from_literal "0"));

--- a/src/kit.ml
+++ b/src/kit.ml
@@ -22,7 +22,7 @@ let[@inline] kit_zero = Ligo.nat_from_literal "0n"
 let[@inline] kit_one = kit_scaling_factor_nat
 
 (* Conversions to/from other types. *)
-let[@inline] kit_of_mukit (amnt: Ligo.nat) : kit = amnt
+let[@inline] kit_of_denomination (amnt: Ligo.nat) : kit = amnt
 let[@inline] kit_to_denomination_int (amnt: kit) : Ligo.int = Ligo.int amnt
 let[@inline] kit_to_denomination_nat (amnt: kit) : Ligo.nat = amnt
 

--- a/src/kit.mli
+++ b/src/kit.mli
@@ -18,7 +18,7 @@ val kit_scaling_factor_nat : Ligo.nat
 
 (* Conversions to/from other types. *)
 val kit_of_mukit : Ligo.nat -> kit
-val kit_to_mukit_int : kit -> Ligo.int
+val kit_to_denomination_int : kit -> Ligo.int
 val kit_to_denomination_nat : kit -> Ligo.nat
 
 val kit_of_fraction_ceil : Ligo.int -> Ligo.int -> kit

--- a/src/kit.mli
+++ b/src/kit.mli
@@ -17,7 +17,7 @@ val kit_scaling_factor_int : Ligo.int
 val kit_scaling_factor_nat : Ligo.nat
 
 (* Conversions to/from other types. *)
-val kit_of_mukit : Ligo.nat -> kit
+val kit_of_denomination : Ligo.nat -> kit
 val kit_to_denomination_int : kit -> Ligo.int
 val kit_to_denomination_nat : kit -> Ligo.nat
 

--- a/src/kit.mli
+++ b/src/kit.mli
@@ -19,7 +19,7 @@ val kit_scaling_factor_nat : Ligo.nat
 (* Conversions to/from other types. *)
 val kit_of_mukit : Ligo.nat -> kit
 val kit_to_mukit_int : kit -> Ligo.int
-val kit_to_mukit_nat : kit -> Ligo.nat
+val kit_to_denomination_nat : kit -> Ligo.nat
 
 val kit_of_fraction_ceil : Ligo.int -> Ligo.int -> kit
 val kit_of_fraction_floor : Ligo.int -> Ligo.int -> kit

--- a/src/liquidationAuction.ml
+++ b/src/liquidationAuction.ml
@@ -317,7 +317,7 @@ let start_liquidation_auction_if_possible
   * dropping). For a descending auction we should improve upon the last bid
   * a fixed factor. *)
 let liquidation_auction_current_auction_minimum_bid (auction: current_liquidation_auction) : kit =
-  kit_max (kit_of_mukit (Ligo.nat_from_literal "1n"))
+  kit_max (kit_of_denomination (Ligo.nat_from_literal "1n"))
     (match auction.state with
      | Descending (start_value, start_time) ->
        let auction_decay_rate = fixedpoint_of_ratio_ceil auction_decay_rate in

--- a/src/liquidationAuction.ml
+++ b/src/liquidationAuction.ml
@@ -221,7 +221,7 @@ let split_liquidation_slice_contents (amnt: Ligo.tez) (contents: liquidation_sli
     match contents_min_kit_for_unwarranted with
     | None -> ((None: kit option), (None: kit option))
     | Some contents_min_kit_for_unwarranted ->
-      let min_kit_for_unwarranted = kit_to_mukit_nat contents_min_kit_for_unwarranted in
+      let min_kit_for_unwarranted = kit_to_denomination_nat contents_min_kit_for_unwarranted in
       let lkit =
         kit_of_fraction_ceil
           (Ligo.mul_nat_int min_kit_for_unwarranted (tez_to_mutez ltez))

--- a/src/parameters.ml
+++ b/src/parameters.ml
@@ -81,8 +81,8 @@ let liquidation_price (p: parameters) : ratio =
         saturate the imbalance to -imbalance_limit.
 *)
 let[@inline] compute_imbalance (outstanding: kit) (circulating: kit) : ratio =
-  let outstanding = kit_to_mukit_nat outstanding in
-  let circulating = kit_to_mukit_nat circulating in
+  let outstanding = kit_to_denomination_nat outstanding in
+  let circulating = kit_to_denomination_nat circulating in
   let { num = num_il; den = den_il; } = imbalance_limit in
 
   if (Ligo.eq_nat_nat circulating (Ligo.nat_from_literal "0n"))
@@ -379,7 +379,7 @@ let[@inline] compute_current_imbalance_index (last_outstanding_kit: kit) (last_c
 *)
 let[@inline] compute_current_outstanding_with_fees (last_outstanding_kit: kit) (last_burrow_fee_index: fixedpoint) (current_burrow_fee_index: fixedpoint) : kit =
   kit_of_fraction_floor
-    (Ligo.mul_nat_int (kit_to_mukit_nat last_outstanding_kit) (fixedpoint_to_raw current_burrow_fee_index))
+    (Ligo.mul_nat_int (kit_to_denomination_nat last_outstanding_kit) (fixedpoint_to_raw current_burrow_fee_index))
     (Ligo.mul_int_int kit_scaling_factor_int (fixedpoint_to_raw last_burrow_fee_index))
 
 (** Compute current outstanding kit, given that the burrow fees have already
@@ -392,7 +392,7 @@ let[@inline] compute_current_outstanding_with_fees (last_outstanding_kit: kit) (
 *)
 let[@inline] compute_current_outstanding_kit (current_outstanding_with_fees: kit) (last_imbalance_index: fixedpoint) (current_imbalance_index: fixedpoint) : kit =
   kit_of_fraction_floor
-    (Ligo.mul_nat_int (kit_to_mukit_nat current_outstanding_with_fees) (fixedpoint_to_raw current_imbalance_index))
+    (Ligo.mul_nat_int (kit_to_denomination_nat current_outstanding_with_fees) (fixedpoint_to_raw current_imbalance_index))
     (Ligo.mul_int_int kit_scaling_factor_int (fixedpoint_to_raw last_imbalance_index))
 
 (** Update the checker's parameters, given (a) the current timestamp

--- a/tests/testArbitrary.ml
+++ b/tests/testArbitrary.ml
@@ -34,8 +34,8 @@ let arb_positive_ctez = QCheck.map (fun x -> ctez_of_muctez (Ligo.nat_from_liter
 
 let arb_address = QCheck.map Ligo.address_of_string QCheck.(string_of_size (Gen.return 36))
 
-let arb_kit = QCheck.map (fun x -> kit_of_mukit (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(0 -- max_int)
-let arb_positive_kit = QCheck.map (fun x -> kit_of_mukit (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(1 -- max_int)
+let arb_kit = QCheck.map (fun x -> kit_of_denomination (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(0 -- max_int)
+let arb_positive_kit = QCheck.map (fun x -> kit_of_denomination (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(1 -- max_int)
 
 let arb_lqt = QCheck.map (fun x -> lqt_of_denomination (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(0 -- max_int)
 let arb_positive_lqt = QCheck.map (fun x -> lqt_of_denomination (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(1 -- max_int)

--- a/tests/testAvlModel.ml
+++ b/tests/testAvlModel.ml
@@ -39,7 +39,7 @@ let tez_gen : Ligo.tez QCheck.Gen.t = QCheck.Gen.(
   )
 
 let kit_gen = QCheck.Gen.(
-    map (fun x -> Kit.kit_of_mukit (Ligo.nat_from_literal (string_of_int x ^ "n"))) (0 -- max_int)
+    map (fun x -> Kit.kit_of_denomination (Ligo.nat_from_literal (string_of_int x ^ "n"))) (0 -- max_int)
   )
 
 let slice_gen = QCheck.Gen.(

--- a/tests/testBurrow.ml
+++ b/tests/testBurrow.ml
@@ -24,7 +24,7 @@ let make_test_burrow ~outstanding_kit ~collateral ~active = Burrow.make_burrow_f
 (* A burrow with fixed parameters which was last touched at 0s. Use for tests which check
  * that functions requiring a burrow to be recently touched fail as expected. *)
 let burrow_for_needs_touch_tests = make_test_burrow
-    ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "0n"))
+    ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "0n"))
     ~collateral:(Ligo.tez_from_literal "0mutez")
     ~active:true
 
@@ -35,7 +35,7 @@ let suite =
        let _ =
          Burrow.burrow_burn_kit
            {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           (kit_of_denomination (Ligo.nat_from_literal "1n"))
            burrow_for_needs_touch_tests
        in ()
     );
@@ -43,11 +43,11 @@ let suite =
     ("burrow_burn_kit - burning exactly outstanding_kit returns burrow with expected outstanding kit" >::
      fun _ ->
        let burrow0 = make_test_burrow
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~collateral:(Ligo.tez_from_literal "0mutez") in
 
-       let kit_to_burn = kit_of_mukit (Ligo.nat_from_literal "1n") in
+       let kit_to_burn = kit_of_denomination (Ligo.nat_from_literal "1n") in
        let burrow, actual_burned = Burrow.burrow_burn_kit Parameters.initial_parameters kit_to_burn burrow0 in
 
        assert_kit_equal ~expected:kit_zero ~real:(Burrow.burrow_outstanding_kit burrow);
@@ -57,42 +57,42 @@ let suite =
     ("burrow_burn_kit - burning greater than outstanding_kit returns burrow with expected outstanding kit" >::
      fun _ ->
        let burrow0 = make_test_burrow
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~collateral:(Ligo.tez_from_literal "0mutez") in
 
-       let kit_to_burn = kit_of_mukit (Ligo.nat_from_literal "2n") in
+       let kit_to_burn = kit_of_denomination (Ligo.nat_from_literal "2n") in
        let burrow, actual_burned = Burrow.burrow_burn_kit Parameters.initial_parameters kit_to_burn burrow0 in
 
        assert_kit_equal ~expected:kit_zero ~real:(Burrow.burrow_outstanding_kit burrow);
-       assert_kit_equal ~expected:(kit_of_mukit (Ligo.nat_from_literal "1n")) ~real:actual_burned
+       assert_kit_equal ~expected:(kit_of_denomination (Ligo.nat_from_literal "1n")) ~real:actual_burned
     );
 
     ("burrow_burn_kit - burning less than outstanding_kit returns burrow with expected outstanding kit" >::
      fun _ ->
        let burrow0 = make_test_burrow
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "2n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "2n"))
            ~active:true
            ~collateral:(Ligo.tez_from_literal "0mutez") in
 
-       let kit_to_burn = kit_of_mukit (Ligo.nat_from_literal "1n") in
+       let kit_to_burn = kit_of_denomination (Ligo.nat_from_literal "1n") in
        let burrow, actual_burned = Burrow.burrow_burn_kit Parameters.initial_parameters kit_to_burn burrow0 in
 
-       assert_kit_equal ~expected:(kit_of_mukit (Ligo.nat_from_literal "1n")) ~real:(Burrow.burrow_outstanding_kit burrow);
+       assert_kit_equal ~expected:(kit_of_denomination (Ligo.nat_from_literal "1n")) ~real:(Burrow.burrow_outstanding_kit burrow);
        assert_kit_equal ~expected:kit_to_burn ~real:actual_burned
     );
 
     ("burrow_burn_kit - burning zero kit returns burrow with expected outstanding kit" >::
      fun _ ->
        let burrow0 = make_test_burrow
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~collateral:(Ligo.tez_from_literal "0mutez") in
 
        let kit_to_burn = kit_zero in
        let burrow, actual_burned = Burrow.burrow_burn_kit Parameters.initial_parameters kit_to_burn burrow0 in
 
-       assert_kit_equal ~expected:(kit_of_mukit (Ligo.nat_from_literal "1n")) ~real:(Burrow.burrow_outstanding_kit burrow);
+       assert_kit_equal ~expected:(kit_of_denomination (Ligo.nat_from_literal "1n")) ~real:(Burrow.burrow_outstanding_kit burrow);
        assert_kit_equal ~expected:kit_to_burn ~real:actual_burned
     );
 
@@ -103,7 +103,7 @@ let suite =
            ~active:true
            ~collateral:(Ligo.tez_from_literal "0mutez") in
 
-       let burrow, _actual_burned = Burrow.burrow_burn_kit Parameters.initial_parameters (kit_of_mukit (Ligo.nat_from_literal "1n")) burrow0 in
+       let burrow, _actual_burned = Burrow.burrow_burn_kit Parameters.initial_parameters (kit_of_denomination (Ligo.nat_from_literal "1n")) burrow0 in
 
        assert_address_equal
          ~expected:(Burrow.burrow_address burrow0)
@@ -147,7 +147,7 @@ let suite =
     ("burrow_deposit_tez - burrow after successful deposit has expected collateral" >::
      fun _ ->
        let burrow0 = make_test_burrow
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~collateral:(Ligo.tez_from_literal "100mutez") in
 
@@ -188,7 +188,7 @@ let suite =
     ("burrow_withdraw_tez - burrow after successful withdrawal has expected collateral" >::
      fun _ ->
        let burrow0 = make_test_burrow
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~collateral:(Ligo.tez_from_literal "100mutez") in
 
@@ -219,7 +219,7 @@ let suite =
     ("burrow_withdraw_tez - fails if withdrawal would overburrow the burrow" >::
      fun _ ->
        let burrow0 = make_test_burrow
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "4n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "4n"))
            ~active:true
            ~collateral:(Ligo.tez_from_literal "10mutez") in
 
@@ -238,17 +238,17 @@ let suite =
     ("burrow_mint_kit - burrow after successful minting has expected collateral" >::
      fun _ ->
        let burrow0 = make_test_burrow
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~collateral:(Ligo.tez_from_literal "100mutez") in
 
        let burrow = Burrow.burrow_mint_kit
            Parameters.initial_parameters
-           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           (kit_of_denomination (Ligo.nat_from_literal "1n"))
            burrow0 in
 
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "2n"))
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "2n"))
          ~real:(Burrow.burrow_outstanding_kit burrow)
     );
 
@@ -257,7 +257,7 @@ let suite =
        let _ =
          Burrow.burrow_mint_kit
            {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-           (kit_of_mukit (Ligo.nat_from_literal "0n"))
+           (kit_of_denomination (Ligo.nat_from_literal "0n"))
            burrow_for_needs_touch_tests
        in ()
     );
@@ -269,7 +269,7 @@ let suite =
            ~active:true
            ~collateral:(Ligo.tez_from_literal "4mutez") in
 
-       let burrow = Burrow.burrow_mint_kit Parameters.initial_parameters (kit_of_mukit (Ligo.nat_from_literal "1n")) burrow0 in
+       let burrow = Burrow.burrow_mint_kit Parameters.initial_parameters (kit_of_denomination (Ligo.nat_from_literal "1n")) burrow0 in
 
        assert_address_equal
          ~expected:(Burrow.burrow_address burrow0)
@@ -302,7 +302,7 @@ let suite =
                 ~collateral:(Ligo.tez_from_literal "12_345_678_904mutez") in
 
             let burrow_max_mintable_kit = Burrow.burrow_max_mintable_kit Parameters.initial_parameters burrow0 in
-            let just_over_max_mintable_kit = Kit.kit_add burrow_max_mintable_kit (kit_of_mukit (Ligo.nat_from_literal "1n")) in
+            let just_over_max_mintable_kit = Kit.kit_add burrow_max_mintable_kit (kit_of_denomination (Ligo.nat_from_literal "1n")) in
             Burrow.burrow_mint_kit Parameters.initial_parameters just_over_max_mintable_kit burrow0
          )
     );
@@ -328,7 +328,7 @@ let suite =
               Parameters.initial_parameters
               Constants.creation_deposit
               (make_test_burrow
-                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+                 ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
                  ~collateral:(Ligo.tez_from_literal "1mutez")
                  ~active:true
               )
@@ -344,7 +344,7 @@ let suite =
               Parameters.initial_parameters
               (Ligo.sub_tez_tez Constants.creation_deposit (Ligo.tez_from_literal "1mutez"))
               (make_test_burrow
-                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+                 ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
                  ~collateral:(Ligo.tez_from_literal "1mutez")
                  ~active:true
               )
@@ -357,7 +357,7 @@ let suite =
            Parameters.initial_parameters
            Constants.creation_deposit
            (make_test_burrow
-              ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+              ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
               ~collateral:(Ligo.tez_from_literal "0mutez")
               ~active:false
            )
@@ -396,7 +396,7 @@ let suite =
             Burrow.burrow_deactivate
               Parameters.initial_parameters
               (make_test_burrow
-                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "0n"))
+                 ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "0n"))
                  ~collateral:(Ligo.tez_from_literal "1mutez")
                  ~active:false
               )
@@ -411,7 +411,7 @@ let suite =
             Burrow.burrow_deactivate
               Parameters.initial_parameters
               (make_test_burrow
-                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+                 ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
                  ~collateral:(Ligo.tez_from_literal "10mutez")
                  ~active:true
               )
@@ -426,7 +426,7 @@ let suite =
             Burrow.burrow_deactivate
               Parameters.initial_parameters
               (make_test_burrow
-                 ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10n"))
+                 ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10n"))
                  ~collateral:(Ligo.tez_from_literal "1mutez")
                  ~active:true
               )
@@ -442,7 +442,7 @@ let suite =
               Parameters.initial_parameters
               (
                 Burrow.make_burrow_for_test
-                  ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "0n"))
+                  ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "0n"))
                   ~active:true
                   ~address:burrow_addr
                   ~delegate:None
@@ -529,7 +529,7 @@ let suite =
     ("burrow_return_kit_from_auction - does not change burrow address" >::
      fun _ ->
        let burrow0 = Burrow.make_burrow_for_test
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~address:burrow_addr
            ~delegate:None
@@ -540,10 +540,10 @@ let suite =
        let slice = LiquidationAuctionPrimitiveTypes.{
            burrow=(Ligo.address_from_literal "12345", Ligo.nat_from_literal "0n");
            tez=Ligo.tez_from_literal "1mutez";
-           min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "1n"));
+           min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "1n"));
          } in
 
-       let burrow, _returned_kit, _excess_kit = Burrow.burrow_return_kit_from_auction slice (kit_of_mukit (Ligo.nat_from_literal "1n")) burrow0 in
+       let burrow, _returned_kit, _excess_kit = Burrow.burrow_return_kit_from_auction slice (kit_of_denomination (Ligo.nat_from_literal "1n")) burrow0 in
 
        assert_address_equal
          ~expected:(Burrow.burrow_address burrow0)
@@ -553,7 +553,7 @@ let suite =
     ("burrow_return_slice_from_auction - expected value" >::
      fun _ ->
        let burrow0 = Burrow.make_burrow_for_test
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "2n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "2n"))
            ~active:true
            ~address:burrow_addr
            ~delegate:None
@@ -564,11 +564,11 @@ let suite =
        let slice = let open LiquidationAuctionPrimitiveTypes in {
            burrow=(burrow_addr, Ligo.nat_from_literal "0n");
            tez=Ligo.tez_from_literal "1mutez";
-           min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "1n"));
+           min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "1n"));
          } in
 
        let expected_burrow = Burrow.make_burrow_for_test
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "2n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "2n"))
            ~active:true
            ~address:burrow_addr
            ~delegate:None
@@ -586,7 +586,7 @@ let suite =
     ("burrow_return_slice_from_auction - does not change burrow address" >::
      fun _ ->
        let burrow0 = Burrow.make_burrow_for_test
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~address:burrow_addr
            ~delegate:None
@@ -597,7 +597,7 @@ let suite =
        let slice = let open LiquidationAuctionPrimitiveTypes in {
            burrow=(Ligo.address_from_literal "12345", Ligo.nat_from_literal "0n");
            tez=Ligo.tez_from_literal "1mutez";
-           min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "1n"));
+           min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "1n"));
          } in
 
        let burrow = Burrow.burrow_return_slice_from_auction slice burrow0 in
@@ -624,7 +624,7 @@ let suite =
     ("compute_min_kit_for_unwarranted - burrow with zero collateral and positive outstanding kit" >::
      fun _ ->
        let burrow0 = make_test_burrow
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~collateral:(Ligo.tez_from_literal "0mutez") in
        let tez_to_auction = Ligo.tez_from_literal "1mutez" in
@@ -652,21 +652,21 @@ let suite =
     ("compute_min_kit_for_unwarranted - burrow with positive collateral and positive outstanding kit" >::
      fun _ ->
        let burrow0 = make_test_burrow
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~collateral:(Ligo.tez_from_literal "1mutez") in
        let tez_to_auction = Ligo.tez_from_literal "1mutez" in
        let min_kit_for_unwarranted = Burrow.compute_min_kit_for_unwarranted Parameters.initial_parameters burrow0 tez_to_auction in
 
        assert_kit_option_equal
-         ~expected:(Some (kit_of_mukit (Ligo.nat_from_literal "2n")))
+         ~expected:(Some (kit_of_denomination (Ligo.nat_from_literal "2n")))
          ~real:min_kit_for_unwarranted
     );
 
     ("compute_min_kit_for_unwarranted - burrow with positive collateral and collateral at auction and positive outstanding kit" >::
      fun _ ->
        let burrow0 = Burrow.make_burrow_for_test
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "5n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "5n"))
            ~active:true
            ~address:burrow_addr
            ~delegate:None
@@ -678,7 +678,7 @@ let suite =
        let min_kit_for_unwarranted = Burrow.compute_min_kit_for_unwarranted Parameters.initial_parameters burrow0 tez_to_auction in
 
        assert_kit_option_equal
-         ~expected:(Some (kit_of_mukit (Ligo.nat_from_literal "7n")))
+         ~expected:(Some (kit_of_denomination (Ligo.nat_from_literal "7n")))
          ~real:min_kit_for_unwarranted
     );
 
@@ -704,7 +704,7 @@ let suite =
     ("compute_tez_to_auction - expected value for an overburrowed burrow" >::
      fun _ ->
        let burrow = Burrow.make_burrow_for_test
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "3n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "3n"))
            ~active:true
            ~address:alice_addr
            ~delegate:None
@@ -725,7 +725,7 @@ let suite =
     ("compute_tez_to_auction - expected value for an underburrowed burrow" >::
      fun _ ->
        let burrow = Burrow.make_burrow_for_test
-           ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "3n"))
+           ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "3n"))
            ~active:true
            ~address:alice_addr
            ~delegate:None
@@ -743,7 +743,7 @@ let suite =
       "burrow_return_kit_from_auction - expected value for burrow with outstanding kit" >::
       fun _ -> (
           let burrow = Burrow.make_burrow_for_test
-              ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10n"))
+              ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10n"))
               ~active:true
               ~address:alice_addr
               ~delegate:None
@@ -760,9 +760,9 @@ let suite =
             }
           in
 
-          let burrow_out, _returned_kit, _excess_kit = Burrow.burrow_return_kit_from_auction slice (kit_of_mukit (Ligo.nat_from_literal "9n")) burrow in
+          let burrow_out, _returned_kit, _excess_kit = Burrow.burrow_return_kit_from_auction slice (kit_of_denomination (Ligo.nat_from_literal "9n")) burrow in
           let burrow_expected = Burrow.make_burrow_for_test
-              ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+              ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
               ~active:true
               ~address:alice_addr
               ~delegate:None
@@ -780,7 +780,7 @@ let suite =
       "burrow_is_cancellation_warranted - warranted cancellation" >::
       fun _ -> (
           let burrow = Burrow.make_burrow_for_test
-              ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "4_657_142n"))
+              ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "4_657_142n"))
               ~active:true
               ~address:alice_addr
               ~delegate:None
@@ -799,7 +799,7 @@ let suite =
       "burrow_is_cancellation_warranted - unwarranted cancellation" >::
       fun _ ->
         let burrow = Burrow.make_burrow_for_test
-            ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "4_657_143n"))
+            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "4_657_143n"))
             ~active:true
             ~address:alice_addr
             ~delegate:None
@@ -818,7 +818,7 @@ let suite =
       "burrow_is_liquidatable - liquidatable burrow" >::
       fun _ ->
         let burrow = Burrow.make_burrow_for_test
-            ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "4_000_000n"))
+            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "4_000_000n"))
             ~active:true
             ~address:alice_addr
             ~delegate:None
@@ -836,7 +836,7 @@ let suite =
       "burrow_is_liquidatable - non-liquidatable burrow" >::
       fun _ ->
         let burrow = Burrow.make_burrow_for_test
-            ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "4_000_000n"))
+            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "4_000_000n"))
             ~active:true
             ~address:alice_addr
             ~delegate:None
@@ -854,7 +854,7 @@ let suite =
       "burrow_total_associated_tez - active burrow" >::
       fun _ ->
         let burrow = Burrow.make_burrow_for_test
-            ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1_000_000n"))
+            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1_000_000n"))
             ~active:true
             ~address:alice_addr
             ~delegate:None
@@ -872,7 +872,7 @@ let suite =
       "burrow_total_associated_tez - inactive burrow" >::
       fun _ ->
         let burrow = Burrow.make_burrow_for_test
-            ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1_000_000n"))
+            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1_000_000n"))
             ~active:false
             ~address:alice_addr
             ~delegate:None
@@ -895,7 +895,7 @@ let suite =
       (* As of writing, the below calculation simplifies to floor(collateral * 10/21) *)
       let burrowing_limit_kit = 47 in
       let min_mint_to_overburrow = burrowing_limit_kit - outstanding_kit + 1 in
-      let arb_kit = QCheck.map (fun x -> kit_of_mukit (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(min_mint_to_overburrow -- max_int) in
+      let arb_kit = QCheck.map (fun x -> kit_of_denomination (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(min_mint_to_overburrow -- max_int) in
 
       qcheck_to_ounit
       @@ QCheck.Test.make
@@ -904,7 +904,7 @@ let suite =
         arb_kit
       @@ fun mint_kit ->
       let burrow = make_test_burrow
-          ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal (string_of_int outstanding_kit ^ "n")))
+          ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal (string_of_int outstanding_kit ^ "n")))
           ~active:true
           ~collateral:(Ligo.tez_from_literal ((string_of_int collateral) ^ "mutez")) in
 
@@ -916,7 +916,7 @@ let suite =
 
     (
       let collateral = 100 in
-      let outstanding_kit = kit_of_mukit (Ligo.nat_from_literal ("1n")) in
+      let outstanding_kit = kit_of_denomination (Ligo.nat_from_literal ("1n")) in
       (* As of writing, the below calculation simplifies to ceil(outstanding_kit * 21/10) *)
       let burrowing_limit_tez = 3 in
       let min_withdrawal_to_overburrow = (collateral - burrowing_limit_tez) + 1 in
@@ -950,7 +950,7 @@ let suite =
         TestArbitrary.arb_tez
       @@ fun tez_to_deposit ->
       let burrow0 = make_test_burrow
-          ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+          ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
           ~active:true
           ~collateral:(Ligo.tez_from_literal "100mutez") in
 
@@ -973,7 +973,7 @@ let suite =
         TestArbitrary.arb_tez
       @@ fun collateral_balance_tez ->
       let burrow0 = make_test_burrow
-          ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "0n"))
+          ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "0n"))
           ~active:true
           ~collateral:collateral_balance_tez in
 

--- a/tests/testCfmm.ml
+++ b/tests/testCfmm.ml
@@ -76,8 +76,8 @@ let make_inputs_for_remove_liquidity_to_succeed =
         * extant for this operation. When we remove liquidity we round the
         * amounts of kit and ctez to return towards zero; they might end up
         * being zero because of this, which would make remove_liquidity fail.
-        * We make the generator thus ensure that at least 1mukit and 1muctez
-        * will be returned. *)
+        * We make the generator thus ensure that at least the lowest
+        * denomination of each will be returned. *)
        let lqt_burned, min_ctez_withdrawn, min_kit_withdrawn =
          if lqt_to_burn = lqt_zero || min_ctez_withdrawn = ctez_zero || min_kit_withdrawn = kit_zero then
            let lqt_to_burn =

--- a/tests/testCfmm.ml
+++ b/tests/testCfmm.ml
@@ -81,7 +81,7 @@ let make_inputs_for_remove_liquidity_to_succeed =
        let lqt_burned, min_ctez_withdrawn, min_kit_withdrawn =
          if lqt_to_burn = lqt_zero || min_ctez_withdrawn = ctez_zero || min_kit_withdrawn = kit_zero then
            let lqt_to_burn =
-             let least_kit_percentage = (div_ratio (kit_to_ratio (kit_of_mukit (Ligo.nat_from_literal "1n"))) (kit_to_ratio kit)) in
+             let least_kit_percentage = (div_ratio (kit_to_ratio (kit_of_denomination (Ligo.nat_from_literal "1n"))) (kit_to_ratio kit)) in
              let least_ctez_percentage = make_ratio (ctez_to_muctez_int (ctez_of_muctez (Ligo.nat_from_literal "1n"))) (ctez_to_muctez_int ctez) in
              let as_q = (mul_ratio (lqt_to_ratio lqt) (max_ratio least_kit_percentage least_ctez_percentage)) in
              lqt_of_fraction_ceil as_q.num as_q.den in
@@ -199,17 +199,17 @@ let buy_kit_unit_test =
     let cfmm : cfmm =
       cfmm_make_for_test
         ~ctez:(ctez_of_muctez (Ligo.nat_from_literal "10_000_000n"))
-        ~kit:(kit_of_mukit (Ligo.nat_from_literal "5_000_000n"))
+        ~kit:(kit_of_denomination (Ligo.nat_from_literal "5_000_000n"))
         ~lqt:(lqt_of_denomination (Ligo.nat_from_literal "1n"))
         ~kit_in_ctez_in_prev_block:one_ratio
         ~last_level:(Ligo.nat_from_literal "0n")
     in
 
-    let expected_returned_kit = kit_of_mukit (Ligo.nat_from_literal "453_636n") in
+    let expected_returned_kit = kit_of_denomination (Ligo.nat_from_literal "453_636n") in
     let expected_updated_cfmm : cfmm =
       cfmm_make_for_test
         ~ctez:(ctez_of_muctez (Ligo.nat_from_literal "11_000_000n"))
-        ~kit:(kit_of_mukit (Ligo.nat_from_literal "4_546_364n"))
+        ~kit:(kit_of_denomination (Ligo.nat_from_literal "4_546_364n"))
         ~lqt:(lqt_of_denomination (Ligo.nat_from_literal "1n"))
         ~kit_in_ctez_in_prev_block:(ratio_of_int (Ligo.int_from_literal "2"))
         ~last_level:(Ligo.nat_from_literal "1n")
@@ -222,7 +222,7 @@ let buy_kit_unit_test =
       cfmm_buy_kit
         cfmm
         (ctez_of_muctez (Ligo.nat_from_literal "1_000_000n"))
-        (kit_of_mukit (Ligo.nat_from_literal "1n"))
+        (kit_of_denomination (Ligo.nat_from_literal "1n"))
         (Ligo.timestamp_from_seconds_literal 10) in
     assert_kit_equal ~expected:expected_returned_kit ~real:returned_kit;
     assert_cfmm_equal ~expected:expected_updated_cfmm ~real:updated_cfmm;
@@ -234,7 +234,7 @@ let buy_kit_unit_test =
       cfmm_buy_kit
         cfmm
         (ctez_of_muctez (Ligo.nat_from_literal "1_000_000n"))
-        (kit_of_mukit (Ligo.nat_from_literal "453_636n"))
+        (kit_of_denomination (Ligo.nat_from_literal "453_636n"))
         (Ligo.timestamp_from_seconds_literal 2) in
     assert_kit_equal ~expected:expected_returned_kit ~real:returned_kit;
     assert_cfmm_equal ~expected:expected_updated_cfmm ~real:updated_cfmm;
@@ -248,7 +248,7 @@ let buy_kit_unit_test =
          cfmm_buy_kit
            cfmm
            (ctez_of_muctez (Ligo.nat_from_literal "1_000_000n"))
-           (kit_of_mukit (Ligo.nat_from_literal "453_637n"))
+           (kit_of_denomination (Ligo.nat_from_literal "453_637n"))
            (Ligo.timestamp_from_seconds_literal 2)
       );
 
@@ -261,7 +261,7 @@ let buy_kit_unit_test =
          cfmm_buy_kit
            cfmm
            (ctez_of_muctez (Ligo.nat_from_literal "1_000_000n"))
-           (kit_of_mukit (Ligo.nat_from_literal "453_636n"))
+           (kit_of_denomination (Ligo.nat_from_literal "453_636n"))
            (Ligo.timestamp_from_seconds_literal 1)
       );
 
@@ -274,7 +274,7 @@ let buy_kit_unit_test =
          cfmm_buy_kit
            cfmm
            ctez_zero
-           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           (kit_of_denomination (Ligo.nat_from_literal "1n"))
            (Ligo.timestamp_from_seconds_literal 10)
       );
 
@@ -287,7 +287,7 @@ let buy_kit_unit_test =
          cfmm_buy_kit
            cfmm
            (ctez_of_muctez (Ligo.nat_from_literal "1n"))
-           (kit_of_mukit (Ligo.nat_from_literal "0n"))
+           (kit_of_denomination (Ligo.nat_from_literal "0n"))
            (Ligo.timestamp_from_seconds_literal 10)
       )
 
@@ -380,7 +380,7 @@ let sell_kit_unit_test =
     let cfmm : cfmm =
       cfmm_make_for_test
         ~ctez:(ctez_of_muctez (Ligo.nat_from_literal "10_000_000n"))
-        ~kit:(kit_of_mukit (Ligo.nat_from_literal "5_000_000n"))
+        ~kit:(kit_of_denomination (Ligo.nat_from_literal "5_000_000n"))
         ~lqt:(lqt_of_denomination (Ligo.nat_from_literal "1n"))
         ~kit_in_ctez_in_prev_block:one_ratio
         ~last_level:(Ligo.nat_from_literal "0n")
@@ -389,7 +389,7 @@ let sell_kit_unit_test =
     let expected_updated_cfmm : cfmm =
       cfmm_make_for_test
         ~ctez:(ctez_of_muctez (Ligo.nat_from_literal "8_336_667n"))
-        ~kit:(kit_of_mukit (Ligo.nat_from_literal "6_000_000n"))
+        ~kit:(kit_of_denomination (Ligo.nat_from_literal "6_000_000n"))
         ~lqt:(lqt_of_denomination (Ligo.nat_from_literal "1n"))
         ~kit_in_ctez_in_prev_block:(ratio_of_int (Ligo.int_from_literal "2"))
         ~last_level:(Ligo.nat_from_literal "1n")
@@ -453,7 +453,7 @@ let sell_kit_unit_test =
       (fun () ->
          cfmm_sell_kit
            cfmm
-           (kit_of_mukit (Ligo.nat_from_literal "0n"))
+           (kit_of_denomination (Ligo.nat_from_literal "0n"))
            (ctez_of_muctez (Ligo.nat_from_literal "1_663_333n"))
            (Ligo.timestamp_from_seconds_literal 10)
       );
@@ -564,17 +564,17 @@ let add_liquidity_unit_test =
     let cfmm : cfmm =
       cfmm_make_for_test
         ~ctez:(ctez_of_muctez (Ligo.nat_from_literal "8_336_667n"))
-        ~kit:(kit_of_mukit (Ligo.nat_from_literal "6_000_000n"))
+        ~kit:(kit_of_denomination (Ligo.nat_from_literal "6_000_000n"))
         ~lqt:(lqt_of_denomination (Ligo.nat_from_literal "1n"))
         ~kit_in_ctez_in_prev_block:one_ratio
         ~last_level:(Ligo.nat_from_literal "0n")
     in
     let expected_returned_liquidity = lqt_of_denomination (Ligo.nat_from_literal "2n") in
-    let expected_returned_kit = kit_of_mukit (Ligo.nat_from_literal "5_605_758n") in
+    let expected_returned_kit = kit_of_denomination (Ligo.nat_from_literal "5_605_758n") in
     let expected_updated_cfmm : cfmm =
       cfmm_make_for_test
         ~ctez:(ctez_of_muctez (Ligo.nat_from_literal "28_336_667n"))
-        ~kit:(kit_of_mukit (Ligo.nat_from_literal "20_394_242n"))
+        ~kit:(kit_of_denomination (Ligo.nat_from_literal "20_394_242n"))
         ~lqt:(lqt_of_denomination (Ligo.nat_from_literal "3n"))
         ~kit_in_ctez_in_prev_block:one_ratio
         ~last_level:(Ligo.nat_from_literal "0n")
@@ -584,7 +584,7 @@ let add_liquidity_unit_test =
       cfmm_add_liquidity
         cfmm
         (ctez_of_muctez (Ligo.nat_from_literal "20_000_000n"))
-        (kit_of_mukit (Ligo.nat_from_literal "20_000_000n"))
+        (kit_of_denomination (Ligo.nat_from_literal "20_000_000n"))
         (lqt_of_denomination (Ligo.nat_from_literal "2n"))
         (Ligo.timestamp_from_seconds_literal 1) in
     assert_lqt_equal ~expected:expected_returned_liquidity ~real:returned_liquidity;
@@ -597,7 +597,7 @@ let test_add_liquidity_failures =
     let cfmm =
       cfmm_make_for_test
         ~ctez:(ctez_of_muctez (Ligo.nat_from_literal "1000_000_000n"))
-        ~kit:(kit_of_mukit (Ligo.nat_from_literal "5000_000_000n"))
+        ~kit:(kit_of_denomination (Ligo.nat_from_literal "5000_000_000n"))
         ~lqt:(lqt_of_denomination (Ligo.nat_from_literal "1000n"))
         ~kit_in_ctez_in_prev_block:one_ratio
         ~last_level:(Ligo.nat_from_literal "0n") in
@@ -607,7 +607,7 @@ let test_add_liquidity_failures =
          cfmm_add_liquidity
            cfmm
            ctez_zero
-           (kit_of_mukit (Ligo.nat_from_literal "20_000_000n"))
+           (kit_of_denomination (Ligo.nat_from_literal "20_000_000n"))
            (lqt_of_denomination (Ligo.nat_from_literal "2n"))
            (Ligo.timestamp_from_seconds_literal 1)
       );
@@ -617,7 +617,7 @@ let test_add_liquidity_failures =
          cfmm_add_liquidity
            cfmm
            (ctez_of_muctez (Ligo.nat_from_literal "1n"))
-           (kit_of_mukit (Ligo.nat_from_literal "0n"))
+           (kit_of_denomination (Ligo.nat_from_literal "0n"))
            (lqt_of_denomination (Ligo.nat_from_literal "2n"))
            (Ligo.timestamp_from_seconds_literal 1)
       );
@@ -627,7 +627,7 @@ let test_add_liquidity_failures =
          cfmm_add_liquidity
            cfmm
            (ctez_of_muctez (Ligo.nat_from_literal "1n"))
-           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           (kit_of_denomination (Ligo.nat_from_literal "1n"))
            lqt_zero
            (Ligo.timestamp_from_seconds_literal 1)
       );
@@ -639,7 +639,7 @@ let test_add_liquidity_failures =
          cfmm_add_liquidity
            cfmm
            (ctez_of_muctez (Ligo.nat_from_literal "1n"))
-           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           (kit_of_denomination (Ligo.nat_from_literal "1n"))
            lqt_zero
            deadline
       );
@@ -652,7 +652,7 @@ let test_add_liquidity_failures =
          cfmm_add_liquidity
            cfmm
            (ctez_of_muctez (Ligo.nat_from_literal "1n"))
-           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           (kit_of_denomination (Ligo.nat_from_literal "1n"))
            lqt_zero
            deadline
       )
@@ -750,7 +750,7 @@ let test_remove_liquidity_failures =
     let cfmm =
       cfmm_make_for_test
         ~ctez:(ctez_of_muctez (Ligo.nat_from_literal "1000_000_000n"))
-        ~kit:(kit_of_mukit (Ligo.nat_from_literal "5000_000_000n"))
+        ~kit:(kit_of_denomination (Ligo.nat_from_literal "5000_000_000n"))
         ~lqt:(lqt_of_denomination (Ligo.nat_from_literal "1000n"))
         ~kit_in_ctez_in_prev_block:one_ratio
         ~last_level:(Ligo.nat_from_literal "0n") in
@@ -758,7 +758,7 @@ let test_remove_liquidity_failures =
       cfmm_add_liquidity
         { cfmm with ctez = ctez_add cfmm.ctez (ctez_of_muctez (Ligo.nat_from_literal "10_000_000n")) }
         (ctez_of_muctez (Ligo.nat_from_literal "101_000_000n"))
-        (kit_of_mukit (Ligo.nat_from_literal "500_000_000n"))
+        (kit_of_denomination (Ligo.nat_from_literal "500_000_000n"))
         (lqt_of_denomination (Ligo.nat_from_literal "1n"))
         (Ligo.timestamp_from_seconds_literal 1) in
     assert_raises
@@ -768,7 +768,7 @@ let test_remove_liquidity_failures =
            cfmm
            lqt_zero
            (ctez_of_muctez (Ligo.nat_from_literal "1n"))
-           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           (kit_of_denomination (Ligo.nat_from_literal "1n"))
            (Ligo.timestamp_from_seconds_literal 100)
       );
     assert_raises
@@ -778,7 +778,7 @@ let test_remove_liquidity_failures =
            cfmm
            liq
            ctez_zero
-           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           (kit_of_denomination (Ligo.nat_from_literal "1n"))
            (Ligo.timestamp_from_seconds_literal 100)
       );
     assert_raises
@@ -788,7 +788,7 @@ let test_remove_liquidity_failures =
            cfmm
            liq
            (ctez_of_muctez (Ligo.nat_from_literal "1n"))
-           (kit_of_mukit (Ligo.nat_from_literal "0n"))
+           (kit_of_denomination (Ligo.nat_from_literal "0n"))
            (Ligo.timestamp_from_seconds_literal 100)
       );
     assert_raises
@@ -800,7 +800,7 @@ let test_remove_liquidity_failures =
            cfmm
            liq
            (ctez_of_muctez (Ligo.nat_from_literal "1n"))
-           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           (kit_of_denomination (Ligo.nat_from_literal "1n"))
            deadline
       );
     assert_raises
@@ -813,7 +813,7 @@ let test_remove_liquidity_failures =
            cfmm
            liq
            (ctez_of_muctez (Ligo.nat_from_literal "1n"))
-           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           (kit_of_denomination (Ligo.nat_from_literal "1n"))
            deadline
       );
     assert_raises
@@ -826,7 +826,7 @@ let test_remove_liquidity_failures =
            cfmm
            liq
            (ctez_of_muctez (Ligo.nat_from_literal "1n"))
-           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           (kit_of_denomination (Ligo.nat_from_literal "1n"))
            deadline
       );
     assert_raises
@@ -839,7 +839,7 @@ let test_remove_liquidity_failures =
            cfmm
            liq
            (ctez_of_muctez (Ligo.nat_from_literal "1n"))
-           (kit_of_mukit (Ligo.nat_from_literal "1n"))
+           (kit_of_denomination (Ligo.nat_from_literal "1n"))
            deadline
       )
 
@@ -867,7 +867,7 @@ let cfmm_tests_from_mutations =
        let cfmm =
          cfmm_make_for_test
            ~ctez:(ctez_of_muctez (Ligo.nat_from_literal "999_999_000_000n"))
-           ~kit:(kit_of_mukit (Ligo.nat_from_literal "999_999_000_000n"))
+           ~kit:(kit_of_denomination (Ligo.nat_from_literal "999_999_000_000n"))
            ~lqt:(lqt_of_denomination (Ligo.nat_from_literal "999_999n"))
            ~kit_in_ctez_in_prev_block:one_ratio
            ~last_level:!Ligo.Tezos.level in
@@ -888,7 +888,7 @@ let cfmm_tests_from_mutations =
      fun _ ->
        Ligo.Tezos.reset ();
        let total_ctez = ctez_of_muctez (Ligo.nat_from_literal "123_456_789n") in
-       let total_kit = kit_of_mukit (Ligo.nat_from_literal "37_194_834n") in
+       let total_kit = kit_of_denomination (Ligo.nat_from_literal "37_194_834n") in
        let total_lqt = lqt_of_denomination (Ligo.nat_from_literal "999_999n") in
        let cfmm =
          cfmm_make_for_test
@@ -918,14 +918,14 @@ let cfmm_tests_from_mutations =
          ~expected:(Ctez.ctez_of_muctez (Ligo.nat_from_literal "38_575_964n"))
          ~real:ctez_withdrawn;
        assert_kit_equal
-         ~expected:(Kit.kit_of_mukit (Ligo.nat_from_literal "11_622_095n"))
+         ~expected:(Kit.kit_of_denomination (Ligo.nat_from_literal "11_622_095n"))
          ~real:kit_withdrawn;
        (* Updated cfmm *)
        assert_ctez_equal
          ~expected:(Ctez.ctez_of_muctez (Ligo.nat_from_literal "84_880_825n"))
          ~real:updated_cfmm.ctez;
        assert_kit_equal
-         ~expected:(Kit.kit_of_mukit (Ligo.nat_from_literal "25_572_739n"))
+         ~expected:(Kit.kit_of_denomination (Ligo.nat_from_literal "25_572_739n"))
          ~real:updated_cfmm.kit;
        assert_lqt_equal
          ~expected:(Lqt.lqt_of_denomination (Ligo.nat_from_literal "687_534n"))
@@ -940,7 +940,7 @@ let cfmm_tests_from_mutations =
      fun _ ->
        Ligo.Tezos.reset ();
        let total_ctez = ctez_of_muctez (Ligo.nat_from_literal "123_456_789n") in
-       let total_kit = kit_of_mukit (Ligo.nat_from_literal "37_194_834n") in
+       let total_kit = kit_of_denomination (Ligo.nat_from_literal "37_194_834n") in
        let total_lqt = lqt_of_denomination (Ligo.nat_from_literal "999_999n") in
        let cfmm =
          cfmm_make_for_test
@@ -949,7 +949,7 @@ let cfmm_tests_from_mutations =
            ~lqt:total_lqt
            ~kit_in_ctez_in_prev_block:one_ratio
            ~last_level:!Ligo.Tezos.level in
-       let accrual = kit_of_mukit (Ligo.nat_from_literal "8_367n") in
+       let accrual = kit_of_denomination (Ligo.nat_from_literal "8_367n") in
        let updated_cfmm = cfmm_add_accrued_kit cfmm accrual in
        assert_kit_equal
          ~expected:(kit_add cfmm.kit accrual)

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -732,7 +732,7 @@ let suite =
        let last_touched = Ligo.timestamp_from_seconds_literal 0 in
        Ligo.Tezos.new_transaction ~seconds_passed:time_delta ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
-       let actual_reward = kit_to_mukit_int (Checker.calculate_touch_reward last_touched) in
+       let actual_reward = kit_to_denomination_int (Checker.calculate_touch_reward last_touched) in
 
        assert_int_equal ~expected:expected_reward ~real:actual_reward;
     );
@@ -747,7 +747,7 @@ let suite =
        let last_touched = Ligo.timestamp_from_seconds_literal 0 in
        Ligo.Tezos.new_transaction ~seconds_passed:time_delta ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
-       let actual_reward = kit_to_mukit_int (Checker.calculate_touch_reward last_touched) in
+       let actual_reward = kit_to_denomination_int (Checker.calculate_touch_reward last_touched) in
 
        assert_int_equal ~expected:expected_reward ~real:actual_reward;
     );
@@ -762,7 +762,7 @@ let suite =
        let last_touched = Ligo.timestamp_from_seconds_literal 0 in
        Ligo.Tezos.new_transaction ~seconds_passed:time_delta ~blocks_passed:2 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
-       let actual_reward = kit_to_mukit_int (Checker.calculate_touch_reward last_touched) in
+       let actual_reward = kit_to_denomination_int (Checker.calculate_touch_reward last_touched) in
 
        assert_int_equal ~expected:expected_reward ~real:actual_reward;
 

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -28,7 +28,7 @@ let _ = Checker.assert_checker_invariants empty_checker
 
 (* Enhance the initial checker state with a populated cfmm in a consistent way. *)
 let empty_checker_with_cfmm (cfmm: CfmmTypes.cfmm) =
-  let checker_kit = kit_sub cfmm.kit (kit_of_mukit (Ligo.nat_from_literal "1n")) in
+  let checker_kit = kit_sub cfmm.kit (kit_of_denomination (Ligo.nat_from_literal "1n")) in
   let checker_liquidity = lqt_sub cfmm.lqt (lqt_of_denomination (Ligo.nat_from_literal "1n")) in
   let checker =
     { empty_checker with
@@ -57,7 +57,7 @@ let checker_with_liquidatable_burrows () =
   let _, checker = Checker.entrypoint_create_burrow (checker, (alice_burrow_1, None)) in
   (* Alice burrow 2:N. Will be liquidatable *)
   Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:3 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-  let _, checker = Checker.entrypoint_mint_kit (checker, (alice_burrow_1, (kit_of_mukit (Ligo.nat_from_literal "100n")))) in
+  let _, checker = Checker.entrypoint_mint_kit (checker, (alice_burrow_1, (kit_of_denomination (Ligo.nat_from_literal "100n")))) in
   let checker = List.fold_left (
       fun checker alice_burrow_no ->
         Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "2_000_000mutez");
@@ -367,14 +367,14 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "100_000_000mutez");
        let _, checker = Checker.entrypoint_create_burrow (checker, (Ligo.nat_from_literal "0n", None)) in
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", (kit_of_mukit (Ligo.nat_from_literal "10_000_000n")))) in
+       let _, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", (kit_of_denomination (Ligo.nat_from_literal "10_000_000n")))) in
 
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let ops, _ = Checker.entrypoint_add_liquidity
            (checker,
             (* Note: all values here were arbitrarily chosen based on the amount of kit we minted above *)
             ( ctez_of_muctez (Ligo.nat_from_literal "5_000_000n")
-            , kit_of_mukit (Ligo.nat_from_literal "5_000_000n")
+            , kit_of_denomination (Ligo.nat_from_literal "5_000_000n")
             , lqt_of_denomination (Ligo.nat_from_literal "5_000_000n")
             , Ligo.timestamp_from_seconds_literal 999
             )
@@ -402,10 +402,10 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "100_000_000mutez");
        let _, checker = Checker.entrypoint_create_burrow (checker, (Ligo.nat_from_literal "0n", None)) in
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", (kit_of_mukit (Ligo.nat_from_literal "10_000_000n")))) in
+       let _, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", (kit_of_denomination (Ligo.nat_from_literal "10_000_000n")))) in
        (* Then burn the kit *)
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let ops, _ = Checker.entrypoint_burn_kit (checker, (Ligo.nat_from_literal "0n", (kit_of_mukit (Ligo.nat_from_literal "10_000_000n")))) in
+       let ops, _ = Checker.entrypoint_burn_kit (checker, (Ligo.nat_from_literal "0n", (kit_of_denomination (Ligo.nat_from_literal "10_000_000n")))) in
        assert_operation_list_equal ~expected:[] ~real:ops
     );
 
@@ -559,7 +559,7 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "100_000_000mutez");
        let _, checker = Checker.entrypoint_create_burrow (checker, (Ligo.nat_from_literal "0n", None)) in
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let ops, _ = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", (kit_of_mukit (Ligo.nat_from_literal "10_000_000n")))) in
+       let ops, _ = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", (kit_of_denomination (Ligo.nat_from_literal "10_000_000n")))) in
        assert_operation_list_equal ~expected:[] ~real:ops
     );
 
@@ -600,14 +600,14 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "100_000_000mutez");
        let _, checker = Checker.entrypoint_create_burrow (checker, (Ligo.nat_from_literal "0n", None)) in
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", (kit_of_mukit (Ligo.nat_from_literal "10_000_000n")))) in
+       let _, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", (kit_of_denomination (Ligo.nat_from_literal "10_000_000n")))) in
        (* Add some liquidity to the contract *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _, checker = Checker.entrypoint_add_liquidity
            (checker,
             (* Note: all values here were arbitrarily chosen based on the amount of kit we minted above *)
             ( ctez_of_muctez (Ligo.nat_from_literal "5_000_000n")
-            , kit_of_mukit (Ligo.nat_from_literal "5_000_000n")
+            , kit_of_denomination (Ligo.nat_from_literal "5_000_000n")
             , lqt_of_denomination (Ligo.nat_from_literal "5_000_000n")
             , Ligo.timestamp_from_seconds_literal 999
             )
@@ -619,7 +619,7 @@ let suite =
             (* Note: all values here were arbitrarily chosen based on the amount of kit we minted above *)
             ( lqt_of_denomination (Ligo.nat_from_literal "5_000_000n")
             , ctez_of_muctez (Ligo.nat_from_literal "5_000_000n")
-            , kit_of_mukit (Ligo.nat_from_literal "5_000_000n")
+            , kit_of_denomination (Ligo.nat_from_literal "5_000_000n")
             , Ligo.timestamp_from_seconds_literal 999
             )
            ) in
@@ -774,7 +774,7 @@ let suite =
        (* Create a burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "1_000_000mutez");
        let _, checker = newly_created_burrow empty_checker "0n" in
-       let some_kit = Kit.kit_of_mukit (Ligo.nat_from_literal "1n") in
+       let some_kit = Kit.kit_of_denomination (Ligo.nat_from_literal "1n") in
 
        assert_raises
          (Failure (Ligo.string_of_int error_UnwantedTezGiven))
@@ -799,14 +799,14 @@ let suite =
        let (ops, checker) =
          Checker.entrypoint_mint_kit
            ( checker
-           , (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "4_285_714n"))
+           , (Ligo.nat_from_literal "0n", kit_of_denomination (Ligo.nat_from_literal "4_285_714n"))
            ) in
 
        (* There should be no operations emitted. *)
        assert_operation_list_equal ~expected:[] ~real:ops;
 
        (* The owner should be able to burn it back. *)
-       let kit_token = kit_of_mukit (Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender)) in
+       let kit_token = kit_of_denomination (Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender)) in
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:sender ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.entrypoint_burn_kit (checker, (Ligo.nat_from_literal "0n", kit_token)) in
 
@@ -825,7 +825,7 @@ let suite =
        let (ops, checker) =
          Checker.entrypoint_mint_kit
            ( checker
-           , (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "4_285_714n"))
+           , (Ligo.nat_from_literal "0n", kit_of_denomination (Ligo.nat_from_literal "4_285_714n"))
            ) in
 
        (* There should be no operations emitted. *)
@@ -835,7 +835,7 @@ let suite =
        assert_raises
          (Failure (Ligo.string_of_int error_NonExistentBurrow))
          (fun () ->
-            let kit_token = kit_of_mukit (Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, bob_addr)) in
+            let kit_token = kit_of_denomination (Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, bob_addr)) in
             Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
             Checker.entrypoint_burn_kit (checker, (Ligo.nat_from_literal "0n", kit_token))
          );
@@ -1043,7 +1043,7 @@ let suite =
        * (1 - fee) * cfmm.kit - 1
       *)
       let max_buyable_kit = 997 in
-      let arb_kit = QCheck.map (fun x -> kit_of_mukit (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(1 -- max_buyable_kit) in
+      let arb_kit = QCheck.map (fun x -> kit_of_denomination (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(1 -- max_buyable_kit) in
       let arb_tez = TestArbitrary.arb_small_positive_tez in
 
       qcheck_to_ounit
@@ -1062,7 +1062,7 @@ let suite =
         empty_checker_with_cfmm
           { empty_checker.cfmm with
             ctez = cfmm_ctez;
-            kit = kit_of_mukit cfmm_kit;
+            kit = kit_of_denomination cfmm_kit;
           } in
 
       (* Calculate minimum tez to get the min_expected kit given the state of the cfmm defined above*)
@@ -1110,11 +1110,11 @@ let suite =
          empty_checker_with_cfmm
            { empty_checker.cfmm with
              ctez = ctez_of_muctez (Ligo.nat_from_literal "2n");
-             kit = kit_of_mukit (Ligo.nat_from_literal "2n");
+             kit = kit_of_denomination (Ligo.nat_from_literal "2n");
            } in
 
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let ops, checker = Checker.entrypoint_buy_kit (checker, (ctez_of_muctez (Ligo.nat_from_literal "1_000_000n"), kit_of_mukit (Ligo.nat_from_literal "1n"), Ligo.timestamp_from_seconds_literal 1)) in
+       let ops, checker = Checker.entrypoint_buy_kit (checker, (ctez_of_muctez (Ligo.nat_from_literal "1_000_000n"), kit_of_denomination (Ligo.nat_from_literal "1n"), Ligo.timestamp_from_seconds_literal 1)) in
        let kit = get_balance_of checker alice_addr kit_token_id in
 
        let expected_ops = [
@@ -1136,7 +1136,7 @@ let suite =
      fun _ ->
        Ligo.Tezos.reset ();
 
-       let kit_to_sell = kit_of_mukit (Ligo.nat_from_literal "1_000_000n") in
+       let kit_to_sell = kit_of_denomination (Ligo.nat_from_literal "1_000_000n") in
        let min_ctez_expected = ctez_of_muctez (Ligo.nat_from_literal "1n") in
 
        let checker =
@@ -1144,7 +1144,7 @@ let suite =
            empty_checker_with_cfmm
              { empty_checker.cfmm with
                ctez = ctez_of_muctez (Ligo.nat_from_literal "2n");
-               kit = kit_of_mukit (Ligo.nat_from_literal "2n");
+               kit = kit_of_denomination (Ligo.nat_from_literal "2n");
                lqt = lqt_of_denomination (Ligo.nat_from_literal "1n");
              } in
          { checker with
@@ -1174,7 +1174,7 @@ let suite =
     ("sell_kit - transaction with value > 0 fails" >::
      fun _ ->
        Ligo.Tezos.reset ();
-       let kit_to_sell = kit_of_mukit (Ligo.nat_from_literal "1n") in
+       let kit_to_sell = kit_of_denomination (Ligo.nat_from_literal "1n") in
        let min_ctez_expected = ctez_of_muctez (Ligo.nat_from_literal "1n") in
 
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "1mutez");
@@ -1189,7 +1189,7 @@ let suite =
      fun _ ->
        Ligo.Tezos.reset ();
 
-       let min_kit_expected = kit_of_mukit (Ligo.nat_from_literal "1n") in
+       let min_kit_expected = kit_of_denomination (Ligo.nat_from_literal "1n") in
        let min_ctez_expected = ctez_of_muctez (Ligo.nat_from_literal "1n") in
        let my_liquidity_tokens = lqt_of_denomination (Ligo.nat_from_literal "1n") in
        let sender = alice_addr in
@@ -1197,17 +1197,17 @@ let suite =
        (* Populate the cfmm with some liquidity (carefully crafted) *)
        let checker =
          { empty_checker with
-           parameters = { empty_checker.parameters with circulating_kit = kit_of_mukit (Ligo.nat_from_literal "1n")};
+           parameters = { empty_checker.parameters with circulating_kit = kit_of_denomination (Ligo.nat_from_literal "1n")};
            cfmm =
              { empty_checker.cfmm with
                ctez = ctez_of_muctez (Ligo.nat_from_literal "2n");
-               kit = kit_of_mukit (Ligo.nat_from_literal "2n");
+               kit = kit_of_denomination (Ligo.nat_from_literal "2n");
                lqt = lqt_of_denomination (Ligo.nat_from_literal "2n");
              };
            fa2_state =
              let fa2_state = initial_fa2_state in
              let fa2_state = ledger_issue_lqt (fa2_state, sender, my_liquidity_tokens) in
-             let fa2_state = ledger_issue_kit (fa2_state, !Ligo.Tezos.self_address, kit_of_mukit (Ligo.nat_from_literal "1n")) in
+             let fa2_state = ledger_issue_kit (fa2_state, !Ligo.Tezos.self_address, kit_of_denomination (Ligo.nat_from_literal "1n")) in
              fa2_state;
          } in
        Checker.assert_checker_invariants checker;
@@ -1232,7 +1232,7 @@ let suite =
     ("remove_liquidity - transaction with value > 0 fails" >::
      fun _ ->
        Ligo.Tezos.reset ();
-       let min_kit_expected = kit_of_mukit (Ligo.nat_from_literal "1n") in
+       let min_kit_expected = kit_of_denomination (Ligo.nat_from_literal "1n") in
        let min_ctez_expected = ctez_of_muctez (Ligo.nat_from_literal "1n") in
        let my_liquidity_tokens = lqt_of_denomination (Ligo.nat_from_literal "1n") in
 
@@ -1300,7 +1300,7 @@ let suite =
          Checker.entrypoint_add_liquidity
            ( checker,
              ( ctez_of_muctez (Ligo.nat_from_literal "5_000_000n")
-             , kit_of_mukit (Ligo.nat_from_literal "5_000_000n")
+             , kit_of_denomination (Ligo.nat_from_literal "5_000_000n")
              , lqt_of_denomination (Ligo.nat_from_literal "5n")
              , Ligo.timestamp_from_seconds_literal 999
              )
@@ -1450,7 +1450,7 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "200_000_000mutez");
        let _, checker = Checker.entrypoint_create_burrow (checker, (Ligo.nat_from_literal "0n", None)) in
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))) in
+       let _, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))) in
 
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _lqt_minted_ret_kit_ops, checker =
@@ -1506,7 +1506,7 @@ let suite =
        let (_ops, checker) =
          Checker.entrypoint_mint_kit
            ( checker
-           , (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "4_285_714n"))
+           , (Ligo.nat_from_literal "0n", kit_of_denomination (Ligo.nat_from_literal "4_285_714n"))
            ) in
 
        let kit = get_balance_of checker bob_addr kit_token_id in
@@ -1527,7 +1527,7 @@ let suite =
          (fun () ->
             Checker.entrypoint_mint_kit
               ( checker
-              , (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "1n"))
+              , (Ligo.nat_from_literal "0n", kit_of_denomination (Ligo.nat_from_literal "1n"))
               )
          );
 
@@ -1627,7 +1627,7 @@ let suite =
        let auction_id =
          min_bid.auction_id in
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "2_709_185n"))
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "2_709_185n"))
          ~real:min_bid.minimum_bid;
 
        (* Bid the minimum first *)
@@ -1639,7 +1639,7 @@ let suite =
        let (ops, checker) =
          Checker.entrypoint_liquidation_auction_place_bid
            ( checker
-           , (auction_id, kit_of_mukit (Ligo.nat_from_literal "4_200_000n"))
+           , (auction_id, kit_of_denomination (Ligo.nat_from_literal "4_200_000n"))
            ) in
 
        let auction_id =
@@ -1729,7 +1729,7 @@ let suite =
 
        (* Mint as much kit as possible. *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:sender ~amount:(Ligo.tez_from_literal "0mutez");
-       let (_ops, checker) = Checker.entrypoint_mint_kit (checker, (burrow_no, kit_of_mukit (Ligo.nat_from_literal "476_667n"))) in
+       let (_ops, checker) = Checker.entrypoint_mint_kit (checker, (burrow_no, kit_of_denomination (Ligo.nat_from_literal "476_667n"))) in
 
        (* Let some time pass. Over time the burrows with outstanding kit should
           	* become overburrowed, and eventually liquidatable. Note that this
@@ -1803,7 +1803,7 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to mint some kit out of the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _ = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "1n"))) in
+       let _ = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", kit_of_denomination (Ligo.nat_from_literal "1n"))) in
        ()
     );
 
@@ -1816,13 +1816,13 @@ let suite =
        let _ops, checker = Checker.entrypoint_create_burrow (empty_checker, (Ligo.nat_from_literal "0n", None)) in
        (* Mint some kit out of the burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _ops, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "1n"))) in
+       let _ops, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", kit_of_denomination (Ligo.nat_from_literal "1n"))) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to burn some kit into the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _ = Checker.entrypoint_burn_kit (checker, (Ligo.nat_from_literal "0n", kit_of_mukit (Ligo.nat_from_literal "1n"))) in
+       let _ = Checker.entrypoint_burn_kit (checker, (Ligo.nat_from_literal "0n", kit_of_denomination (Ligo.nat_from_literal "1n"))) in
        ()
     );
 
@@ -1915,7 +1915,7 @@ let suite =
          (* Add some liquidity *)
          Ligo.Tezos.new_transaction ~seconds_passed:121 ~blocks_passed:2 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
          let ctez_to_give = Ctez.ctez_of_muctez (Ligo.nat_from_literal "400_000n") in
-         let kit_to_give = Kit.kit_of_mukit (Ligo.nat_from_literal "400_000n") in
+         let kit_to_give = Kit.kit_of_denomination (Ligo.nat_from_literal "400_000n") in
          let min_lqt_to_mint = Lqt.lqt_of_denomination (Ligo.nat_from_literal "5n") in
          let deadline = Ligo.add_timestamp_int !Ligo.Tezos.now (Ligo.int_from_literal "20") in
          let _ops, checker = Checker.entrypoint_add_liquidity (checker, (ctez_to_give, kit_to_give, min_lqt_to_mint, deadline)) in
@@ -1941,7 +1941,7 @@ let suite =
 
        "view_sell_kit_min_ctez_expected" >:: with_cfmm_setup
          (fun checker ->
-            let kit_to_sell = Kit.kit_of_mukit (Ligo.nat_from_literal "100_000n") in
+            let kit_to_sell = Kit.kit_of_denomination (Ligo.nat_from_literal "100_000n") in
             let min_ctez_to_buy = Checker.view_sell_kit_min_ctez_expected (kit_to_sell, checker) in
             let deadline = Ligo.add_timestamp_int !Ligo.Tezos.now (Ligo.int_from_literal "20") in
             (* must succeed, otherwise view_sell_kit_min_ctez_expected overapproximated *)

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -856,12 +856,12 @@ let suite =
       let sender = alice_addr in
       let checker = empty_checker_with_cfmm cfmm in
 
-      let senders_old_mukit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* before *)
+      let senders_old_kit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* before *)
 
       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:sender ~amount:(Ligo.tez_from_literal "0mutez");
       let ops, checker = Checker.entrypoint_buy_kit (checker, (ctez_amount, min_kit_expected, deadline)) in
 
-      let senders_new_mukit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* after *)
+      let senders_new_kit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* after *)
 
       begin match ops with
         | [Transaction (FA12TransferTransactionValue transfer, _, _)] ->
@@ -874,8 +874,8 @@ let suite =
       end;
 
       Ligo.geq_nat_nat
-        senders_new_mukit
-        (Ligo.add_nat_nat senders_old_mukit (kit_to_denomination_nat min_kit_expected))
+        senders_new_kit
+        (Ligo.add_nat_nat senders_old_kit (kit_to_denomination_nat min_kit_expected))
     );
 
     (
@@ -891,14 +891,14 @@ let suite =
       let checker = empty_checker_with_cfmm cfmm in
       let sender = alice_addr in
 
-      let checker_cfmm_old_mukit = kit_to_denomination_nat checker.cfmm.kit in
-      let senders_old_mukit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* before *)
+      let checker_cfmm_old_kit = kit_to_denomination_nat checker.cfmm.kit in
+      let senders_old_kit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* before *)
 
       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:sender ~amount:(Ligo.tez_from_literal "0mutez");
       let ops, checker = Checker.entrypoint_buy_kit (checker, (ctez_amount, min_kit_expected, deadline)) in
 
-      let checker_cfmm_new_mukit = kit_to_denomination_nat checker.cfmm.kit in
-      let senders_new_mukit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* after *)
+      let checker_cfmm_new_kit = kit_to_denomination_nat checker.cfmm.kit in
+      let senders_new_kit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* after *)
 
       begin match ops with
         | [Transaction (FA12TransferTransactionValue transfer, _, _)] ->
@@ -911,8 +911,8 @@ let suite =
       end;
 
       Ligo.eq_nat_nat
-        (Ligo.add_nat_nat checker_cfmm_old_mukit senders_old_mukit)
-        (Ligo.add_nat_nat checker_cfmm_new_mukit senders_new_mukit)
+        (Ligo.add_nat_nat checker_cfmm_old_kit senders_old_kit)
+        (Ligo.add_nat_nat checker_cfmm_new_kit senders_new_kit)
     );
 
     (
@@ -1077,7 +1077,7 @@ let suite =
       (* Adjust transaction by a random amount of extra tez *)
       let tez_provided = Ligo.add_tez_tez minimum_tez additional_tez in
 
-      let senders_old_mukit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* before *)
+      let senders_old_kit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* before *)
 
       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:sender ~amount:(Ligo.tez_from_literal "0mutez");
       let ops, checker = Checker.entrypoint_buy_kit (checker, (ctez_from_tez tez_provided, min_expected_kit, Ligo.timestamp_from_seconds_literal 1)) in
@@ -1092,11 +1092,11 @@ let suite =
         | _ -> failwith ("Expected [Transaction (FA12TransferTransactionValue _, _, _)] but got " ^ show_operation_list ops)
       end;
 
-      let senders_new_mukit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* after *)
+      let senders_new_kit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* after *)
 
       Ligo.geq_nat_nat
-        senders_new_mukit
-        (Ligo.add_nat_nat senders_old_mukit (kit_to_denomination_nat min_expected_kit))
+        senders_new_kit
+        (Ligo.add_nat_nat senders_old_kit (kit_to_denomination_nat min_expected_kit))
         (* FIXME: This test only rarely evaluates the 'eq' part of 'geq'. Reducing the range of possible `additional_tez` or increasing the
          * number of QCheck samples may improve this.
         *)
@@ -1375,8 +1375,8 @@ let suite =
     ("view_total_supply (FA2) - initial kit supply" >::
      fun _ ->
        Ligo.Tezos.reset ();
-       let total_mukit_amount = Checker.view_total_supply (Fa2Interface.kit_token_id, empty_checker) in
-       assert_nat_equal ~expected:(Ligo.nat_from_literal "0n") ~real:total_mukit_amount;
+       let total_kit_amount = Checker.view_total_supply (Fa2Interface.kit_token_id, empty_checker) in
+       assert_nat_equal ~expected:(Ligo.nat_from_literal "0n") ~real:total_kit_amount;
        ()
     );
 

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -1383,8 +1383,8 @@ let suite =
     ("view_total_supply (FA2) - initial lqt supply" >::
      fun _ ->
        Ligo.Tezos.reset ();
-       let total_mulqt_amount = Checker.view_total_supply (Fa2Interface.lqt_token_id, empty_checker) in
-       assert_nat_equal ~expected:(Ligo.nat_from_literal "0n") ~real:total_mulqt_amount;
+       let total_lqt_amount = Checker.view_total_supply (Fa2Interface.lqt_token_id, empty_checker) in
+       assert_nat_equal ~expected:(Ligo.nat_from_literal "0n") ~real:total_lqt_amount;
        ()
     );
 

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -875,7 +875,7 @@ let suite =
 
       Ligo.geq_nat_nat
         senders_new_mukit
-        (Ligo.add_nat_nat senders_old_mukit (kit_to_mukit_nat min_kit_expected))
+        (Ligo.add_nat_nat senders_old_mukit (kit_to_denomination_nat min_kit_expected))
     );
 
     (
@@ -891,13 +891,13 @@ let suite =
       let checker = empty_checker_with_cfmm cfmm in
       let sender = alice_addr in
 
-      let checker_cfmm_old_mukit = kit_to_mukit_nat checker.cfmm.kit in
+      let checker_cfmm_old_mukit = kit_to_denomination_nat checker.cfmm.kit in
       let senders_old_mukit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* before *)
 
       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:sender ~amount:(Ligo.tez_from_literal "0mutez");
       let ops, checker = Checker.entrypoint_buy_kit (checker, (ctez_amount, min_kit_expected, deadline)) in
 
-      let checker_cfmm_new_mukit = kit_to_mukit_nat checker.cfmm.kit in
+      let checker_cfmm_new_mukit = kit_to_denomination_nat checker.cfmm.kit in
       let senders_new_mukit = Fa2Interface.get_fa2_ledger_value checker.fa2_state.ledger (Fa2Interface.kit_token_id, sender) in (* after *)
 
       begin match ops with
@@ -1070,7 +1070,7 @@ let suite =
           (ratio_of_nat cfmm_kit)
           (
             sub_ratio
-              (div_ratio (ratio_of_nat (Ligo.nat_from_literal "998n")) (ratio_of_nat (kit_to_mukit_nat min_expected_kit)))
+              (div_ratio (ratio_of_nat (Ligo.nat_from_literal "998n")) (ratio_of_nat (kit_to_denomination_nat min_expected_kit)))
               (ratio_of_nat (Ligo.nat_from_literal "1n"))
           ) in
       let minimum_tez = Ligo.mul_nat_tez (Ligo.abs (Common.cdiv_int_int ratio_minimum_tez.num ratio_minimum_tez.den)) (Ligo.tez_from_literal "1mutez") in
@@ -1096,7 +1096,7 @@ let suite =
 
       Ligo.geq_nat_nat
         senders_new_mukit
-        (Ligo.add_nat_nat senders_old_mukit (kit_to_mukit_nat min_expected_kit))
+        (Ligo.add_nat_nat senders_old_mukit (kit_to_denomination_nat min_expected_kit))
         (* FIXME: This test only rarely evaluates the 'eq' part of 'geq'. Reducing the range of possible `additional_tez` or increasing the
          * number of QCheck samples may improve this.
         *)

--- a/tests/testCheckerEntrypoints.ml
+++ b/tests/testCheckerEntrypoints.ml
@@ -28,7 +28,7 @@ let with_sealed_state_and_cfmm_setup f =
        (* Add some liquidity *)
        Ligo.Tezos.new_transaction ~seconds_passed:121 ~blocks_passed:2 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let ctez_to_give = Ctez.ctez_of_muctez (Ligo.nat_from_literal "400_000n") in
-       let kit_to_give = Kit.kit_of_mukit (Ligo.nat_from_literal "400_000n") in
+       let kit_to_give = Kit.kit_of_denomination (Ligo.nat_from_literal "400_000n") in
        let min_lqt_to_mint = Lqt.lqt_of_denomination (Ligo.nat_from_literal "5n") in
        let deadline = Ligo.add_timestamp_int !Ligo.Tezos.now (Ligo.int_from_literal "20") in
        let op = CheckerMain.(CheckerEntrypoint (LazyParams (Add_liquidity (ctez_to_give, kit_to_give, min_lqt_to_mint, deadline)))) in
@@ -127,7 +127,7 @@ let suite =
           assert_raises
             (Failure (Ligo.string_of_int error_BuyKitPriceFailure))
             (fun () ->
-               let min_kit_to_buy = Kit.kit_add min_kit_to_buy (Kit.kit_of_mukit (Ligo.nat_from_literal "1n")) in
+               let min_kit_to_buy = Kit.kit_add min_kit_to_buy (Kit.kit_of_denomination (Ligo.nat_from_literal "1n")) in
                let op = CheckerMain.(CheckerEntrypoint (LazyParams (Buy_kit (ctez_to_sell, min_kit_to_buy, deadline)))) in
                CheckerMain.main (op, sealed_wrapper)
             )
@@ -137,7 +137,7 @@ let suite =
     ("wrapper_view_sell_kit_min_ctez_expected - sealed" >::
      with_sealed_state_and_cfmm_setup
        (fun sealed_wrapper ->
-          let kit_to_sell = Kit.kit_of_mukit (Ligo.nat_from_literal "100_000n") in
+          let kit_to_sell = Kit.kit_of_denomination (Ligo.nat_from_literal "100_000n") in
           let min_ctez_to_buy = CheckerEntrypoints.wrapper_view_sell_kit_min_ctez_expected (kit_to_sell, sealed_wrapper) in
           let deadline = Ligo.add_timestamp_int !Ligo.Tezos.now (Ligo.int_from_literal "20") in
           (* must succeed, otherwise wrapper_view_sell_kit_min_ctez_expected overapproximated *)
@@ -174,7 +174,7 @@ let suite =
           assert_raises
             (Failure (Ligo.string_of_int error_AddLiquidityTooMuchKitRequired))
             (fun () ->
-               let max_kit_to_sell = Kit.kit_sub max_kit_to_sell (Kit.kit_of_mukit (Ligo.nat_from_literal "1n")) in
+               let max_kit_to_sell = Kit.kit_sub max_kit_to_sell (Kit.kit_of_denomination (Ligo.nat_from_literal "1n")) in
                let op = CheckerMain.(CheckerEntrypoint (LazyParams (Add_liquidity (ctez_to_sell, max_kit_to_sell, min_lqt_to_buy, deadline)))) in
                CheckerMain.main (op, sealed_wrapper)
             );
@@ -215,7 +215,7 @@ let suite =
           assert_raises
             (Failure (Ligo.string_of_int error_RemoveLiquidityCantWithdrawEnoughKit))
             (fun () ->
-               let min_kit_to_buy = Kit.kit_add min_kit_to_buy (Kit.kit_of_mukit (Ligo.nat_from_literal "1n")) in
+               let min_kit_to_buy = Kit.kit_add min_kit_to_buy (Kit.kit_of_denomination (Ligo.nat_from_literal "1n")) in
                let op = CheckerMain.(CheckerEntrypoint (LazyParams (Remove_liquidity (lqt_to_sell, min_ctez_to_buy, min_kit_to_buy, deadline)))) in
                CheckerMain.main (op, sealed_wrapper)
             )
@@ -239,7 +239,7 @@ let suite =
           let op = CheckerMain.(CheckerEntrypoint (LazyParams (Create_burrow (Ligo.nat_from_literal "0n", None)))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
           assert_kit_equal
-            ~expected:(Kit.kit_of_mukit (Ligo.nat_from_literal "476_190n"))
+            ~expected:(Kit.kit_of_denomination (Ligo.nat_from_literal "476_190n"))
             ~real:(CheckerEntrypoints.wrapper_view_burrow_max_mintable_kit ((bob_addr, Ligo.nat_from_literal "0n"), sealed_wrapper))
        )
     );

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -113,13 +113,13 @@ let suite =
     ("If checker is not sealed, the deployer should be able to call DeployFunction - Mint_kit" >::
      fun _ ->
        test_deploy_function_with_lazy_params_succeeds
-         (Mint_kit (Ligo.nat_from_literal "29n", Kit.kit_of_mukit (Ligo.nat_from_literal "231_643n"))) (* note: values randomly chosen *)
+         (Mint_kit (Ligo.nat_from_literal "29n", Kit.kit_of_denomination (Ligo.nat_from_literal "231_643n"))) (* note: values randomly chosen *)
     );
 
     ("If checker is not sealed, the deployer should be able to call DeployFunction - Burn_kit" >::
      fun _ ->
        test_deploy_function_with_lazy_params_succeeds
-         (Burn_kit (Ligo.nat_from_literal "826n", Kit.kit_of_mukit (Ligo.nat_from_literal "5_473_525_867n"))) (* note: values randomly chosen *)
+         (Burn_kit (Ligo.nat_from_literal "826n", Kit.kit_of_denomination (Ligo.nat_from_literal "5_473_525_867n"))) (* note: values randomly chosen *)
     );
 
     ("If checker is not sealed, the deployer should be able to call DeployFunction - Activate_burrow" >::
@@ -167,7 +167,7 @@ let suite =
     ("If checker is not sealed, the deployer should be able to call DeployFunction - Buy_kit" >::
      fun _ ->
        let ctez = Ctez.ctez_of_muctez (Ligo.nat_from_literal "13n") in
-       let kit = Kit.kit_of_mukit (Ligo.nat_from_literal "29n") in
+       let kit = Kit.kit_of_denomination (Ligo.nat_from_literal "29n") in
        let deadline = !Ligo.Tezos.now in
        test_deploy_function_with_lazy_params_succeeds
          (Buy_kit (ctez, kit, deadline)) (* note: values randomly chosen *)
@@ -175,7 +175,7 @@ let suite =
 
     ("If checker is not sealed, the deployer should be able to call DeployFunction - Sell_kit" >::
      fun _ ->
-       let kit = Kit.kit_of_mukit (Ligo.nat_from_literal "31n") in
+       let kit = Kit.kit_of_denomination (Ligo.nat_from_literal "31n") in
        let ctez = Ctez.ctez_of_muctez (Ligo.nat_from_literal "5n") in
        let deadline = !Ligo.Tezos.now in
        test_deploy_function_with_lazy_params_succeeds
@@ -185,7 +185,7 @@ let suite =
     ("If checker is not sealed, the deployer should be able to call DeployFunction - Add_liquidity" >::
      fun _ ->
        let ctez = Ctez.ctez_of_muctez (Ligo.nat_from_literal "97n") in
-       let kit = Kit.kit_of_mukit (Ligo.nat_from_literal "3n") in
+       let kit = Kit.kit_of_denomination (Ligo.nat_from_literal "3n") in
        let lqt = Lqt.lqt_of_denomination (Ligo.nat_from_literal "59n") in
        let deadline = !Ligo.Tezos.now in
        test_deploy_function_with_lazy_params_succeeds
@@ -196,7 +196,7 @@ let suite =
      fun _ ->
        let lqt = Lqt.lqt_of_denomination (Ligo.nat_from_literal "41n") in
        let ctez = Ctez.ctez_of_muctez (Ligo.nat_from_literal "47n") in
-       let kit = Kit.kit_of_mukit (Ligo.nat_from_literal "19n") in
+       let kit = Kit.kit_of_denomination (Ligo.nat_from_literal "19n") in
        let deadline = !Ligo.Tezos.now in
        test_deploy_function_with_lazy_params_succeeds
          (Remove_liquidity (lqt, ctez, kit, deadline)) (* note: values randomly chosen *)
@@ -205,7 +205,7 @@ let suite =
     ("If checker is not sealed, the deployer should be able to call DeployFunction - Liquidation_auction_place_bid" >::
      fun _ ->
        let auction_id = AVLPtr (Ptr.(ptr_next ptr_init)) in (* 2 *)
-       let kit = Kit.kit_of_mukit (Ligo.nat_from_literal "98n") in
+       let kit = Kit.kit_of_denomination (Ligo.nat_from_literal "98n") in
        test_deploy_function_with_lazy_params_succeeds
          (Liquidation_auction_place_bid (auction_id, kit)) (* note: values randomly chosen *)
     );
@@ -346,7 +346,7 @@ let suite =
 
           (* Mint_kit *)
           Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Mint_kit (burrow_id, Kit.kit_of_mukit (Ligo.nat_from_literal "1_000_000n"))))) in
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Mint_kit (burrow_id, Kit.kit_of_denomination (Ligo.nat_from_literal "1_000_000n"))))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
           (* Idea: Might want to touch checker here, before burning the kit, so that the
@@ -355,7 +355,7 @@ let suite =
 
           (* Burn_kit *)
           Ligo.Tezos.new_transaction ~seconds_passed:200 ~blocks_passed:3 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Burn_kit (burrow_id, Kit.kit_of_mukit (Ligo.nat_from_literal "1_000_000n"))))) in
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Burn_kit (burrow_id, Kit.kit_of_denomination (Ligo.nat_from_literal "1_000_000n"))))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
           (* Set_burrow_delegate *)

--- a/tests/testFa2Interface.ml
+++ b/tests/testFa2Interface.ml
@@ -16,7 +16,7 @@ let mk_kit_tx ~from_ ~to_ ~amount =
     txs =
       [ { to_ = to_;
           token_id = kit_token_id;
-          amount = kit_to_mukit_nat amount;
+          amount = kit_to_denomination_nat amount;
         }
       ];
   }

--- a/tests/testFa2Interface.ml
+++ b/tests/testFa2Interface.ml
@@ -8,7 +8,7 @@ open Lqt
 let property_test_count = 100
 
 (* Utility functions *)
-let ask_kit_of fa2_state addr = kit_of_mukit (fa2_get_balance (fa2_state, addr, kit_token_id))
+let ask_kit_of fa2_state addr = kit_of_denomination (fa2_get_balance (fa2_state, addr, kit_token_id))
 let ask_lqt_of fa2_state addr = lqt_of_denomination (fa2_get_balance (fa2_state, addr, lqt_token_id))
 
 let mk_kit_tx ~from_ ~to_ ~amount =
@@ -203,13 +203,13 @@ let suite =
        assert_raises
          (Failure "FA2_INSUFFICIENT_BALANCE")
          (fun () ->
-            let kit_amount = kit_of_mukit (Ligo.nat_from_literal "1n") in
+            let kit_amount = kit_of_denomination (Ligo.nat_from_literal "1n") in
             ledger_withdraw_kit (fa2_state_in, leena_addr, kit_amount)
          );
 
        (* Issue an amount, starting from zero. *)
        let fa2_state_in = fa2_state_out in
-       let kit_amount = kit_of_mukit (Ligo.nat_from_literal "123_456n") in
+       let kit_amount = kit_of_denomination (Ligo.nat_from_literal "123_456n") in
        let fa2_state_out = ledger_issue_kit (fa2_state_in, leena_addr, kit_amount) in
        assert_kit_equal
          ~expected:(kit_add (ask_kit_of fa2_state_in leena_addr) kit_amount)
@@ -217,7 +217,7 @@ let suite =
 
        (* Issue an amount, starting from non-zero. *)
        let fa2_state_in = fa2_state_out in
-       let kit_amount = kit_of_mukit (Ligo.nat_from_literal "789_012_345n") in
+       let kit_amount = kit_of_denomination (Ligo.nat_from_literal "789_012_345n") in
        let fa2_state_out = ledger_issue_kit (fa2_state_in, leena_addr, kit_amount) in
        assert_kit_equal
          ~expected:(kit_add (ask_kit_of fa2_state_in leena_addr) kit_amount)
@@ -228,13 +228,13 @@ let suite =
        assert_raises
          (Failure "FA2_INSUFFICIENT_BALANCE")
          (fun () ->
-            let kit_amount = kit_add (ask_kit_of fa2_state_in leena_addr) (kit_of_mukit (Ligo.nat_from_literal "1n")) in
+            let kit_amount = kit_add (ask_kit_of fa2_state_in leena_addr) (kit_of_denomination (Ligo.nat_from_literal "1n")) in
             ledger_withdraw_kit (fa2_state_in, leena_addr, kit_amount)
          );
 
        (* Withdrawing less than entire amount should succeed. *)
        let fa2_state_in = fa2_state_out in
-       let kit_amount = kit_sub (ask_kit_of fa2_state_in leena_addr) (kit_of_mukit (Ligo.nat_from_literal "1_234n")) in
+       let kit_amount = kit_sub (ask_kit_of fa2_state_in leena_addr) (kit_of_denomination (Ligo.nat_from_literal "1_234n")) in
        let fa2_state_out = ledger_withdraw_kit (fa2_state_in, leena_addr, kit_amount) in
        assert_kit_equal
          ~expected:(ask_kit_of fa2_state_in leena_addr)
@@ -438,19 +438,19 @@ let suite =
 
        (* Populate all accounts with different amounts. *)
        let fa2_state_in =
-         let fa2_state_in = ledger_issue_kit (fa2_state_in, leena_addr, kit_of_mukit (Ligo.nat_from_literal "7_000_000n")) in
-         let fa2_state_in = ledger_issue_kit (fa2_state_in, bob_addr,   kit_of_mukit (Ligo.nat_from_literal "8_000_000n")) in
-         let fa2_state_in = ledger_issue_kit (fa2_state_in, alice_addr, kit_of_mukit (Ligo.nat_from_literal "9_000_000n")) in
+         let fa2_state_in = ledger_issue_kit (fa2_state_in, leena_addr, kit_of_denomination (Ligo.nat_from_literal "7_000_000n")) in
+         let fa2_state_in = ledger_issue_kit (fa2_state_in, bob_addr,   kit_of_denomination (Ligo.nat_from_literal "8_000_000n")) in
+         let fa2_state_in = ledger_issue_kit (fa2_state_in, alice_addr, kit_of_denomination (Ligo.nat_from_literal "9_000_000n")) in
          fa2_state_in in
 
        (* Ensure all accounts have the expected kit in them. *)
-       assert_kit_equal ~expected:(kit_of_mukit (Ligo.nat_from_literal "7_000_000n")) ~real:(ask_kit_of fa2_state_in leena_addr);
-       assert_kit_equal ~expected:(kit_of_mukit (Ligo.nat_from_literal "8_000_000n")) ~real:(ask_kit_of fa2_state_in bob_addr);
-       assert_kit_equal ~expected:(kit_of_mukit (Ligo.nat_from_literal "9_000_000n")) ~real:(ask_kit_of fa2_state_in alice_addr);
+       assert_kit_equal ~expected:(kit_of_denomination (Ligo.nat_from_literal "7_000_000n")) ~real:(ask_kit_of fa2_state_in leena_addr);
+       assert_kit_equal ~expected:(kit_of_denomination (Ligo.nat_from_literal "8_000_000n")) ~real:(ask_kit_of fa2_state_in bob_addr);
+       assert_kit_equal ~expected:(kit_of_denomination (Ligo.nat_from_literal "9_000_000n")) ~real:(ask_kit_of fa2_state_in alice_addr);
 
        (* Scenario 1: Alice sends funds to leena directly. *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let amount = kit_of_mukit (Ligo.nat_from_literal "123_456n") in
+       let amount = kit_of_denomination (Ligo.nat_from_literal "123_456n") in
        let tx = mk_kit_tx ~from_:alice_addr ~to_:leena_addr ~amount:amount in
        let fa2_state_out = fa2_run_transfer (fa2_state_in, [tx]) in
 
@@ -470,7 +470,7 @@ let suite =
        let update_op = add_kit_operator ~owner:leena_addr ~operator:alice_addr in
        let fa2_state_in = fa2_run_update_operators (fa2_state_in, [update_op]) in
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let amount = kit_of_mukit (Ligo.nat_from_literal "1_500_000n") in
+       let amount = kit_of_denomination (Ligo.nat_from_literal "1_500_000n") in
        let tx = mk_kit_tx ~from_:leena_addr ~to_:bob_addr ~amount:amount in
        let fa2_state_out = fa2_run_transfer (fa2_state_in, [tx]) in
 
@@ -490,9 +490,9 @@ let suite =
         * this operation to fail. *)
        let fa2_state_in = fa2_state_out in
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let amount1 = kit_of_mukit (Ligo.nat_from_literal "5_623_456n") in
+       let amount1 = kit_of_denomination (Ligo.nat_from_literal "5_623_456n") in
        let tx1 = mk_kit_tx ~from_:leena_addr ~to_:alice_addr ~amount:amount1 in
-       let amount2 = kit_of_mukit (Ligo.nat_from_literal "14_500_000n") in
+       let amount2 = kit_of_denomination (Ligo.nat_from_literal "14_500_000n") in
        let tx2 = mk_kit_tx ~from_:alice_addr ~to_:bob_addr ~amount:amount2 in
 
        (* The numbers are too high for the operations to be executed in the wrong order. *)

--- a/tests/testKit.ml
+++ b/tests/testKit.ml
@@ -21,41 +21,41 @@ let suite =
 
        (* add *)
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "8_000_000n"))
-         ~real:(kit_add (kit_of_mukit (Ligo.nat_from_literal "5_000_000n")) (kit_of_mukit (Ligo.nat_from_literal "3_000_000n")));
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "8_000_000n"))
+         ~real:(kit_add (kit_of_denomination (Ligo.nat_from_literal "5_000_000n")) (kit_of_denomination (Ligo.nat_from_literal "3_000_000n")));
 
        (* subtract *)
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "2_000_000n"))
-         ~real:(kit_sub (kit_of_mukit (Ligo.nat_from_literal "5_000_000n")) (kit_of_mukit (Ligo.nat_from_literal "3_000_000n")));
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "2_000_000n"))
+         ~real:(kit_sub (kit_of_denomination (Ligo.nat_from_literal "5_000_000n")) (kit_of_denomination (Ligo.nat_from_literal "3_000_000n")));
        assert_raises
          (Failure (Ligo.string_of_int internalError_KitSubNegative))
          (fun _ ->
-            (kit_sub (kit_of_mukit (Ligo.nat_from_literal "1n")) (kit_of_mukit (Ligo.nat_from_literal "2n")));
+            (kit_sub (kit_of_denomination (Ligo.nat_from_literal "1n")) (kit_of_denomination (Ligo.nat_from_literal "2n")));
          );
 
        (* scale *)
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "15_370_401n"))
-         ~real:(kit_scale (kit_of_mukit (Ligo.nat_from_literal "5_123_467n")) (fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "3"))));
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "15_370_401n"))
+         ~real:(kit_scale (kit_of_denomination (Ligo.nat_from_literal "5_123_467n")) (fixedpoint_of_ratio_floor (ratio_of_int (Ligo.int_from_literal "3"))));
 
        (* fractions *)
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "333_334n"))
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "333_334n"))
          ~real:(kit_of_fraction_ceil (Ligo.int_from_literal "1") (Ligo.int_from_literal "3"));
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "333_333n"))
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "333_333n"))
          ~real:(kit_of_fraction_floor (Ligo.int_from_literal "1") (Ligo.int_from_literal "3"));
 
        (* compare *)
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "5_000_000n"))
-         ~real:(max (kit_of_mukit (Ligo.nat_from_literal "5_000_000n")) (kit_of_mukit (Ligo.nat_from_literal "3_000_000n")));
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "5_000_000n"))
+         ~real:(max (kit_of_denomination (Ligo.nat_from_literal "5_000_000n")) (kit_of_denomination (Ligo.nat_from_literal "3_000_000n")));
 
        (* show *)
        assert_string_equal
          ~expected:"50309951mukit"
-         ~real:(show_kit (kit_of_mukit (Ligo.nat_from_literal "50_309_951n")));
+         ~real:(show_kit (kit_of_denomination (Ligo.nat_from_literal "50_309_951n")));
     )
   ]
 

--- a/tests/testKit.ml
+++ b/tests/testKit.ml
@@ -54,7 +54,7 @@ let suite =
 
        (* show *)
        assert_string_equal
-         ~expected:"50309951mukit"
+         ~expected:"50.309951kit"
          ~real:(show_kit (kit_of_denomination (Ligo.nat_from_literal "50_309_951n")));
     )
   ]

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -88,7 +88,7 @@ let arbitrary_non_empty_cfmm (kit_in_ctez_in_prev_block: Common.ratio) (last_lev
     (QCheck.triple TestArbitrary.arb_positive_ctez TestArbitrary.arb_positive_kit TestArbitrary.arb_lqt)
 
 (* amount >= cfmm_tez * (1 - fee) / fee *)
-(* 1mukit <= min_kit_expected < FLOOR{amount * (cfmm_kit / (cfmm_tez + amount)) * FACTOR} *)
+(* 1 (kit) <= min_kit_expected < FLOOR{amount * (cfmm_kit / (cfmm_tez + amount)) * FACTOR} *)
 (* NB: some values are fixed *)
 let make_inputs_for_buy_kit_to_succeed =
   QCheck.map

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -98,7 +98,7 @@ let make_inputs_for_buy_kit_to_succeed =
          let { Common.num = x_num; Common.den = x_den; } =
            Ratio.div_ratio (Ratio.mul_ratio (Ctez.ratio_of_ctez ctez) (Ratio.sub_ratio Common.one_ratio Constants.cfmm_fee)) Constants.cfmm_fee in
          Ctez.ctez_of_fraction_ceil x_num x_den in
-       let min_kit_expected = Kit.kit_of_mukit (Ligo.nat_from_literal "1n") in (* absolute minimum *)
+       let min_kit_expected = Kit.kit_of_denomination (Ligo.nat_from_literal "1n") in (* absolute minimum *)
        let deadline = Ligo.add_timestamp_int !Ligo.Tezos.now (Ligo.int_from_literal "1") in (* always one second later *)
        (cfmm, amount, min_kit_expected, deadline)
     )

--- a/tests/testLiquidation.ml
+++ b/tests/testLiquidation.ml
@@ -260,7 +260,7 @@ let initial_burrow =
     ~delegate:None
     ~active:true
     ~collateral:(Ligo.tez_from_literal "10_000_000mutez")
-    ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "20_000_000n"))
+    ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "20_000_000n"))
     ~adjustment_index:(compute_adjustment_index params)
     ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
     ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -274,7 +274,7 @@ let barely_not_overburrowed_test =
         ~delegate:None
         ~active:true
         ~collateral:(Ligo.tez_from_literal "7_673_400mutez")
-        ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+        ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -299,7 +299,7 @@ let barely_overburrowed_test =
         ~delegate:None
         ~active:true
         ~collateral:(Ligo.tez_from_literal "7_673_399mutez")
-        ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+        ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -324,7 +324,7 @@ let barely_non_liquidatable_test =
         ~delegate:None
         ~active:true
         ~collateral:(Ligo.tez_from_literal "6_171_200mutez")
-        ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+        ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -349,7 +349,7 @@ let barely_liquidatable_test =
         ~delegate:None
         ~active:true
         ~collateral:(Ligo.tez_from_literal "6_171_199mutez")
-        ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+        ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -369,7 +369,7 @@ let barely_liquidatable_test =
                 ~address:burrow_addr
                 ~delegate:None
                 ~collateral:(Ligo.tez_from_literal "2_346_632mutez")
-                ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+                ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "2_818_396mutez")
                 ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -384,7 +384,7 @@ let barely_liquidatable_test =
       | None | Some (Complete, _) | Some (Close, _) -> failwith "impossible"
       | Some (Partial, details) -> details in
 
-    let expected_min_kit_for_unwarranted = kit_of_mukit (Ligo.nat_from_literal "8_677_329n") in
+    let expected_min_kit_for_unwarranted = kit_of_denomination (Ligo.nat_from_literal "8_677_329n") in
     assert_kit_option_equal
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.tez_to_auction);
@@ -413,7 +413,7 @@ let barely_non_complete_liquidatable_test =
         ~delegate:None
         ~active:true
         ~collateral:(Ligo.tez_from_literal "5_065_065mutez")
-        ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+        ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -433,7 +433,7 @@ let barely_non_complete_liquidatable_test =
                 ~address:burrow_addr
                 ~delegate:None
                 ~collateral:(Ligo.tez_from_literal "0mutez")
-                ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+                ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "4_060_000mutez")
                 ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -448,7 +448,7 @@ let barely_non_complete_liquidatable_test =
       | None | Some (Complete, _) | Some (Close, _) -> failwith "impossible"
       | Some (Partial, details) -> details in
 
-    let expected_min_kit_for_unwarranted = kit_of_mukit (Ligo.nat_from_literal "15_229_815n") in
+    let expected_min_kit_for_unwarranted = kit_of_denomination (Ligo.nat_from_literal "15_229_815n") in
     assert_kit_option_equal
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.tez_to_auction);
@@ -475,7 +475,7 @@ let barely_complete_liquidatable_test =
         ~delegate:None
         ~active:true
         ~collateral:(Ligo.tez_from_literal "5_065_064mutez")
-        ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+        ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -495,7 +495,7 @@ let barely_complete_liquidatable_test =
                 ~address:burrow_addr
                 ~delegate:None
                 ~collateral:(Ligo.tez_from_literal "0mutez")
-                ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+                ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "4_059_999mutez")
                 ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -510,7 +510,7 @@ let barely_complete_liquidatable_test =
       | None | Some (Partial, _) | Some (Close, _) -> failwith "impossible"
       | Some (Complete, details) -> details in
 
-    let expected_min_kit_for_unwarranted = kit_of_mukit (Ligo.nat_from_literal "15_229_814n") in
+    let expected_min_kit_for_unwarranted = kit_of_denomination (Ligo.nat_from_literal "15_229_814n") in
     assert_kit_option_equal
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.tez_to_auction);
@@ -537,7 +537,7 @@ let barely_non_close_liquidatable_test =
         ~delegate:None
         ~active:true
         ~collateral:(Ligo.tez_from_literal "1_001_001mutez")
-        ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+        ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -557,7 +557,7 @@ let barely_non_close_liquidatable_test =
                 ~address:burrow_addr
                 ~delegate:None
                 ~collateral:(Ligo.tez_from_literal "0mutez")
-                ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+                ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
                 ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -596,7 +596,7 @@ let barely_close_liquidatable_test =
         ~delegate:None
         ~active:true
         ~collateral:(Ligo.tez_from_literal "1_001_000mutez")
-        ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+        ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -616,7 +616,7 @@ let barely_close_liquidatable_test =
                 ~address:burrow_addr
                 ~delegate:None
                 ~collateral:(Ligo.tez_from_literal "0mutez")
-                ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+                ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
                 ~collateral_at_auction:(Ligo.tez_from_literal "999_999mutez")
                 ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -631,7 +631,7 @@ let barely_close_liquidatable_test =
       | None | Some (Partial, _) | Some (Complete, _) -> failwith "impossible"
       | Some (Close, details) -> details in
 
-    let expected_min_kit_for_unwarranted = kit_of_mukit (Ligo.nat_from_literal "18_981_000n") in
+    let expected_min_kit_for_unwarranted = kit_of_denomination (Ligo.nat_from_literal "18_981_000n") in
     assert_kit_option_equal
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.tez_to_auction);
@@ -656,7 +656,7 @@ let unwarranted_liquidation_unit_test =
         ~delegate:None
         ~active:true
         ~collateral:(Ligo.tez_from_literal "7_673_400mutez")
-        ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "10_000_000n"))
+        ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -684,7 +684,7 @@ let partial_liquidation_unit_test =
                 ~delegate:None
                 ~active:true
                 ~collateral:(Ligo.tez_from_literal "1_847_528mutez")
-                ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "20_000_000n"))
+                ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "20_000_000n"))
                 ~adjustment_index:(compute_adjustment_index params)
                 ~collateral_at_auction:(Ligo.tez_from_literal "7_142_472mutez")
                 ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -701,7 +701,7 @@ let partial_liquidation_unit_test =
       | None | Some (Complete, _) | Some (Close, _) -> failwith "impossible"
       | Some (Partial, details) -> details in
 
-    let expected_min_kit_for_unwarranted = kit_of_mukit (Ligo.nat_from_literal "27_141_394n") in
+    let expected_min_kit_for_unwarranted = kit_of_denomination (Ligo.nat_from_literal "27_141_394n") in
     assert_kit_option_equal
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.tez_to_auction);
@@ -727,7 +727,7 @@ let complete_liquidation_unit_test =
         ~delegate:None
         ~active:true
         ~collateral:(Ligo.tez_from_literal "10_000_000mutez")
-        ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "100_000_000n"))
+        ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "100_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -744,7 +744,7 @@ let complete_liquidation_unit_test =
                 ~delegate:None
                 ~active:true
                 ~collateral:(Ligo.tez_from_literal "0mutez")
-                ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "100_000_000n"))
+                ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "100_000_000n"))
                 ~adjustment_index:(compute_adjustment_index params)
                 ~collateral_at_auction:(Ligo.tez_from_literal "8_990_000mutez")
                 ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -761,7 +761,7 @@ let complete_liquidation_unit_test =
       | None | Some (Partial, _) | Some (Close, _) -> failwith "impossible"
       | Some (Complete, details) -> details in
 
-    let expected_min_kit_for_unwarranted = kit_of_mukit (Ligo.nat_from_literal "170_810_000n") in
+    let expected_min_kit_for_unwarranted = kit_of_denomination (Ligo.nat_from_literal "170_810_000n") in
     assert_kit_option_equal
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.tez_to_auction);
@@ -789,7 +789,7 @@ let complete_and_close_liquidation_test =
         ~delegate:None
         ~active:true
         ~collateral:(Ligo.tez_from_literal "1_000_000mutez")
-        ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "100_000_000n"))
+        ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "100_000_000n"))
         ~adjustment_index:(compute_adjustment_index params)
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -806,7 +806,7 @@ let complete_and_close_liquidation_test =
                 ~delegate:None
                 ~active:false
                 ~collateral:(Ligo.tez_from_literal "0mutez")
-                ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "100_000_000n"))
+                ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "100_000_000n"))
                 ~adjustment_index:(compute_adjustment_index params)
                 ~collateral_at_auction:(Ligo.tez_from_literal "999_000mutez")
                 ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0)
@@ -823,7 +823,7 @@ let complete_and_close_liquidation_test =
       | None | Some (Partial, _) | Some (Complete, _) -> failwith "impossible"
       | Some (Close, details) -> details in
 
-    let expected_min_kit_for_unwarranted = kit_of_mukit (Ligo.nat_from_literal "189_810_000n") in
+    let expected_min_kit_for_unwarranted = kit_of_denomination (Ligo.nat_from_literal "189_810_000n") in
     assert_kit_option_equal
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.tez_to_auction);
@@ -849,7 +849,7 @@ let complete_and_close_liquidation_test =
 let test_burrow_request_liquidation_invariant_close =
   let upper_collat_bound_for_test = 1_001_000 in
   (* upper_collat_bound_for_test / 1.9 + 1 *)
-  let kit_to_allow_liquidation = kit_of_mukit (Ligo.nat_from_literal "526_843n") in
+  let kit_to_allow_liquidation = kit_of_denomination (Ligo.nat_from_literal "526_843n") in
   let arb_tez = QCheck.map (fun x -> Ligo.tez_from_literal ((string_of_int x) ^ "mutez")) QCheck.(0 -- upper_collat_bound_for_test) in
 
   qcheck_to_ounit
@@ -898,7 +898,7 @@ let test_burrow_request_liquidation_invariant_complete =
          (Ligo.int_from_literal "10_000"))
       (Ligo.int_from_literal "899_999") in
   let outstanding_kit = match Ligo.is_nat min_kit_to_trigger_case with
-    | Some n -> kit_add (kit_of_mukit n) extra_kit
+    | Some n -> kit_add (kit_of_denomination n) extra_kit
     | None -> failwith "The calculated outstanding_kit for the test case was not a nat"
   in
   let burrow0 = make_burrow_for_test
@@ -927,7 +927,7 @@ let test_burrow_request_liquidation_invariant_partial =
   let min_kit_for_case = 5_263_158  in
   (* (999 / 1000 collat - creation_deposit) - 1/10 * (999 / 1000 collat - creation_deposit) *)
   let max_kit_for_case = 8_091_000 in
-  let arb_kit = QCheck.map (fun x -> kit_of_mukit (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(min_kit_for_case -- max_kit_for_case) in
+  let arb_kit = QCheck.map (fun x -> kit_of_denomination (Ligo.nat_from_literal (string_of_int x ^ "n"))) QCheck.(min_kit_for_case -- max_kit_for_case) in
 
   qcheck_to_ounit
   @@ QCheck.Test.make
@@ -985,7 +985,7 @@ let regression_test_72 =
     let burrow0 =
       Burrow.make_burrow_for_test
         ~collateral:(Ligo.tez_from_literal "4369345928872593390mutez")
-        ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "3928478924648448718n"))
+        ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "3928478924648448718n"))
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~active:true
         ~address:burrow_addr
@@ -1005,7 +1005,7 @@ let regression_test_93 =
     let burrow_in =
       Burrow.make_burrow_for_test
         ~collateral:(Ligo.tez_from_literal "4369345928872593390mutez")
-        ~outstanding_kit:(kit_of_mukit (Ligo.nat_from_literal "3928478924648448718n"))
+        ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "3928478924648448718n"))
         ~collateral_at_auction:(Ligo.tez_from_literal "0mutez")
         ~active:true
         ~address:burrow_addr

--- a/tests/testLiquidationAuction.ml
+++ b/tests/testLiquidationAuction.ml
@@ -86,7 +86,7 @@ let suite =
          let slice = {
            burrow = burrow_id_1;
            tez = Ligo.tez_from_literal "4_000_000mutez";
-           min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "1_000_000n"))
+           min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "1_000_000n"))
          } in
          (* 2 ^ (Constants.max_liquidation_queue_height - 2) *)
          let max_length = 1024 in
@@ -243,7 +243,7 @@ let suite =
                      (fun outcome -> match outcome with
                         | _ -> Some {
                             sold_tez = Ligo.tez_from_literal "1mutez";
-                            winning_bid = {address=Ligo.address_of_string "someone" ; kit=kit_of_mukit (Ligo.nat_from_literal "1_000_000n")};
+                            winning_bid = {address=Ligo.address_of_string "someone" ; kit=kit_of_denomination (Ligo.nat_from_literal "1_000_000n")};
                             younger_auction = None;
                             older_auction = None;
                           }
@@ -298,13 +298,13 @@ let suite =
          liquidation_auction_send_to_auction auctions {
            burrow = burrow_id_1;
            tez = Ligo.tez_from_literal "2_000_000mutez";
-           min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "4_000_000n")); (* note: randomly chosen *)
+           min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "4_000_000n")); (* note: randomly chosen *)
          } in
        let start_price = Common.{num=(Ligo.int_from_literal "3"); den=(Ligo.int_from_literal "7")} in
        let auctions = liquidation_auction_touch auctions start_price in
        let current = Option.get auctions.current_auction in
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "4_666_667n"))
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "4_666_667n"))
          ~real:(liquidation_auction_current_auction_minimum_bid current);
     );
 
@@ -316,7 +316,7 @@ let suite =
          liquidation_auction_send_to_auction auctions {
            burrow = burrow_id_1;
            tez = Ligo.tez_from_literal "2_000_000mutez";
-           min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "4_000_000n")); (* note: randomly chosen *)
+           min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "4_000_000n")); (* note: randomly chosen *)
          } in
        let start_price = Common.one_ratio in
        let auctions = liquidation_auction_touch auctions start_price in
@@ -325,27 +325,27 @@ let suite =
          ~expected:(Some (Ligo.tez_from_literal "2_000_000mutez"))
          ~real:(liquidation_auction_current_auction_tez auctions);
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "2_000_000n"))
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "2_000_000n"))
          ~real:(liquidation_auction_current_auction_minimum_bid current);
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "2_000_000n"))
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "2_000_000n"))
          ~real:(liquidation_auction_current_auction_minimum_bid current);
        (* Price of descending auction should go down... *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "1_999_666n"))
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "1_999_666n"))
          ~real:(liquidation_auction_current_auction_minimum_bid current);
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "1_999_333n"))
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "1_999_333n"))
          ~real:(liquidation_auction_current_auction_minimum_bid current);
        Ligo.Tezos.new_transaction ~seconds_passed:58 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "1_980_098n"))
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "1_980_098n"))
          ~real:(liquidation_auction_current_auction_minimum_bid current);
        Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "1_960_394n"))
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "1_960_394n"))
          ~real:(liquidation_auction_current_auction_minimum_bid current);
     );
 
@@ -357,19 +357,19 @@ let suite =
          liquidation_auction_send_to_auction
            auctions
            { burrow = burrow_id_1; tez = Ligo.tez_from_literal "5_000_000_000mutez";
-             min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "9_000_001n")); (* note: randomly chosen *)
+             min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "9_000_001n")); (* note: randomly chosen *)
            } in
        let (auctions, _) =
          liquidation_auction_send_to_auction
            auctions
            { burrow = burrow_id_2; tez = Ligo.tez_from_literal "5_000_000_000mutez";
-             min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "9_000_002n")); (* note: randomly chosen *)
+             min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "9_000_002n")); (* note: randomly chosen *)
            } in
        let (auctions, _) =
          liquidation_auction_send_to_auction
            auctions
            { burrow = burrow_id_3; tez = Ligo.tez_from_literal "5_000_000_000mutez";
-             min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "9_000_003n")); (* note: randomly chosen *)
+             min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "9_000_003n")); (* note: randomly chosen *)
            } in
        let start_price = Common.one_ratio in
        let auctions = liquidation_auction_touch auctions start_price in
@@ -386,19 +386,19 @@ let suite =
          liquidation_auction_send_to_auction
            auctions
            { burrow = burrow_id_1; tez = Ligo.tez_from_literal "4_000_000_000mutez";
-             min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "9_000_004n")); (* note: randomly chosen *)
+             min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "9_000_004n")); (* note: randomly chosen *)
            } in
        let (auctions, _) =
          liquidation_auction_send_to_auction
            auctions
            { burrow = burrow_id_2; tez = Ligo.tez_from_literal "5_000_000_000mutez";
-             min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "9_000_005n")); (* note: randomly chosen *)
+             min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "9_000_005n")); (* note: randomly chosen *)
            } in
        let (auctions, _) =
          liquidation_auction_send_to_auction
            auctions
            { burrow = burrow_id_3; tez = Ligo.tez_from_literal "3_000_000_000mutez";
-             min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "9_000_006n")); (* note: randomly chosen *)
+             min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "9_000_006n")); (* note: randomly chosen *)
            } in
        let start_price = Common.one_ratio in
        let auctions = liquidation_auction_touch auctions start_price in
@@ -415,7 +415,7 @@ let suite =
          liquidation_auction_send_to_auction
            auctions
            { burrow = burrow_id_1; tez = Ligo.tez_from_literal "2_000_000mutez";
-             min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "4_000_007n")); (* note: randomly chosen *)
+             min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "4_000_007n")); (* note: randomly chosen *)
            } in
        let start_price = Common.one_ratio in
        let auctions = liquidation_auction_touch auctions start_price in
@@ -425,24 +425,24 @@ let suite =
        (* Below minimum bid *)
        assert_raises
          (Failure (Ligo.string_of_int error_BidTooLow))
-         (fun () -> liquidation_auction_place_bid current { address = bidder; kit = kit_of_mukit (Ligo.nat_from_literal "1_000_000n"); });
+         (fun () -> liquidation_auction_place_bid current { address = bidder; kit = kit_of_denomination (Ligo.nat_from_literal "1_000_000n"); });
        (* Right below minimum bid *)
        assert_raises
          (Failure (Ligo.string_of_int error_BidTooLow))
-         (fun () -> liquidation_auction_place_bid current { address = bidder; kit = kit_of_mukit (Ligo.nat_from_literal "1_999_999n"); });
+         (fun () -> liquidation_auction_place_bid current { address = bidder; kit = kit_of_denomination (Ligo.nat_from_literal "1_999_999n"); });
        (* On/Above minimum bid, we get a bid ticket and our bid plus 0.33 cNp becomes the new minimum bid *)
-       let (current, _) = liquidation_auction_place_bid current { address = bidder; kit = kit_of_mukit (Ligo.nat_from_literal "2_000_000n"); } in
+       let (current, _) = liquidation_auction_place_bid current { address = bidder; kit = kit_of_denomination (Ligo.nat_from_literal "2_000_000n"); } in
        assert_kit_equal
-         ~expected:(kit_of_mukit (Ligo.nat_from_literal "2_006_599n"))
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "2_006_599n"))
          ~real:(liquidation_auction_current_auction_minimum_bid current);
        (* Minimum bid does not drop over time *)
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        (* Can increase the bid.*)
-       let (current, _) = liquidation_auction_place_bid current {address=bidder; kit=kit_of_mukit (Ligo.nat_from_literal "4_000_000n")} in
+       let (current, _) = liquidation_auction_place_bid current {address=bidder; kit=kit_of_denomination (Ligo.nat_from_literal "4_000_000n")} in
        (* Does not allow a lower bid.*)
        assert_raises
          (Failure (Ligo.string_of_int error_BidTooLow))
-         (fun () -> liquidation_auction_place_bid current {address=bidder; kit=kit_of_mukit (Ligo.nat_from_literal "3_000_000n")});
+         (fun () -> liquidation_auction_place_bid current {address=bidder; kit=kit_of_denomination (Ligo.nat_from_literal "3_000_000n")});
 
        ()
     );
@@ -462,7 +462,7 @@ let suite =
         auctions
         (* Note: The amounts don't matter here. We are only interested in the bidding logic *)
         { burrow = burrow_id_1; tez = Ligo.tez_from_literal "1_000_000mutez";
-          min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal "1n")); (* note: randomly chosen *)
+          min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal "1n")); (* note: randomly chosen *)
         } in
     let start_price = Common.one_ratio in
     let auctions = liquidation_auction_touch auctions start_price in

--- a/tests/testParameters.ml
+++ b/tests/testParameters.ml
@@ -137,56 +137,56 @@ let test_compute_imbalance_zero_circulating =
 
 let test_compute_imbalance_equal =
   "test_compute_imbalance_equal" >:: fun _ ->
-    let outstanding = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
-    let circulating = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
+    let outstanding = kit_of_denomination (Ligo.nat_from_literal "1_000_000_000n") in
+    let circulating = kit_of_denomination (Ligo.nat_from_literal "1_000_000_000n") in
     assert_ratio_equal
       ~expected:Common.zero_ratio
       ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_negative_small =
   "test_compute_imbalance_negative_small" >:: fun _ ->
-    let outstanding = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
-    let circulating = kit_of_mukit (Ligo.nat_from_literal   "937_500_001n") in
+    let outstanding = kit_of_denomination (Ligo.nat_from_literal "1_000_000_000n") in
+    let circulating = kit_of_denomination (Ligo.nat_from_literal   "937_500_001n") in
     assert_ratio_equal
       ~expected:(Common.make_ratio (Ligo.int_from_literal "-187499997") (Ligo.int_from_literal "3750000004")) (* JUST BELOW SATURATION *)
       ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_negative_big =
   "test_compute_imbalance_negative_big" >:: fun _ ->
-    let outstanding = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
-    let circulating = kit_of_mukit (Ligo.nat_from_literal   "937_500_000n") in
+    let outstanding = kit_of_denomination (Ligo.nat_from_literal "1_000_000_000n") in
+    let circulating = kit_of_denomination (Ligo.nat_from_literal   "937_500_000n") in
     assert_ratio_equal
       ~expected:(Common.make_ratio (Ligo.int_from_literal "-5") (Ligo.int_from_literal "100")) (* JUST ABOVE SATURATION *)
       ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_negative_capped =
   "test_compute_imbalance_negative_capped" >:: fun _ ->
-    let outstanding = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
-    let circulating = kit_of_mukit (Ligo.nat_from_literal             "1n") in
+    let outstanding = kit_of_denomination (Ligo.nat_from_literal "1_000_000_000n") in
+    let circulating = kit_of_denomination (Ligo.nat_from_literal             "1n") in
     assert_ratio_equal
       ~expected:(Common.make_ratio (Ligo.int_from_literal "-5") (Ligo.int_from_literal "100")) (* SATURATED *)
       ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_positive_small =
   "test_compute_imbalance_positive_small" >:: fun _ ->
-    let outstanding = kit_of_mukit (Ligo.nat_from_literal   "933_333_334n") in
-    let circulating = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
+    let outstanding = kit_of_denomination (Ligo.nat_from_literal   "933_333_334n") in
+    let circulating = kit_of_denomination (Ligo.nat_from_literal "1_000_000_000n") in
     assert_ratio_equal
       ~expected:(Common.make_ratio (Ligo.int_from_literal "199999998") (Ligo.int_from_literal "4000000000")) (* JUST BELOW SATURATION *)
       ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_positive_big =
   "test_compute_imbalance_positive_big" >:: fun _ ->
-    let outstanding = kit_of_mukit (Ligo.nat_from_literal   "933_333_333n") in
-    let circulating = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
+    let outstanding = kit_of_denomination (Ligo.nat_from_literal   "933_333_333n") in
+    let circulating = kit_of_denomination (Ligo.nat_from_literal "1_000_000_000n") in
     assert_ratio_equal
       ~expected:(Common.make_ratio (Ligo.int_from_literal "5") (Ligo.int_from_literal "100")) (* JUST ABOVE SATURATION *)
       ~real:(compute_imbalance outstanding circulating)
 
 let test_compute_imbalance_positive_capped =
   "test_compute_imbalance_positive_capped" >:: fun _ ->
-    let outstanding = kit_of_mukit (Ligo.nat_from_literal             "1n") in
-    let circulating = kit_of_mukit (Ligo.nat_from_literal "1_000_000_000n") in
+    let outstanding = kit_of_denomination (Ligo.nat_from_literal             "1n") in
+    let circulating = kit_of_denomination (Ligo.nat_from_literal "1_000_000_000n") in
     assert_ratio_equal
       ~expected:(Common.make_ratio (Ligo.int_from_literal "5") (Ligo.int_from_literal "100")) (* SATURATED *)
       ~real:(compute_imbalance outstanding circulating)
@@ -558,8 +558,8 @@ let test_touch_1 =
         drift  = fixedpoint_of_hex_string "0.00000000848F8818"; (* 0.00000000012056322737 *)
         burrow_fee_index = fixedpoint_of_hex_string "1.00000991D674CC29"; (* 1.00000057039729312258 *)
         imbalance_index = fixedpoint_of_hex_string "0.FFFFA04D9F700662";
-        outstanding_kit = kit_of_mukit (Ligo.nat_from_literal "999_994n");
-        circulating_kit = kit_of_mukit (Ligo.nat_from_literal "0_000_000n"); (* NOTE that it ends up being identical to the one we started with *)
+        outstanding_kit = kit_of_denomination (Ligo.nat_from_literal "999_994n");
+        circulating_kit = kit_of_denomination (Ligo.nat_from_literal "0_000_000n"); (* NOTE that it ends up being identical to the one we started with *)
         last_touched = !Ligo.Tezos.now;
       }
       ~real:new_parameters;
@@ -577,8 +577,8 @@ let test_touch_2 =
         drift_derivative = fixedpoint_zero;
         burrow_fee_index = fixedpoint_one;
         imbalance_index = fixedpoint_one;
-        outstanding_kit = (kit_of_mukit (Ligo.nat_from_literal "1_753_165n")); (* 1_753_164n should leave as is *)
-        circulating_kit = (kit_of_mukit (Ligo.nat_from_literal "1_000_000n"));
+        outstanding_kit = (kit_of_denomination (Ligo.nat_from_literal "1_753_165n")); (* 1_753_164n should leave as is *)
+        circulating_kit = (kit_of_denomination (Ligo.nat_from_literal "1_000_000n"));
         last_touched = Ligo.timestamp_from_seconds_literal 0;
       } in
     Ligo.Tezos.reset ();
@@ -597,13 +597,13 @@ let test_touch_2 =
         drift = fixedpoint_of_hex_string "0.00000000848F8818";
         burrow_fee_index = fixedpoint_of_hex_string "1.00000991D674CC29";
         imbalance_index = fixedpoint_of_hex_string "0.FFFFA04D9F700662";
-        outstanding_kit = kit_of_mukit (Ligo.nat_from_literal "1_753_155n");
-        circulating_kit = kit_of_mukit (Ligo.nat_from_literal "1_000_001n");
+        outstanding_kit = kit_of_denomination (Ligo.nat_from_literal "1_753_155n");
+        circulating_kit = kit_of_denomination (Ligo.nat_from_literal "1_000_001n");
         last_touched = !Ligo.Tezos.now;
       }
       ~real:new_parameters;
     assert_kit_equal
-      ~expected:(kit_of_mukit (Ligo.nat_from_literal "1n"))
+      ~expected:(kit_of_denomination (Ligo.nat_from_literal "1n"))
       ~real:total_accrual_to_cfmm
 
 (* ************************************************************************* *)
@@ -787,7 +787,7 @@ let test_remove_outstanding_and_circulating_kit_effect_outstanding_underflow =
   @@ fun (kit1, kit2, kit3, kit4) ->
 
   let outstanding_to_remove, outstanding =
-    kit_add (kit_max kit1 kit2) (kit_of_mukit (Ligo.nat_from_literal "1n")), kit_min kit1 kit2 in (* to induce underflow *)
+    kit_add (kit_max kit1 kit2) (kit_of_denomination (Ligo.nat_from_literal "1n")), kit_min kit1 kit2 in (* to induce underflow *)
   let circulating_to_remove, circulating = kit_min kit3 kit4, kit_max kit3 kit4 in                (* to avoid underflows *)
 
   let params1 =
@@ -829,44 +829,44 @@ let test_add_remove_outstanding_circulating_kit_unit =
       ~expected:kit_zero
       ~real:params.outstanding_kit;
     (* add some circulating kit only *)
-    let kit_to_add_to_circulating = Kit.kit_of_mukit (Ligo.nat_from_literal "172_635_932_647n") in
+    let kit_to_add_to_circulating = Kit.kit_of_denomination (Ligo.nat_from_literal "172_635_932_647n") in
     let params = add_circulating_kit params kit_to_add_to_circulating in
     (* the circulating should have increased, but not the outstanding *)
     assert_kit_equal
-      ~expected:(Kit.kit_of_mukit (Ligo.nat_from_literal "172_635_932_647n"))
+      ~expected:(Kit.kit_of_denomination (Ligo.nat_from_literal "172_635_932_647n"))
       ~real:params.circulating_kit;
     assert_kit_equal
       ~expected:kit_zero
       ~real:params.outstanding_kit;
     (* add some to both the outstanding and the circulating kit *)
-    let kit_to_add_to_both = Kit.kit_of_mukit (Ligo.nat_from_literal "5_473_635_298_465n") in
+    let kit_to_add_to_both = Kit.kit_of_denomination (Ligo.nat_from_literal "5_473_635_298_465n") in
     let params = add_outstanding_and_circulating_kit params kit_to_add_to_both in
     (* both should have increased *)
     assert_kit_equal
-      ~expected:(Kit.kit_of_mukit (Ligo.nat_from_literal "5_646_271_231_112n"))
+      ~expected:(Kit.kit_of_denomination (Ligo.nat_from_literal "5_646_271_231_112n"))
       ~real:params.circulating_kit;
     assert_kit_equal
-      ~expected:(Kit.kit_of_mukit (Ligo.nat_from_literal "5_473_635_298_465n"))
+      ~expected:(Kit.kit_of_denomination (Ligo.nat_from_literal "5_473_635_298_465n"))
       ~real:params.outstanding_kit;
     (* remove some from both the outstanding and the circulating kit *)
-    let kit_to_remove_from_both = Kit.kit_of_mukit (Ligo.nat_from_literal "765_601_721n") in
+    let kit_to_remove_from_both = Kit.kit_of_denomination (Ligo.nat_from_literal "765_601_721n") in
     let params = remove_outstanding_and_circulating_kit params kit_to_remove_from_both kit_to_remove_from_both in
     (* both should have decreased *)
     assert_kit_equal
-      ~expected:(Kit.kit_of_mukit (Ligo.nat_from_literal "5_645_505_629_391n"))
+      ~expected:(Kit.kit_of_denomination (Ligo.nat_from_literal "5_645_505_629_391n"))
       ~real:params.circulating_kit;
     assert_kit_equal
-      ~expected:(Kit.kit_of_mukit (Ligo.nat_from_literal "5_472_869_696_744n"))
+      ~expected:(Kit.kit_of_denomination (Ligo.nat_from_literal "5_472_869_696_744n"))
       ~real:params.outstanding_kit;
     (* remove some from the circulating kit only *)
-    let kit_to_remove_from_circulating = Kit.kit_of_mukit (Ligo.nat_from_literal "4_123_827_936_001n") in
+    let kit_to_remove_from_circulating = Kit.kit_of_denomination (Ligo.nat_from_literal "4_123_827_936_001n") in
     let params = remove_circulating_kit params kit_to_remove_from_circulating in
     (*the circulating should have decreased, not not the outstanding *)
     assert_kit_equal
-      ~expected:(Kit.kit_of_mukit (Ligo.nat_from_literal "1_521_677_693_390n"))
+      ~expected:(Kit.kit_of_denomination (Ligo.nat_from_literal "1_521_677_693_390n"))
       ~real:params.circulating_kit;
     assert_kit_equal
-      ~expected:(Kit.kit_of_mukit (Ligo.nat_from_literal "5_472_869_696_744n"))
+      ~expected:(Kit.kit_of_denomination (Ligo.nat_from_literal "5_472_869_696_744n"))
       ~real:params.outstanding_kit;
     ()
 

--- a/tests/testSliceList.ml
+++ b/tests/testSliceList.ml
@@ -20,7 +20,7 @@ let gen_liquidation_slice_contents_single_burrow_id =
          LiquidationAuctionPrimitiveTypes.
            ({ tez = Ligo.tez_from_literal ((string_of_int tz) ^ "mutez")
             ; burrow = burrow_id_1
-            ; min_kit_for_unwarranted = Some (kit_of_mukit (Ligo.nat_from_literal ((string_of_int kit) ^ "n")))
+            ; min_kit_for_unwarranted = Some (kit_of_denomination (Ligo.nat_from_literal ((string_of_int kit) ^ "n")))
             })
       )
       (pair (int_range 0 10_000_000_000) (int_range 0 max_int))


### PR DESCRIPTION
Since the scaling factor for both `kit` and `lqt` can vary between checker instances, both our naming and docs could get out-of-sync. To remedy this, this PR performs the following renamings (matching our current conventions for `lqt`):

* s/kit_to_mukit_nat/kit_to_denomination_nat
* s/kit_to_mukit_int/kit_to_denomination_int
* s/kit_of_mukit/kit_of_denomination

and removes any mention of `mukit` or `mulqt` from the documentation too. I've left `muctez` as-is, since that is not for us to set.

This is the last bit of #222.