### PR TITLE
Scaling factor cleanup

### DIFF
--- a/src/cfmm.ml
+++ b/src/cfmm.ml
@@ -37,7 +37,7 @@ let cfmm_sync_last_observed (cfmm: cfmm) : cfmm =
       kit_in_ctez_in_prev_block =
         make_ratio
           (Ligo.mul_nat_int (ctez_to_muctez_nat cfmm.ctez) kit_scaling_factor_int)
-          (Ligo.mul_nat_int (kit_to_denomination_nat cfmm.kit) (Ligo.int_from_literal "1_000_000"));
+          (Ligo.mul_nat_int (kit_to_denomination_nat cfmm.kit) ctez_scaling_factor_int);
       last_level = !Ligo.Tezos.level;
     }
 
@@ -120,7 +120,7 @@ let cfmm_view_min_ctez_expected_cfmm_sell_kit
         (Ligo.mul_nat_int (ctez_to_muctez_nat cfmm.ctez) num_uf) in
     let denominator =
       Ligo.mul_int_int
-        (Ligo.int_from_literal "1_000_000")
+        ctez_scaling_factor_int
         (Ligo.mul_nat_int (kit_to_denomination_nat new_cfmm_kit) den_uf) in
     let bought_ctez = ctez_of_fraction_floor numerator denominator in
 
@@ -242,7 +242,7 @@ let cfmm_view_min_ctez_withdrawn_min_kit_withdrawn_cfmm_remove_liquidity
     let ctez_withdrawn =
       ctez_of_fraction_floor
         (Ligo.mul_nat_int (ctez_to_muctez_nat cfmm.ctez) (lqt_to_denomination_int lqt_burned))
-        (Ligo.mul_int_nat (Ligo.int_from_literal "1_000_000") (lqt_to_denomination_nat cfmm.lqt))
+        (Ligo.mul_int_nat ctez_scaling_factor_int (lqt_to_denomination_nat cfmm.lqt))
     in
     let kit_withdrawn =
       kit_of_fraction_floor

--- a/src/common.ml
+++ b/src/common.ml
@@ -60,6 +60,9 @@ let clamp_int (v: Ligo.int) (lower: Ligo.int) (upper: Ligo.int) : Ligo.int =
 (* OPERATIONS ON tez *)
 let tez_to_mutez (x: Ligo.tez) = Ligo.int (Ligo.div_tez_tez x (Ligo.tez_from_literal "1mutez"))
 
+let tez_scaling_factor_int : Ligo.int = Ligo.int_from_literal "1_000_000"
+let tez_scaling_factor_nat : Ligo.nat = Ligo.nat_from_literal "1_000_000n"
+
 (* OPERATIONS ON nat *)
 let min_nat (x: Ligo.nat) (y: Ligo.nat) = if Ligo.leq_nat_nat x y then x else y
 let max_nat (x: Ligo.nat) (y: Ligo.nat) = if Ligo.geq_nat_nat x y then x else y
@@ -92,7 +95,7 @@ let fraction_to_tez_floor (x_num: Ligo.int) (x_den: Ligo.int) : Ligo.tez =
   match Ligo.is_nat x_num with
   | None -> (Ligo.failwith internalError_FractionToTezFloorNegative : Ligo.tez)
   | Some n ->
