### PR TITLE
Make the API use more generic names for collateral

### DIFF
--- a/docs/spec/functional_spec.rst
+++ b/docs/spec/functional_spec.rst
@@ -49,7 +49,7 @@ Withdraw a non-negative amount of tez from a burrow. Fail if the burrow
 does not exist, if this action would overburrow it, or if the sender is not
 the burrow owner.
 
-``withdraw_tez: (pair nat mutez)``
+``withdraw_collateral: (pair nat mutez)``
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |

--- a/docs/spec/functional_spec.rst
+++ b/docs/spec/functional_spec.rst
@@ -33,7 +33,7 @@ Deposit collateral in a burrow
 Deposit a non-negative amount of tez as collateral to a burrow. Fail if
 the burrow does not exist, or if the sender is not the burrow owner.
 
-``deposit_tez: nat``
+``deposit_collateral: nat``
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -285,7 +285,7 @@ class E2ETest(SandboxedTestCase):
         call_checker_endpoint("deposit_collateral", 1, amount=2_000_000)
 
         # Withdraw tez
-        call_checker_endpoint("withdraw_tez", (1, 2_000_000))
+        call_checker_endpoint("withdraw_collateral", (1, 2_000_000))
 
         # Set delegate
         call_checker_endpoint("set_burrow_delegate", (1, account))

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -177,7 +177,7 @@ def cancel_liquidation_slice_profiler(
         }
     }
     for op in ret["contents"]:
-        # Ignore other operations (e.g. deposit_tez)
+        # Ignore other operations (e.g. deposit_collateral)
         if op["parameters"]["entrypoint"] != "cancel_liquidation_slice":
             continue
         profile["cancel_liquidation_slice"]["gas"].append(op["gas_limit"])
@@ -282,7 +282,7 @@ class E2ETest(SandboxedTestCase):
         assert_kit_balance(checker, account, 999_990)
 
         # Deposit tez
-        call_checker_endpoint("deposit_tez", 1, amount=2_000_000)
+        call_checker_endpoint("deposit_collateral", 1, amount=2_000_000)
 
         # Withdraw tez
         call_checker_endpoint("withdraw_tez", (1, 2_000_000))
