### PR TITLE
Remove the delegate from the burrow representation

### DIFF
--- a/docs/spec/burrow-state-liquidations.rst
+++ b/docs/spec/burrow-state-liquidations.rst
@@ -10,8 +10,6 @@ State
   it’s considered “inactive”.
 - ``address``: the address of the contract holding the burrow's collateral and
   creation deposit.
-- ``delegate``: the delegate for the amount of tez (collateral + creation
-  deposit) the burrow holds.
 -  ``collateral``: the amount of tez stored in the burrow. Collateral
    that has been sent to auctions **does not** count towards this
    amount; for all we know, it’s gone forever.

--- a/src/burrow.mli
+++ b/src/burrow.mli
@@ -78,7 +78,7 @@ val burrow_return_slice_from_auction : LiquidationAuctionPrimitiveTypes.liquidat
 (** Given an amount of collateral (including a creation deposit, not counting
   * towards that collateral), create a burrow with its owner set to the input
   * address. Fail if the collateral given is less than the creation deposit. *)
-val burrow_create : parameters -> Ligo.address -> tok -> Ligo.key_hash option -> burrow
+val burrow_create : parameters -> Ligo.address -> tok -> burrow
 
 (** Add non-negative collateral to a burrow. *)
 val burrow_deposit_collateral : parameters -> tok -> burrow -> burrow
@@ -104,9 +104,6 @@ val burrow_activate : parameters -> tok -> burrow -> burrow
   * (a) is already inactive, or (b) is overburrowed, or (c) has kit
   * outstanding, or (d) has collateral sent off to auctions. *)
 val burrow_deactivate : parameters -> burrow -> (burrow * tok)
-
-(** Set the delegate of a burrow. *)
-val burrow_set_delegate : parameters -> Ligo.key_hash option -> burrow -> burrow
 
 (* ************************************************************************* *)
 (*                          Liquidation-related                              *)
@@ -154,7 +151,6 @@ val burrow_active : burrow -> bool
 val make_burrow_for_test :
   active:bool ->
   address:Ligo.address ->
-  delegate:(Ligo.key_hash option) ->
   collateral:tok ->
   outstanding_kit:kit ->
   adjustment_index:fixedpoint ->

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -163,7 +163,7 @@ let[@inline] entrypoint_create_burrow (state, (burrow_no, delegate_opt): checker
       !Ligo.Tezos.amount (* NOTE!!! The creation deposit is in the burrow too, even if we don't consider it to be collateral! *)
       {checker_address = !Ligo.Tezos.self_address; burrow_id = burrow_id; } in
 
-  let burrow = burrow_create state.parameters burrow_address (tok_of_tez !Ligo.Tezos.amount) delegate_opt in
+  let burrow = burrow_create state.parameters burrow_address (tok_of_tez !Ligo.Tezos.amount) in
   let state = {state with burrows = Ligo.Big_map.update burrow_id (Some burrow) state.burrows} in
   assert_checker_invariants state;
   ([op], state)
@@ -283,11 +283,9 @@ let entrypoint_set_burrow_delegate (state, (burrow_no, delegate_opt): checker * 
   let burrow_id = (!Ligo.Tezos.sender, burrow_no) in
   let burrow = find_burrow state.burrows burrow_id in
   let _ = ensure_burrow_has_no_unclaimed_slices state.liquidation_auctions burrow_id in
-  let burrow = burrow_set_delegate state.parameters delegate_opt burrow in
   let op = match (LigoOp.Tezos.get_entrypoint_opt "%burrowSetDelegate" (burrow_address burrow) : Ligo.key_hash option Ligo.contract option) with
     | Some c -> LigoOp.Tezos.opt_key_hash_transaction delegate_opt (Ligo.tez_from_literal "0mutez") c
     | None -> (Ligo.failwith error_GetEntrypointOptFailureBurrowSetDelegate : LigoOp.operation) in
-  let state = {state with burrows = Ligo.Big_map.update burrow_id (Some burrow) state.burrows} in
   assert_checker_invariants state;
   ([op], state)
 

--- a/tests/testBurrow.ml
+++ b/tests/testBurrow.ml
@@ -16,7 +16,6 @@ let make_test_burrow ~outstanding_kit ~collateral ~active = Burrow.make_burrow_f
     ~outstanding_kit:outstanding_kit
     ~active:active
     ~address:burrow_addr
-    ~delegate:None
     ~collateral:collateral
     ~adjustment_index:fixedpoint_one
     ~collateral_at_auction:tok_zero
@@ -105,30 +104,6 @@ let suite =
            ~collateral:tok_zero in
 
        let burrow, _actual_burned = Burrow.burrow_burn_kit Parameters.initial_parameters (kit_of_denomination (Ligo.nat_from_literal "1n")) burrow0 in
-
-       assert_address_equal
-         ~expected:(Burrow.burrow_address burrow0)
-         ~real:(Burrow.burrow_address burrow)
-    );
-
-    ("burrow_set_delegate - does not fail for a burrow which needs to be touched" >::
-     fun _ ->
-       let _ =
-         Burrow.burrow_set_delegate
-           {Parameters.initial_parameters with last_touched=(Ligo.timestamp_from_seconds_literal 1)}
-           (Some charles_key_hash)
-           burrow_for_needs_touch_tests
-       in ()
-    );
-
-    ("burrow_set_delegate - does not change burrow address" >::
-     fun _ ->
-       let burrow0 = make_test_burrow
-           ~outstanding_kit:kit_zero
-           ~active:true
-           ~collateral:tok_zero in
-
-       let burrow = Burrow.burrow_set_delegate Parameters.initial_parameters (Some charles_key_hash) burrow0 in
 
        assert_address_equal
          ~expected:(Burrow.burrow_address burrow0)
@@ -446,7 +421,6 @@ let suite =
                   ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "0n"))
                   ~active:true
                   ~address:burrow_addr
-                  ~delegate:None
                   ~collateral:(tok_of_denomination (Ligo.nat_from_literal "10n"))
                   ~adjustment_index:fixedpoint_one
                   ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "1n"))
