### PR TITLE
Add instructions for manually deploying checker on a testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ installed on your system and configured. Below are some instructions for
 setting up from scratch; if you've done this already, you can skip to the
 instructions "Deploy Checker" below.
 
-Initial `tezos-client` Download and Setup
----
+### Initial `tezos-client` Download and Setup
 
 1. Install `tezos-client` (instructions taken from
    [here](https://assets.tqtezos.com/docs/setup/1-tezos-client/))
@@ -142,10 +141,7 @@ $ tezos-client activate account alice with tz1Ukue3ZGoNM6UY3mgGcrQnRqg68DsXECZC.
 $ tezos-client reveal key for alice
 ```
 
-Deploy Checker
----
-This is the checker-specific setup that you need to configure and deploy it.
-
+### Deploy Checker
 
 1. Enter a nix-shell
 ```console

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $ source $HOME/.bashrc
 $ tezos-client --endpoint https://rpczero.tzbeta.net config update
 ```
 
-3. Verify that the operation worked
+3. Verify that you can connect to the network
 ```console
 $ tezos-client bootstrapped
 ```

--- a/README.md
+++ b/README.md
@@ -99,3 +99,90 @@ And finally, deploy checker itself:
 ```console
 $ checker deploy checker
 ```
+
+## Deployment to a Testnet (Manually)
+
+To be able to deploy checker on a testnet you need to have `tezos-client`
+installed on your system and configured. Below are some instructions for
+setting up from scratch; if you've done this already, you can skip to the
+instructions "Deploy Checker" below.
+
+Initial Setup
+---
+
+1. Install `tezos-client` (instructions taken from
+   [here](https://assets.tqtezos.com/docs/setup/1-tezos-client/))
+```console
+$ wget https://github.com/serokell/tezos-packaging/releases/latest/download/tezos-client
+$ chmod +x tezos-client
+$ mkdir -p $HOME/.local/bin
+$ mv tezos-client $HOME/.local/bin
+$ echo 'export PATH="$HOME/.local/bin:$PATH"' >> $HOME/.bashrc
+$ source $HOME/.bashrc
+```
+
+2. Set the node to connect to
+```console
+$ tezos-client --endpoint https://rpczero.tzbeta.net config update
+```
+
+3. Verify that the operation worked
+```console
+$ tezos-client bootstrapped
+```
+
+4. Get a json file from [the faucet (https://faucet.tzalpha.net/),
+   if you don't have one already, and import it
+```console
+$ tezos-client activate account alice with tz1Ukue3ZGoNM6UY3mgGcrQnRqg68DsXECZC.json # your json file from the faucet here
+```
+
+5. Make sure to reveal your public key to the chain otherwise injecting operations won't work
+```console
+$ tezos-client reveal key for alice
+```
+
+Deploy Checker
+---
+This is the checker-specific setup that you need to configure and deploy it.
+
+
+1. Enter a nix-shell
+```console
+$ nix-shell
+```
+
+2. Build checker
+```console
+$ make build
+```
+
+3. Find the path to CLI config file (usually at $HOME/.config/.checker)
+```console
+$ checker --help
+```
+
+4. Modify the CLI config file
+   - Set `tezos_address` to the endpoint URL above (in this case https://rpczero.tzbeta.net).
+   - Set `tezos_key` to your private key (you can find this by typing `tezos-client show address alice -S`).
+   - Set `tezos_port` to 443 (i.e., standard https port).
+
+5. If `ctez` is not already deployed, deploy one
+```console
+checker deploy ctez
+```
+
+6. If an oracle is not already deployed, you can deploy the mock oracle
+```console
+checker deploy mock-oracle
+```
+
+7. Finally, deploy checker
+```console
+$ checker deploy checker --ctez KT1DKZZbMyFeXmZJT729tWPxN5i1kChX8obw --oracle KT1MZ1h1nRXFsMRc7dDxJ9HnVTJh8WcL9qDn
+```
+After `--ctez` you need the FA1.2 address for a deployed ctez contract, and
+after `--oracle` you need the address of a deployed oracle contract.  However,
+if you had to do both `checker deploy ctez` and `checker deploy mock-oracle`,
+then `checker deploy checker` should suffice (since both these instructions
+update the CLI config file in place).

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ installed on your system and configured. Below are some instructions for
 setting up from scratch; if you've done this already, you can skip to the
 instructions "Deploy Checker" below.
 
-Initial Setup
+Initial `tezos-client` Download and Setup
 ---
 
 1. Install `tezos-client` (instructions taken from
@@ -179,7 +179,7 @@ checker deploy mock-oracle
 
 7. Finally, deploy checker
 ```console
-$ checker deploy checker --ctez KT1DKZZbMyFeXmZJT729tWPxN5i1kChX8obw --oracle KT1MZ1h1nRXFsMRc7dDxJ9HnVTJh8WcL9qDn
+$ checker deploy checker --ctez <ctez-fa12-address> --oracle <oracle-address>
 ```
 After `--ctez` you need the FA1.2 address for a deployed ctez contract, and
 after `--oracle` you need the address of a deployed oracle contract.  However,


### PR DESCRIPTION
Probably we'll use #235 more for deployment from now on, but it's probably best to have the instructions for manual deployment written down somewhere as well.