### PR TITLE
ci: Catch errors on the comment workflow

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -74,20 +74,29 @@ jobs:
               // only run the job if there is no existing comment
               if(await (commentExists(pr.number, marker))) {
                 console.log("Comment exists, skipping.");
-              } else {
-                const ret = await (execFile(
+                continue;
+              }
+
+              let ret;
+
+              try {
+                ret = await (execFile(
                   "nix-shell",
                   [ "--run"
                   , "./scripts/artifacts.py compare-stats --previous " + pr.base.sha + " --next " + pr.head.sha
                   ]
                 ));
-                console.log(ret);
-
-                github.issues.createComment({
-                  issue_number: pr.number,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  body: ret.stdout + "\n\n[hiddencomment]: " + marker
-                });
+              } catch (error) {
+                console.log("artifacts.py failed, skipping:", error);
+                continue;
               }
+
+              console.log(ret);
+
+              github.issues.createComment({
+                issue_number: pr.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: ret.stdout + "\n\n[hiddencomment]: " + marker
+              });
             }


### PR DESCRIPTION
`artifacts.py` might fail if the artifacts provided by the job is not of the correct shape. If this happens, it wouldn't be nice for the global comment task to fail. So, this PR wraps it with a `try..catch`. Unfortunately, as usual, we can not test it on this branch, so we'll see if it fails after merging.