### PR TITLE
Add a GitHub workflow to deploy checker to a testnet

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -16,15 +16,15 @@ on:
       node:
         description: 'Node to connect to'
         required: true
-        default: 'https://edonet.smartpy.io/'
+        default: 'https://rpczero.tzbeta.net/'
       ctez:
         description: 'Ctez contract'
         required: true
-        default: 'KT1JHiNYzzwYZ2sZmZGcPCqgi3RAjoWshntQ'
+        default: 'KT1XaQyVJHKzr1qXPMoLawi56esqKzyzeuhE'
       oracle:
         description: 'Oracle contract'
         required: true
-        default: 'KT1RAcdY2zaX5PryXV9PDdJsT3cubWXkVEBg'
+        default: 'KT1Xbo2Lkg6nPqyka4fqD7kLTtW5wDD3vkGe'
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -2,7 +2,7 @@
 # It contains the private key on a testnet. To reproduce, fetch an account from the faucet,
 # and run:
 #
-#   tezos-client activate account alice with tz1Ukue3ZGoNM6UY3mgGcrQnRqg68DsXECZC.json
+#   tezos-client activate account alice with tz1xxx.json
 #   tezos-client reveal key for alice
 #   tezos-client show address alice -S
 #

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -1,0 +1,61 @@
+# This workflow depends on a repository secret called `TESTNET_ACCOUNT_SECRET_KEY`.
+# It contains the private key on a testnet. To reproduce, fetch an account from the faucet,
+# and run:
+#
+#   tezos-client activate account alice with tz1Ukue3ZGoNM6UY3mgGcrQnRqg68DsXECZC.json
+#   tezos-client reveal key for alice
+#   tezos-client show address alice -S
+#
+# Then set the `Secret Key` as the aforamentioned secret. It should be of form: unencrypted:edsk****
+
+name: Deploy to the testnet
+
+on:
+  workflow_dispatch:
+    inputs:
+      node:
+        description: 'Node to connect to'
+        required: true
+        default: 'https://edonet.smartpy.io/'
+      ctez:
+        description: 'Ctez contract'
+        required: true
+        default: 'KT1JHiNYzzwYZ2sZmZGcPCqgi3RAjoWshntQ'
+      oracle:
+        description: 'Oracle contract'
+        required: true
+        default: 'KT1RAcdY2zaX5PryXV9PDdJsT3cubWXkVEBg'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cachix/install-nix-action@v13
+      - uses: actions/checkout@v2
+      - uses: cachix/cachix-action@v10
+        with:
+          name: tezos-checker
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Build shell dependencies
+        run: nix-shell --pure --run ':'
+      - name: Build checker
+        run: nix-build -A michelson
+      - name: Configure checker CLI
+        run: >
+          nix-shell --pure --run '
+            checker show-config \
+              | jq ".tezos_address = \"${{ github.event.inputs.node }}\"" \
+              | jq ".tezos_port = 443" \
+              | jq ".tezos_key = \"${{ secrets.TESTNET_ACCOUNT_SECRET_KEY }}\"" \
+              | cat > ~/checkerconfig.json \
+            '
+      - name: Deploy checker
+        run: >
+          nix-shell --pure --run '
+            checker \
+              --config ~/checkerconfig.json \
+              deploy checker \
+              --src result/ \
+              --ctez "${{ github.event.inputs.ctez }}" \
+              --oracle "${{ github.event.inputs.oracle }}" \
+            '

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -6,7 +6,7 @@
 #   tezos-client reveal key for alice
 #   tezos-client show address alice -S
 #
-# Then set the `Secret Key` as the aforamentioned secret. It should be of form: unencrypted:edsk****
+# Then set the `Secret Key` as the aforementioned secret. It should be of the form: unencrypted:edsk****
 
 name: Deploy to the testnet
 


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to deploy checker to a testnet.

Once this is merged, someone with write access to the checker repository should be able to run this workflow (via navigating to this workflow through the "Actions" tab), and it should even ask for some inputs like the checker branch to deploy, RPC node, and ctez and oracle contracts.

I also withdrew some funds from the faucet to a fresh account, and created a secret called `TESTNET_ACCOUNT_SECRET_KEY` that is used by this workflow. It is not supposed to be accessible if one does not have write access to this repository, and even if it leaks somehow it is not the end of the world.

You can see (in half an hour or so) an example run here: https://github.com/tezos-checker/checker/actions/runs/1127054476