@@ -580,7 +580,7 @@ class LiquidationsStressTest(SandboxedTestCase):
         ):
             cancel_ops.append(
                 (
-                    checker.deposit_tez(
+                    checker.deposit_collateral(
                         leaf["leaf"]["value"]["contents"]["burrow"][1]
                     ).with_amount(1_000_000_000),
                     checker.cancel_liquidation_slice(queued_leaf_ptr),

--- a/src/burrow.ml
+++ b/src/burrow.ml
@@ -192,7 +192,7 @@ let burrow_create (p: parameters) (addr: Ligo.address) (tok: tok) (delegate_opt:
 
 (** Add non-negative collateral to a burrow. *)
 (* TOKFIX: we need a more generic name (e.g., deposit_collateral) *)
-let[@inline] burrow_deposit_tez (p: parameters) (t: tok) (b: burrow) : burrow =
+let[@inline] burrow_deposit_collateral (p: parameters) (t: tok) (b: burrow) : burrow =
   let b = burrow_touch p b in
   let burrow_out = { b with collateral = tok_add b.collateral t } in
   assert (b.address = burrow_out.address);

--- a/src/burrow.ml
+++ b/src/burrow.ml
@@ -201,7 +201,7 @@ let[@inline] burrow_deposit_collateral (p: parameters) (t: tok) (b: burrow) : bu
 (** Withdraw a non-negative amount of collateral from the burrow, as long as
   * this will not overburrow it. *)
 (* TOKFIX: we need a more generic name (e.g., withdraw_collateral) *)
-let burrow_withdraw_tez (p: parameters) (t: tok) (b: burrow) : burrow =
+let burrow_withdraw_collateral (p: parameters) (t: tok) (b: burrow) : burrow =
   let b = burrow_touch p b in
   let burrow = { b with collateral = tok_sub b.collateral t } in
   let burrow_out = if burrow_is_overburrowed p burrow

--- a/src/burrow.mli
+++ b/src/burrow.mli
@@ -85,7 +85,7 @@ val burrow_deposit_collateral : parameters -> tok -> burrow -> burrow
 
 (** Withdraw an amount of collateral from the burrow, as long as this will
   * not overburrow it. *)
-val burrow_withdraw_tez : parameters -> tok -> burrow -> burrow
+val burrow_withdraw_collateral : parameters -> tok -> burrow -> burrow
 
 (** Mint a non-negative amount of kit from the burrow, as long as this will
   * not overburrow it *)

--- a/src/burrow.mli
+++ b/src/burrow.mli
@@ -81,7 +81,7 @@ val burrow_return_slice_from_auction : LiquidationAuctionPrimitiveTypes.liquidat
 val burrow_create : parameters -> Ligo.address -> tok -> Ligo.key_hash option -> burrow
 
 (** Add non-negative collateral to a burrow. *)
-val burrow_deposit_tez : parameters -> tok -> burrow -> burrow
+val burrow_deposit_collateral : parameters -> tok -> burrow -> burrow
 
 (** Withdraw an amount of collateral from the burrow, as long as this will
   * not overburrow it. *)

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -177,12 +177,12 @@ let entrypoint_touch_burrow (state, burrow_id: checker * burrow_id) : LigoOp.ope
   assert_checker_invariants state;
   (([]: LigoOp.operation list), state)
 
-let entrypoint_deposit_tez (state, burrow_no: checker * Ligo.nat) : (LigoOp.operation list * checker) =
+let entrypoint_deposit_collateral (state, burrow_no: checker * Ligo.nat) : (LigoOp.operation list * checker) =
   assert_checker_invariants state;
   let burrow_id = (!Ligo.Tezos.sender, burrow_no) in
   let burrow = find_burrow state.burrows burrow_id in
   let _ = ensure_burrow_has_no_unclaimed_slices state.liquidation_auctions burrow_id in
-  let burrow = burrow_deposit_tez state.parameters (tok_of_tez !Ligo.Tezos.amount) burrow in
+  let burrow = burrow_deposit_collateral state.parameters (tok_of_tez !Ligo.Tezos.amount) burrow in
   let op = match (LigoOp.Tezos.get_entrypoint_opt "%burrowStoreTez" (burrow_address burrow) : unit Ligo.contract option) with
     | Some c -> LigoOp.Tezos.unit_transaction () !Ligo.Tezos.amount c
     | None -> (Ligo.failwith error_GetEntrypointOptFailureBurrowStoreTez : LigoOp.operation) in

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -206,13 +206,13 @@ let entrypoint_mint_kit (state, (burrow_no, kit): checker * (Ligo.nat * kit)) : 
   assert_checker_invariants state;
   (([]: LigoOp.operation list), state)
 
-let entrypoint_withdraw_tez (state, (burrow_no, tez): checker * (Ligo.nat * Ligo.tez)) : LigoOp.operation list * checker =
+let entrypoint_withdraw_collateral (state, (burrow_no, tez): checker * (Ligo.nat * Ligo.tez)) : LigoOp.operation list * checker =
   assert_checker_invariants state;
   let burrow_id = (!Ligo.Tezos.sender, burrow_no) in
   let _ = ensure_no_tez_given () in
   let burrow = find_burrow state.burrows burrow_id in
   let _ = ensure_burrow_has_no_unclaimed_slices state.liquidation_auctions burrow_id in
-  let burrow = burrow_withdraw_tez state.parameters (tok_of_tez tez) burrow in
+  let burrow = burrow_withdraw_collateral state.parameters (tok_of_tez tez) burrow in
   let state = {state with burrows = Ligo.Big_map.update burrow_id (Some burrow) state.burrows} in
   let op = match (LigoOp.Tezos.get_entrypoint_opt "%burrowSendTezTo" (burrow_address burrow): (Ligo.tez * Ligo.address) Ligo.contract option) with
     | Some c -> LigoOp.Tezos.tez_address_transaction (tez, !Ligo.Tezos.sender) (Ligo.tez_from_literal "0mutez") c

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -65,7 +65,7 @@ val entrypoint_deposit_collateral : checker * Ligo.nat -> (LigoOp.operation list
     - The ID of the burrow from which the collateral should be withdrawn
     - The amount of tez to withdraw
 *)
-val entrypoint_withdraw_tez : checker * (Ligo.nat * Ligo.tez) -> LigoOp.operation list * checker
+val entrypoint_withdraw_collateral : checker * (Ligo.nat * Ligo.tez) -> LigoOp.operation list * checker
 
 (** Mint kits from a specific burrow. Fail if the burrow does not exist, if
     there is not enough collateral, or if the sender is not the burrow owner.

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -55,7 +55,7 @@ val entrypoint_create_burrow : checker * (Ligo.nat * Ligo.key_hash option) -> (L
     Parameters:
     - The ID of the burrow into which the collateral will be deposited
 *)
-val entrypoint_deposit_tez : checker * Ligo.nat -> (LigoOp.operation list * checker)
+val entrypoint_deposit_collateral : checker * Ligo.nat -> (LigoOp.operation list * checker)
 
 (** Withdraw a non-negative amount of tez from a burrow. Fail if the burrow
     does not exist, if this action would overburrow it, or if the sender is not

--- a/tests/testBurrow.ml
+++ b/tests/testBurrow.ml
@@ -135,24 +135,24 @@ let suite =
          ~real:(Burrow.burrow_address burrow)
     );
 
-    ("burrow_deposit_tez - does not fail for a burrow which needs to be touched" >::
+    ("burrow_deposit_collateral - does not fail for a burrow which needs to be touched" >::
      fun _ ->
        let _ =
-         Burrow.burrow_deposit_tez
+         Burrow.burrow_deposit_collateral
            {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
            (tok_of_denomination (Ligo.nat_from_literal "1n"))
            burrow_for_needs_touch_tests
        in ()
     );
 
-    ("burrow_deposit_tez - burrow after successful deposit has expected collateral" >::
+    ("burrow_deposit_collateral - burrow after successful deposit has expected collateral" >::
      fun _ ->
        let burrow0 = make_test_burrow
            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~collateral:(tok_of_denomination (Ligo.nat_from_literal "100n")) in
 
-       let burrow = Burrow.burrow_deposit_tez
+       let burrow = Burrow.burrow_deposit_collateral
            Parameters.initial_parameters
            (tok_of_denomination (Ligo.nat_from_literal "1n"))
            burrow0 in
@@ -162,14 +162,14 @@ let suite =
          ~real:(Burrow.burrow_collateral burrow)
     );
 
-    ("burrow_deposit_tez - does not change burrow address" >::
+    ("burrow_deposit_collateral - does not change burrow address" >::
      fun _ ->
        let burrow0 = make_test_burrow
            ~outstanding_kit:kit_zero
            ~active:true
            ~collateral:tok_zero in
 
-       let burrow = Burrow.burrow_deposit_tez Parameters.initial_parameters (tok_of_denomination (Ligo.nat_from_literal "1n")) burrow0 in
+       let burrow = Burrow.burrow_deposit_collateral Parameters.initial_parameters (tok_of_denomination (Ligo.nat_from_literal "1n")) burrow0 in
 
        assert_address_equal
          ~expected:(Burrow.burrow_address burrow0)
@@ -946,7 +946,7 @@ let suite =
     (
       qcheck_to_ounit
       @@ QCheck.Test.make
-        ~name:"burrow_deposit_tez - increases burrow collateral by exactly deposit amount"
+        ~name:"burrow_deposit_collateral - increases burrow collateral by exactly deposit amount"
         ~count:property_test_count
         TestArbitrary.arb_tok
       @@ fun tok_to_deposit ->
@@ -955,7 +955,7 @@ let suite =
           ~active:true
           ~collateral:(tok_of_denomination (Ligo.nat_from_literal "100n")) in
 
-      let burrow = Burrow.burrow_deposit_tez
+      let burrow = Burrow.burrow_deposit_collateral
           Parameters.initial_parameters
           tok_to_deposit
           burrow0 in

--- a/tests/testBurrow.ml
+++ b/tests/testBurrow.ml
@@ -176,24 +176,24 @@ let suite =
          ~real:(Burrow.burrow_address  burrow)
     );
 
-    ("burrow_withdraw_tez - does not fail for a burrow which needs to be touched" >::
+    ("burrow_withdraw_collateral - does not fail for a burrow which needs to be touched" >::
      fun _ ->
        let _ =
-         Burrow.burrow_withdraw_tez
+         Burrow.burrow_withdraw_collateral
            {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
            tok_zero
            burrow_for_needs_touch_tests
        in ()
     );
 
-    ("burrow_withdraw_tez - burrow after successful withdrawal has expected collateral" >::
+    ("burrow_withdraw_collateral - burrow after successful withdrawal has expected collateral" >::
      fun _ ->
        let burrow0 = make_test_burrow
            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~collateral:(tok_of_denomination (Ligo.nat_from_literal "100n")) in
 
-       let burrow = Burrow.burrow_withdraw_tez
+       let burrow = Burrow.burrow_withdraw_collateral
            Parameters.initial_parameters
            (tok_of_denomination (Ligo.nat_from_literal "1n"))
            burrow0 in
@@ -203,21 +203,21 @@ let suite =
          ~real:(Burrow.burrow_collateral burrow)
     );
 
-    ("burrow_withdraw_tez - does not change burrow address" >::
+    ("burrow_withdraw_collateral - does not change burrow address" >::
      fun _ ->
        let burrow0 = make_test_burrow
            ~outstanding_kit:kit_zero
            ~active:true
            ~collateral:(tok_of_denomination (Ligo.nat_from_literal "1n")) in
 
-       let burrow = Burrow.burrow_withdraw_tez Parameters.initial_parameters (tok_of_denomination (Ligo.nat_from_literal "1n")) burrow0 in
+       let burrow = Burrow.burrow_withdraw_collateral Parameters.initial_parameters (tok_of_denomination (Ligo.nat_from_literal "1n")) burrow0 in
 
        assert_address_equal
          ~expected:(Burrow.burrow_address burrow0)
          ~real:(Burrow.burrow_address  burrow)
     );
 
-    ("burrow_withdraw_tez - fails if withdrawal would overburrow the burrow" >::
+    ("burrow_withdraw_collateral - fails if withdrawal would overburrow the burrow" >::
      fun _ ->
        let burrow0 = make_test_burrow
            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "4n"))
@@ -228,7 +228,7 @@ let suite =
          (Failure (Ligo.string_of_int error_WithdrawTezFailure))
          (fun () ->
             let _ =
-              Burrow.burrow_withdraw_tez
+              Burrow.burrow_withdraw_collateral
                 {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
                 (tok_of_denomination (Ligo.nat_from_literal "2n"))
                 burrow0
@@ -925,7 +925,7 @@ let suite =
 
       qcheck_to_ounit
       @@ QCheck.Test.make
-        ~name:"burrow_withdraw_tez - fails when the withdrawal would cause the burrow to be overburrowed"
+        ~name:"burrow_withdraw_collateral - fails when the withdrawal would cause the burrow to be overburrowed"
         ~count:property_test_count
         arb_tez
       @@ fun tez_to_withdraw ->
@@ -936,7 +936,7 @@ let suite =
 
       assert_raises
         (Failure (Ligo.string_of_int error_WithdrawTezFailure))
-        (fun () -> Burrow.burrow_withdraw_tez Parameters.initial_parameters tez_to_withdraw burrow);
+        (fun () -> Burrow.burrow_withdraw_collateral Parameters.initial_parameters tez_to_withdraw burrow);
       true
     );
 

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -259,7 +259,7 @@ let suite =
        | None -> assert_failure "Expected a burrow representation to exist but none was found"
     );
 
-    ("deposit_tez - owner can deposit" >::
+    ("deposit_collateral - owner can deposit" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let initial_deposit = tok_of_denomination (Ligo.nat_from_literal "3_000_000n") in
@@ -271,14 +271,14 @@ let suite =
        let (_, burrow_no) as burrow_id, checker = newly_created_burrow empty_checker "0n" in
        (* Make a deposit *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(tez_of_tok deposit);
-       let _, checker = Checker.entrypoint_deposit_tez (checker, burrow_no) in
+       let _, checker = Checker.entrypoint_deposit_collateral (checker, burrow_no) in
 
        match Ligo.Big_map.find_opt burrow_id checker.burrows with
        | Some burrow -> assert_tok_equal ~expected:expected_collateral ~real:(burrow_collateral burrow)
        | None -> assert_failure "Expected a burrow representation to exist but none was found"
     );
 
-    ("deposit_tez - non-owner cannot deposit" >::
+    ("deposit_collateral - non-owner cannot deposit" >::
      fun _ ->
        Ligo.Tezos.reset ();
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "3_000_000mutez");
@@ -288,7 +288,7 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "1_000_000mutez");
        assert_raises
          (Failure (Ligo.string_of_int error_NonExistentBurrow))
-         (fun () -> Checker.entrypoint_deposit_tez (checker, Ligo.nat_from_literal "0n"))
+         (fun () -> Checker.entrypoint_deposit_collateral (checker, Ligo.nat_from_literal "0n"))
     );
 
     ("withdraw_tez - owner can withdraw" >::
@@ -445,7 +445,7 @@ let suite =
        assert_operation_list_equal ~expected:expected_ops ~real:ops
     );
 
-    ("entrypoint_deposit_tez - emits expected operations" >::
+    ("entrypoint_deposit_collateral - emits expected operations" >::
      fun _ ->
        Ligo.Tezos.reset ();
        (* Create the burrow *)
@@ -453,7 +453,7 @@ let suite =
        let (_, burrow_no), checker = newly_created_burrow empty_checker "0n" in
        (* Make a deposit *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "3_000_000mutez");
-       let ops, checker = Checker.entrypoint_deposit_tez (checker, burrow_no) in
+       let ops, checker = Checker.entrypoint_deposit_collateral (checker, burrow_no) in
        let burrow = Option.get (Ligo.Big_map.find_opt (alice_addr, burrow_no) checker.burrows) in
        let expected_ops = [
          (LigoOp.Tezos.unit_transaction
@@ -520,7 +520,7 @@ let suite =
 
        (* Deposit some extra collateral to one of the burrows with slices in the auction queue *)
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:burrow_owner ~amount:(Ligo.tez_from_literal "4_000_000mutez");
-       let _, checker = Checker.entrypoint_deposit_tez (checker, burrow_no) in
+       let _, checker = Checker.entrypoint_deposit_collateral (checker, burrow_no) in
 
        (* Now cancel one of the burrow's liquidation slices *)
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:burrow_owner ~amount:(Ligo.tez_from_literal "0mutez");
@@ -1760,7 +1760,7 @@ let suite =
        ()
     );
 
-    ("deposit_tez - does not fail on untouched burrows" >::
+    ("deposit_collateral - does not fail on untouched burrows" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let amount = tez_of_tok Constants.creation_deposit in
@@ -1772,7 +1772,7 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to deposit some tez to the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:amount;
-       let _ = Checker.entrypoint_deposit_tez (checker, Ligo.nat_from_literal "0n") in
+       let _ = Checker.entrypoint_deposit_collateral (checker, Ligo.nat_from_literal "0n") in
        ()
     );
 

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -291,7 +291,7 @@ let suite =
          (fun () -> Checker.entrypoint_deposit_collateral (checker, Ligo.nat_from_literal "0n"))
     );
 
-    ("withdraw_tez - owner can withdraw" >::
+    ("withdraw_collateral - owner can withdraw" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let initial_deposit = tok_of_denomination (Ligo.nat_from_literal "3_000_000n") in
@@ -302,14 +302,14 @@ let suite =
        let burrow_id, checker = newly_created_burrow empty_checker "0n" in
 
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.entrypoint_withdraw_tez (checker, (Ligo.nat_from_literal "0n", tez_of_tok withdrawal)) in
+       let _, checker = Checker.entrypoint_withdraw_collateral (checker, (Ligo.nat_from_literal "0n", tez_of_tok withdrawal)) in
 
        match Ligo.Big_map.find_opt burrow_id checker.burrows with
        | Some burrow -> assert_tok_equal ~expected:expected_collateral ~real:(burrow_collateral burrow)
        | None -> assert_failure "Expected a burrow representation to exist but none was found"
     );
 
-    ("withdraw_tez - transaction with value > 0 fails" >::
+    ("withdraw_collateral - transaction with value > 0 fails" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let initial_deposit = Ligo.tez_from_literal "3_000_000mutez" in
@@ -321,10 +321,10 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "42mutez");
        assert_raises
          (Failure (Ligo.string_of_int error_UnwantedTezGiven))
-         (fun () -> Checker.entrypoint_withdraw_tez (checker, (Ligo.nat_from_literal "0n", withdrawal)))
+         (fun () -> Checker.entrypoint_withdraw_collateral (checker, (Ligo.nat_from_literal "0n", withdrawal)))
     );
 
-    ("withdraw_tez - non-owner cannot withdraw" >::
+    ("withdraw_collateral - non-owner cannot withdraw" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let initial_deposit = Ligo.tez_from_literal "3_000_000mutez" in
@@ -335,7 +335,7 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
        assert_raises
          (Failure (Ligo.string_of_int error_NonExistentBurrow))
-         (fun () -> Checker.entrypoint_withdraw_tez (checker, (Ligo.nat_from_literal "0n", withdrawal)))
+         (fun () -> Checker.entrypoint_withdraw_collateral (checker, (Ligo.nat_from_literal "0n", withdrawal)))
     );
 
     ("entrypoint_activate_burrow - emits expected operations" >::
@@ -703,7 +703,7 @@ let suite =
        assert_operation_list_equal ~expected:[] ~real:ops
     );
 
-    ("entrypoint_withdraw_tez - emits expected operations" >::
+    ("entrypoint_withdraw_collateral - emits expected operations" >::
      fun _ ->
        Ligo.Tezos.reset ();
        (* Create a burrow *)
@@ -711,7 +711,7 @@ let suite =
        let (_, burrow_no), checker = newly_created_burrow empty_checker "0n" in
        (* Try to withdraw some tez from the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let ops, checker = Checker.entrypoint_withdraw_tez (checker, (Ligo.nat_from_literal "0n", Ligo.tez_from_literal "1_000_000mutez")) in
+       let ops, checker = Checker.entrypoint_withdraw_collateral (checker, (Ligo.nat_from_literal "0n", Ligo.tez_from_literal "1_000_000mutez")) in
        let burrow = Option.get (Ligo.Big_map.find_opt (alice_addr, burrow_no) checker.burrows) in
        let expected_ops = [
          (LigoOp.Tezos.tez_address_transaction
@@ -1776,7 +1776,7 @@ let suite =
        ()
     );
 
-    ("entrypoint_withdraw_tez - does not fail on untouched burrows" >::
+    ("entrypoint_withdraw_collateral - does not fail on untouched burrows" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let amount = tez_of_tok (tok_add Constants.creation_deposit Constants.creation_deposit) in
@@ -1788,7 +1788,7 @@ let suite =
        let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
        (* Try to withdraw some tez from the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _ = Checker.entrypoint_withdraw_tez (checker, (Ligo.nat_from_literal "0n", tez_of_tok Constants.creation_deposit)) in
+       let _ = Checker.entrypoint_withdraw_collateral (checker, (Ligo.nat_from_literal "0n", tez_of_tok Constants.creation_deposit)) in
        ()
     );
 

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -104,10 +104,10 @@ let suite =
          (Deposit_collateral (Ligo.nat_from_literal "128n")) (* note: values randomly chosen *)
     );
 
-    ("If checker is not sealed, the deployer should be able to call DeployFunction - Withdraw_tez" >::
+    ("If checker is not sealed, the deployer should be able to call DeployFunction - Withdraw_collateral" >::
      fun _ ->
        test_deploy_function_with_lazy_params_succeeds
-         (Withdraw_tez (Ligo.nat_from_literal "32n", Ligo.tez_from_literal "4_231_643mutez")) (* note: values randomly chosen *)
+         (Withdraw_collateral (Ligo.nat_from_literal "32n", Ligo.tez_from_literal "4_231_643mutez")) (* note: values randomly chosen *)
     );
 
     ("If checker is not sealed, the deployer should be able to call DeployFunction - Mint_kit" >::
@@ -339,9 +339,9 @@ let suite =
           let op = CheckerMain.(CheckerEntrypoint (LazyParams (Deposit_collateral (burrow_id)))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
-          (* Withdraw_tez *)
+          (* Withdraw_collateral *)
           Ligo.Tezos.new_transaction ~seconds_passed:121 ~blocks_passed:2 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Withdraw_tez (burrow_id, Ligo.tez_from_literal "1_000_000mutez")))) in
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Withdraw_collateral (burrow_id, Ligo.tez_from_literal "1_000_000mutez")))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
           (* Mint_kit *)

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -98,10 +98,10 @@ let suite =
          (Create_burrow (Ligo.nat_from_literal "63n", Some charles_key_hash)) (* note: values randomly chosen *)
     );
 
-    ("If checker is not sealed, the deployer should be able to call DeployFunction - Deposit_tez" >::
+    ("If checker is not sealed, the deployer should be able to call DeployFunction - Deposit_collateral" >::
      fun _ ->
        test_deploy_function_with_lazy_params_succeeds
-         (Deposit_tez (Ligo.nat_from_literal "128n")) (* note: values randomly chosen *)
+         (Deposit_collateral (Ligo.nat_from_literal "128n")) (* note: values randomly chosen *)
     );
 
     ("If checker is not sealed, the deployer should be able to call DeployFunction - Withdraw_tez" >::
@@ -334,9 +334,9 @@ let suite =
           let op = CheckerMain.(CheckerEntrypoint (LazyParams (Create_burrow (burrow_id, None)))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
-          (* Deposit_tez *)
+          (* Deposit_collateral *)
           Ligo.Tezos.new_transaction ~seconds_passed:62 ~blocks_passed:1 ~sender:user_addr ~amount:(Ligo.tez_from_literal "6_000_000mutez");
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Deposit_tez (burrow_id)))) in
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Deposit_collateral (burrow_id)))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
           (* Withdraw_tez *)


### PR DESCRIPTION
Specifically, implement the following renamings:
```diff
- deposit_tez
+ deposit_collateral

- withdraw_tez
+ withdraw_collateral
```
This is another small step towards addressing #213.