### PR TITLE
Fix out-of-scope variable names in .github/workflows/comment.yml

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -32,7 +32,7 @@ jobs:
             console.log(prs);
 
             async function testsPassed(ref) {
-              const res = (await github.request('GET /repos/{owner}/{repo}/commits/{ref}/check-runs', {
+              const res = (await github.request('GET /repos/{context.repo.owner}/{context.repo.repo}/commits/{ref}/check-runs', {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: ref
@@ -42,8 +42,8 @@ jobs:
 
             async function commentExists(issue_number, marker) {
               const cs = await github.issues.listComments({
-                owner,
-                repo,
+                context.repo.owner,
+                context.repo.repo,
                 issue_number,
               })
 


### PR DESCRIPTION
See error here: https://github.com/tezos-checker/checker/runs/3300497077?check_suite_focus=true

Since we didn't change anything in the script I wonder why we started getting this error now. Either way though, this might be the reason `testsPassed` kept returning `false`. We'll see.