@@ -481,7 +455,7 @@ let suite =
     (* Note: this is a bit overkill but testing anyways since the address field is extremely important *)
     ("burrow_create - address matches provided address" >::
      fun _ ->
-       let burrow = Burrow.burrow_create Parameters.initial_parameters burrow_addr Constants.creation_deposit None in
+       let burrow = Burrow.burrow_create Parameters.initial_parameters burrow_addr Constants.creation_deposit in
 
        assert_address_equal
          ~expected:burrow_addr
@@ -492,7 +466,7 @@ let suite =
     (
       "burrow_create - created burrow has zero collateral at auction" >::
       fun _ ->
-        let burrow = Burrow.burrow_create Parameters.initial_parameters burrow_addr Constants.creation_deposit None in
+        let burrow = Burrow.burrow_create Parameters.initial_parameters burrow_addr Constants.creation_deposit in
 
         assert_tok_equal
           ~expected:tok_zero
@@ -502,7 +476,7 @@ let suite =
     (
       "burrow_create - created burrow has zero outstanding kit" >::
       fun _ ->
-        let burrow = Burrow.burrow_create Parameters.initial_parameters burrow_addr Constants.creation_deposit None in
+        let burrow = Burrow.burrow_create Parameters.initial_parameters burrow_addr Constants.creation_deposit in
 
         assert_kit_equal
           ~expected:kit_zero
@@ -533,7 +507,6 @@ let suite =
            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~address:burrow_addr
-           ~delegate:None
            ~collateral:tok_zero
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "1n"))
@@ -557,7 +530,6 @@ let suite =
            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "2n"))
            ~active:true
            ~address:burrow_addr
-           ~delegate:None
            ~collateral:(tok_of_denomination (Ligo.nat_from_literal "2n"))
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "3n"))
@@ -572,7 +544,6 @@ let suite =
            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "2n"))
            ~active:true
            ~address:burrow_addr
-           ~delegate:None
            ~collateral:(tok_of_denomination (Ligo.nat_from_literal "3n"))
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "2n"))
@@ -590,7 +561,6 @@ let suite =
            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
            ~active:true
            ~address:burrow_addr
