### PR TITLE
Add a docker-based workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ For running the end-to-end tests, type:
 $ CHECKER_DIR=$(nix-build -A michelson --arg e2eTestsHack true --no-out-link) python e2e/main.py
 ```
 
+### Development using Docker
+
+If you are not on Linux, or do not want to install the Nix package manager; a Docker-based development environment is also
+provided:
+
+```
+$ docker build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -f nix/Dockerfile . -t checker-devcontainer
+$ docker run -it -v "$PWD:/mnt" checker-devcontainer
+```
+
+Within the image, you can use the `make` based workflow above. It also contains the `checker` executable that lets you
+deploy the contract.
+
+If you change the dependencies (including the code for the `checker` executable), spin up a fresh container.
+
 ## Local Deployment
 
 The contract can be deployed to a local, Docker sandbox run using the provided

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ CHECKER_DIR=$(nix-build -A michelson --arg e2eTestsHack true --no-out-link) py
 If you are not on Linux, or do not want to install the Nix package manager; a Docker-based development environment is also
 provided:
 
-```
+```console
 $ docker build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -f nix/Dockerfile . -t checker-devcontainer
 $ docker run -it -v "$PWD:/mnt" checker-devcontainer
 ```

--- a/nix/Dockerfile
+++ b/nix/Dockerfile
@@ -1,0 +1,62 @@
+FROM ubuntu:21.10
+
+RUN apt-get update
+RUN apt-get install -y \
+  curl xz-utils sudo \
+  # brings /etc/services which seems to be necessary for Nix
+  netbase
+
+# https://aka.ms/vscode-remote/containers/non-root-user
+ARG USER=checkeruser
+ENV USER=$USER
+
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN groupadd -f --gid $USER_GID $USER \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USER \
+    && echo $USER ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USER \
+    && chmod 0440 /etc/sudoers.d/$USER
+
+RUN mkdir /nix
+RUN chown -R $USER_UID:$USER_GID /nix /mnt
+
+USER $USER
+
+# install nix
+RUN curl -L https://nixos.org/nix/install | sh
+
+# install cachix and add tezos-checker cache
+RUN bash -c '\
+  source "$HOME/.nix-profile/etc/profile.d/nix.sh"; \
+  nix-env -iA cachix -f https://cachix.org/api/v1/install && \
+  cachix use tezos-checker'
+
+# copy the files necessary for the nix evaluation. this is to prepopulate
+# /nix/store with checkers dependencies.
+RUN mkdir /tmp/checkernix
+
+WORKDIR /tmp/checkernix
+RUN mkdir -p nix/ bin/
+
+COPY --chown=$USER_UID:$USER_GID *.nix                      ./
+COPY --chown=$USER_UID:$USER_GID nix/*.nix nix/sources.json nix/
+
+COPY --chown=$USER_UID:$USER_GID bin/ligo                   bin/
+
+COPY --chown=$USER_UID:$USER_GID poetry.lock pyproject.toml ./
+COPY --chown=$USER_UID:$USER_GID client/                    ./client
+COPY --chown=$USER_UID:$USER_GID e2e/                       ./e2e
+
+RUN bash -c 'source "$HOME/.nix-profile/etc/profile.d/nix.sh"; nix-shell --run :'
+
+RUN rm -r /tmp/checkernix
+
+# go back to the /mnt directory
+WORKDIR /mnt
+
+USER ROOT
+COPY --chown=root:root nix/entrypoint.sh /entrypoint.sh
+
+USER $USER
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/nix/entrypoint.sh
+++ b/nix/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+NIX_SH="$HOME/.nix-profile/etc/profile.d/nix.sh"
+source "$NIX_SH"
+
+if ! [[ -f /mnt/shell.nix ]]; then
+  echo "Mount a checker repository under /mnt/ for this image to work." >&2
+  exit 1
+fi
+
+nix-shell /mnt/shell.nix --run "$@"


### PR DESCRIPTION
This PR introduces a Docker-based workflow for developing checker.

It provides instructions to build a Docker image which contains Nix alongside with a prepopulated `/nix/store` with Checker's dependencies. It expects a Checker repository to be mounted under `/nix`, and automatically enters to the `nix-shell` on entrypoint.

We had a chat with @gkaracha and decided to remove VSCode from the mix and just provide a simple Docker image. They can still edit the code using vscode, and see the errors by running `make` under the docker container (Or they can do `fd | entr -c make build-ocaml` which is exactly the same way that I develop checker, so in my opinion it is not horrible :) ).

I considered a GitHub action to build and test this Docker image, but then I decided against it because I don't think this will be changed frequently.