-    let n = Ligo.mul_nat_nat n (Ligo.nat_from_literal "1_000_000n") in
+    let n = Ligo.mul_nat_nat n tez_scaling_factor_nat in
     let d = Ligo.abs x_den in
     (match Ligo.ediv_nat_nat n d with
      (* Note: Ignoring coverage for the case below since the assertion above makes it unreachable in OCaml *)

--- a/src/common.mli
+++ b/src/common.mli
@@ -15,6 +15,8 @@ val clamp_int : Ligo.int -> Ligo.int -> Ligo.int -> Ligo.int
 
 (* OPERATIONS ON tez *)
 val tez_to_mutez : Ligo.tez -> Ligo.int
+val tez_scaling_factor_int : Ligo.int
+val tez_scaling_factor_nat : Ligo.nat
 
 (* OPERATIONS ON nat *)
 val min_nat : Ligo.nat -> Ligo.nat -> Ligo.nat

--- a/src/parameters.ml
+++ b/src/parameters.ml
@@ -25,8 +25,8 @@ type parameters =
 (** Initial state of the parameters. *)
 let initial_parameters : parameters =
   { q = fixedpoint_one;
-    index = Ligo.nat_from_literal "1_000_000n";
-    protected_index = Ligo.nat_from_literal "1_000_000n";
+    index = tez_scaling_factor_nat;
+    protected_index = tez_scaling_factor_nat;
     target = fixedpoint_one;
     drift = fixedpoint_zero;
     drift_derivative = fixedpoint_zero;
@@ -47,13 +47,13 @@ let[@inline] tz_liquidation (p: parameters) : Ligo.nat = min_nat p.index p.prote
 let minting_price (p: parameters) : ratio =
   make_ratio
     (Ligo.mul_int_nat (fixedpoint_to_raw p.q) (tz_minting p))
-    (Ligo.mul_int_int (fixedpoint_to_raw fixedpoint_one) (Ligo.int_from_literal "1_000_000"))
+    (Ligo.mul_int_int fixedpoint_scaling_factor tez_scaling_factor_int)
 
 (** Current liquidation price (in tez/kit). *)
 let liquidation_price (p: parameters) : ratio =
   make_ratio
     (Ligo.mul_int_nat (fixedpoint_to_raw p.q) (tz_liquidation p))
-    (Ligo.mul_int_int (fixedpoint_to_raw fixedpoint_one) (Ligo.int_from_literal "1_000_000"))
+    (Ligo.mul_int_int fixedpoint_scaling_factor tez_scaling_factor_int)
 
 (** Given the amount of kit necessary to close all existing burrows
     (outstanding) and the amount of kit that is currently in circulation
@@ -120,7 +120,7 @@ let compute_adjustment_index (p: parameters) : fixedpoint =
           (fixedpoint_to_raw p.burrow_fee_index)
           (fixedpoint_to_raw p.imbalance_index)
        )
-       (fixedpoint_to_raw fixedpoint_one)
+       fixedpoint_scaling_factor
     )
 
 (** Given the current target, calculate the rate of change of the drift (drift
@@ -278,7 +278,7 @@ let[@inline] compute_current_q (last_q: fixedpoint) (last_drift: fixedpoint) (la
   let six_sf =
     Ligo.mul_int_int
       (Ligo.int_from_literal "6")
-      (fixedpoint_to_raw fixedpoint_one) in
+      fixedpoint_scaling_factor in
   fixedpoint_of_raw
     (fdiv_int_int
        (Ligo.mul_int_int
@@ -328,7 +328,7 @@ let[@inline] compute_current_target (current_q: fixedpoint) (current_index: Ligo
           )
        )
        (Ligo.mul_int_int
-          (Ligo.int_from_literal "1_000_000")
+          tez_scaling_factor_int
           num
        )
     )

--- a/src/tok.ml
+++ b/src/tok.ml
@@ -38,7 +38,7 @@ let tok_of_fraction_floor (x_num: Ligo.int) (x_den: Ligo.int) : tok =
 let tok_of_tez (tz: Ligo.tez) : tok =
   tok_of_fraction_floor
     (Ligo.int (Ligo.div_tez_tez tz (Ligo.tez_from_literal "1mutez")))
-    (Ligo.int_from_literal "1_000_000")
+    tez_scaling_factor_int
 
 let tez_of_tok (tk: tok) : Ligo.tez =
   fraction_to_tez_floor


### PR DESCRIPTION
I noticed that some scaling factors were hard-wired, which means they'd get out of sync upon changing the tokens we use. This PR fixes that.
 
Commit log:
* Uninline `tez_scaling_factor`. This is needed for #171: if we end up changing the indices and they don't refer to tez anymore then the hard-wired scaling factor would get out of sync.
* Uninline `ctez_scaling factor`. Also needed for #171. If we change the token used in cfmm from ctez to something else (or if ctez changes its scaling factor, though this is highly unlikely), the hard-wired scaling factor would get out of sync.
* `(fixedpoint_to_raw fixedpoint_one)` is simply `fixedpoint_scaling_factor`.