-           ~delegate:None
            ~collateral:tok_zero
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "1n"))
@@ -670,7 +640,6 @@ let suite =
            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "5n"))
            ~active:true
            ~address:burrow_addr
-           ~delegate:None
            ~collateral:(tok_of_denomination (Ligo.nat_from_literal "2n"))
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "2n"))
@@ -708,7 +677,6 @@ let suite =
            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "3n"))
            ~active:true
            ~address:alice_addr
-           ~delegate:None
            ~collateral:(tok_of_denomination (Ligo.nat_from_literal "3n"))
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "3n"))
@@ -729,7 +697,6 @@ let suite =
            ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "3n"))
            ~active:true
            ~address:alice_addr
-           ~delegate:None
            ~collateral:(tok_of_denomination (Ligo.nat_from_literal "3n"))
            ~adjustment_index:fixedpoint_one
            ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "3n"))
@@ -747,7 +714,6 @@ let suite =
               ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10n"))
               ~active:true
               ~address:alice_addr
-              ~delegate:None
               ~collateral:tok_zero
               ~adjustment_index:fixedpoint_one
               ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "3n"))
@@ -766,7 +732,6 @@ let suite =
               ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1n"))
               ~active:true
               ~address:alice_addr
-              ~delegate:None
               ~collateral:tok_zero
               ~adjustment_index:fixedpoint_one
               ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "1n"))
@@ -784,7 +749,6 @@ let suite =
               ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "4_657_142n"))
               ~active:true
               ~address:alice_addr
-              ~delegate:None
               ~collateral:(tok_of_denomination (Ligo.nat_from_literal "5_000_000n"))
               ~adjustment_index:fixedpoint_one
               ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "3_000_000n"))
@@ -803,7 +767,6 @@ let suite =
             ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "4_657_143n"))
             ~active:true
             ~address:alice_addr
-            ~delegate:None
             ~collateral:(tok_of_denomination (Ligo.nat_from_literal "5_000_000n"))
             ~adjustment_index:fixedpoint_one
             ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "3_000_000n"))
@@ -822,7 +785,6 @@ let suite =
             ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "4_000_000n"))
             ~active:true
             ~address:alice_addr
-            ~delegate:None
             ~collateral:(tok_of_denomination (Ligo.nat_from_literal "2_469_999n"))
             ~adjustment_index:fixedpoint_one
             ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "3_000_000n"))
@@ -840,7 +802,6 @@ let suite =
             ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "4_000_000n"))
             ~active:true
             ~address:alice_addr
-            ~delegate:None
             ~collateral:(tok_of_denomination (Ligo.nat_from_literal "2_470_000n"))
             ~adjustment_index:fixedpoint_one
             ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "3_000_000n"))
@@ -858,7 +819,6 @@ let suite =
             ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1_000_000n"))
             ~active:true
             ~address:alice_addr
-            ~delegate:None
             ~collateral:(tok_of_denomination (Ligo.nat_from_literal "2_000_000n"))
             ~adjustment_index:fixedpoint_one
             ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "3_000_000n"))
@@ -876,7 +836,6 @@ let suite =
             ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "1_000_000n"))
             ~active:false
             ~address:alice_addr
-            ~delegate:None
             ~collateral:(tok_of_denomination (Ligo.nat_from_literal "2_000_000n"))
             ~adjustment_index:fixedpoint_one
             ~collateral_at_auction:(tok_of_denomination (Ligo.nat_from_literal "3_000_000n"))
@@ -1031,7 +990,6 @@ let suite =
           ~outstanding_kit:outstanding
           ~active:true
           ~address:burrow_addr
-          ~delegate:None
           ~collateral:(tok_of_denomination (Ligo.nat_from_literal "1n"))
           ~adjustment_index:fixedpoint_one
           ~collateral_at_auction:tok_zero
@@ -1059,7 +1017,6 @@ let suite =
           ~outstanding_kit:outstanding_kit
           ~active:true
           ~address:burrow_addr
-          ~delegate:None
           ~collateral:collateral
           ~adjustment_index:fixedpoint_one
           ~collateral_at_auction:collateral_at_auction

--- a/tests/testLiquidation.ml
+++ b/tests/testLiquidation.ml
@@ -57,7 +57,6 @@ let arbitrary_burrow (params: parameters) =
     (fun (tez, kit) ->
        make_burrow_for_test
          ~address:burrow_addr
-         ~delegate:None
          ~active:true
          ~collateral:tez
          ~outstanding_kit:kit
@@ -258,7 +257,6 @@ let test_general_liquidation_properties =
 let initial_burrow =
   make_burrow_for_test
     ~address:burrow_addr
-    ~delegate:None
     ~active:true
     ~collateral:(tok_of_denomination (Ligo.nat_from_literal "10_000_000n"))
     ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "20_000_000n"))
@@ -272,7 +270,6 @@ let barely_not_overburrowed_test =
     let burrow =
       make_burrow_for_test
         ~address:burrow_addr
-        ~delegate:None
         ~active:true
         ~collateral:(tok_of_denomination (Ligo.nat_from_literal "7_673_400n"))
         ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
@@ -297,7 +294,6 @@ let barely_overburrowed_test =
     let burrow =
       make_burrow_for_test
         ~address:burrow_addr
-        ~delegate:None
         ~active:true
         ~collateral:(tok_of_denomination (Ligo.nat_from_literal "7_673_399n"))
         ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
@@ -322,7 +318,6 @@ let barely_non_liquidatable_test =
     let burrow =
       make_burrow_for_test
         ~address:burrow_addr
-        ~delegate:None
         ~active:true
         ~collateral:(tok_of_denomination (Ligo.nat_from_literal "6_171_200n"))
         ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
@@ -347,7 +342,6 @@ let barely_liquidatable_test =
     let burrow =
       make_burrow_for_test
         ~address:burrow_addr
-        ~delegate:None
         ~active:true
         ~collateral:(tok_of_denomination (Ligo.nat_from_literal "6_171_199n"))
         ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
@@ -368,7 +362,6 @@ let barely_liquidatable_test =
               make_burrow_for_test
                 ~active:true
                 ~address:burrow_addr
-                ~delegate:None
                 ~collateral:(tok_of_denomination (Ligo.nat_from_literal "2_346_632n"))
                 ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
@@ -411,7 +404,6 @@ let barely_non_complete_liquidatable_test =
     let burrow =
       make_burrow_for_test
         ~address:burrow_addr
-        ~delegate:None
         ~active:true
         ~collateral:(tok_of_denomination (Ligo.nat_from_literal "5_065_065n"))
         ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
@@ -432,7 +424,6 @@ let barely_non_complete_liquidatable_test =
               make_burrow_for_test
                 ~active:true
                 ~address:burrow_addr
-                ~delegate:None
                 ~collateral:tok_zero
                 ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
@@ -473,7 +464,6 @@ let barely_complete_liquidatable_test =
     let burrow =
       make_burrow_for_test
         ~address:burrow_addr
-        ~delegate:None
         ~active:true
         ~collateral:(tok_of_denomination (Ligo.nat_from_literal "5_065_064n"))
         ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
@@ -494,7 +484,6 @@ let barely_complete_liquidatable_test =
               make_burrow_for_test
                 ~active:true
                 ~address:burrow_addr
-                ~delegate:None
                 ~collateral:tok_zero
                 ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
@@ -535,7 +524,6 @@ let barely_non_close_liquidatable_test =
     let burrow =
       make_burrow_for_test
         ~address:burrow_addr
-        ~delegate:None
         ~active:true
         ~collateral:(tok_of_denomination (Ligo.nat_from_literal "1_001_001n"))
         ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
@@ -556,7 +544,6 @@ let barely_non_close_liquidatable_test =
               make_burrow_for_test
                 ~active:true
                 ~address:burrow_addr
-                ~delegate:None
                 ~collateral:tok_zero
                 ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
@@ -594,7 +581,6 @@ let barely_close_liquidatable_test =
     let burrow =
       make_burrow_for_test
         ~address:burrow_addr
-        ~delegate:None
         ~active:true
         ~collateral:(tok_of_denomination (Ligo.nat_from_literal "1_001_000n"))
         ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
@@ -615,7 +601,6 @@ let barely_close_liquidatable_test =
               make_burrow_for_test
                 ~active:false
                 ~address:burrow_addr
-                ~delegate:None
                 ~collateral:tok_zero
                 ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
                 ~adjustment_index:fixedpoint_one
@@ -654,7 +639,6 @@ let unwarranted_liquidation_unit_test =
     let burrow =
       make_burrow_for_test
         ~address:burrow_addr
-        ~delegate:None
         ~active:true
         ~collateral:(tok_of_denomination (Ligo.nat_from_literal "7_673_400n"))
         ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "10_000_000n"))
@@ -682,7 +666,6 @@ let partial_liquidation_unit_test =
             burrow_state =
               make_burrow_for_test
                 ~address:burrow_addr
-                ~delegate:None
                 ~active:true
                 ~collateral:(tok_of_denomination (Ligo.nat_from_literal "1_847_528n"))
                 ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "20_000_000n"))
@@ -725,7 +708,6 @@ let complete_liquidation_unit_test =
     let burrow =
       make_burrow_for_test
         ~address:burrow_addr
-        ~delegate:None
         ~active:true
         ~collateral:(tok_of_denomination (Ligo.nat_from_literal "10_000_000n"))
         ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "100_000_000n"))
@@ -742,7 +724,6 @@ let complete_liquidation_unit_test =
             burrow_state =
               make_burrow_for_test
                 ~address:burrow_addr
-                ~delegate:None
                 ~active:true
                 ~collateral:tok_zero
                 ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "100_000_000n"))
@@ -787,7 +768,6 @@ let complete_and_close_liquidation_test =
     let burrow =
       make_burrow_for_test
         ~address:burrow_addr
-        ~delegate:None
         ~active:true
         ~collateral:(tok_of_denomination (Ligo.nat_from_literal "1_000_000n"))
         ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "100_000_000n"))
@@ -804,7 +784,6 @@ let complete_and_close_liquidation_test =
             burrow_state =
               make_burrow_for_test
                 ~address:burrow_addr
-                ~delegate:None
                 ~active:false
                 ~collateral:tok_zero
                 ~outstanding_kit:(kit_of_denomination (Ligo.nat_from_literal "100_000_000n"))
@@ -862,7 +841,6 @@ let test_burrow_request_liquidation_invariant_close =
 
   let burrow0 = make_burrow_for_test
       ~address:burrow_addr
-      ~delegate:None
       ~active:true
       ~collateral:collateral
       ~outstanding_kit:kit_to_allow_liquidation
@@ -904,7 +882,6 @@ let test_burrow_request_liquidation_invariant_complete =
   in
   let burrow0 = make_burrow_for_test
       ~address:burrow_addr
-      ~delegate:None
       ~active:true
       ~collateral:collateral
       ~outstanding_kit:outstanding_kit
@@ -939,7 +916,6 @@ let test_burrow_request_liquidation_invariant_partial =
 
   let burrow0 = make_burrow_for_test
       ~address:burrow_addr
-      ~delegate:None
       ~active:true
       ~collateral:(tok_of_denomination (Ligo.nat_from_literal (string_of_int collateral ^ "n")))
       ~outstanding_kit:outstanding_kit
@@ -990,7 +966,6 @@ let regression_test_72 =
         ~collateral_at_auction:tok_zero
         ~active:true
         ~address:burrow_addr
-        ~delegate:None
         ~adjustment_index:fixedpoint_one
         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 
@@ -1010,7 +985,6 @@ let regression_test_93 =
         ~collateral_at_auction:tok_zero
         ~active:true
         ~address:burrow_addr
-        ~delegate:None
         ~adjustment_index:fixedpoint_one
         ~last_checker_timestamp:(Ligo.timestamp_from_seconds_literal 0) in
 


### PR DESCRIPTION
Since `set_burrow_delegate` merely propagates requests to change the delegate to the burrow contract. On top of reducing byte counts and gas costs, I expect this change to reduce storage representation differences between FA2/tez collateral (that is, w.r.t. #213).