### PR TITLE
Add off-chain views for the current liquidation auction

### DIFF
--- a/docs/spec/functional_spec.rst
+++ b/docs/spec/functional_spec.rst
@@ -614,3 +614,19 @@ Seal the contract and make it ready for use
 -------------------------------------------
 
 ``sealContract: (pair address address)``
+
+Off-chain views
+===============
+
+Get details on the current liquidation auction
+----------------------------------------------
+
+Returns an error if there is currently no active liquidation auction.
+
+``currentLiquidationAuctionDetails: unit -> view_current_liquidation_auction_details_result``
+
++---------------+-----------------------+-------------------------------------------------------------------------+
+| Parameter     |      Field Type       | Description                                                             |
++===============+=======================+=========================================================================+
+| unit          | unit                  | ()                                                                      |
++---------------+-----------------------+-------------------------------------------------------------------------+

--- a/docs/spec/functional_spec.rst
+++ b/docs/spec/functional_spec.rst
@@ -577,14 +577,12 @@ Check whether a burrow can be liquidated
 +---------------+-----------------------+-------------------------------------------------------------------------+
 
 
-Minimum bid for the current liquidation auction (if exists)
------------------------------------------------------------
+Get details on the current liquidation auction
+----------------------------------------------
 
-Returns a pair of the unique identifier for the current auction and the minimum
-amount of kit that one could currently bid in said auction. Fails if there is
-no open auction.
+Fails if there is currently no liquidation auction.
 
-``current_liquidation_auction_minimum_bid : unit -> pair nat nat``
+``current_liquidation_auction_details: unit -> view_current_liquidation_auction_details_result``
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
@@ -614,19 +612,3 @@ Seal the contract and make it ready for use
 -------------------------------------------
 
 ``sealContract: (pair address address)``
-
-Off-chain views
-===============
-
-Get details on the current liquidation auction
-----------------------------------------------
-
-Returns an error if there is currently no active liquidation auction.
-
-``currentLiquidationAuctionDetails: unit -> view_current_liquidation_auction_details_result``
-
-+---------------+-----------------------+-------------------------------------------------------------------------+
-| Parameter     |      Field Type       | Description                                                             |
-+===============+=======================+=========================================================================+
-| unit          | unit                  | ()                                                                      |
-+---------------+-----------------------+-------------------------------------------------------------------------+

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -603,8 +603,11 @@ class LiquidationsStressTest(SandboxedTestCase):
         )
 
         # And we place a bid for the auction we started earlier:
-        ret = checker.metadata.currentLiquidationAuctionMinimumBid().storage_view()
-        auction_id, minimum_bid = ret["contents"], ret["nat_1"]
+        auction_details = (
+            checker.metadata.currentLiquidationAuctionDetails().storage_view()
+        )
+
+        auction_id, minimum_bid = auction_details["contents"], auction_details["nat_3"]
         # FIXME: The return value is supposed to be annotated as "auction_id" and "minimum_bid", I
         # do not know why we get these names. I think there is an underlying pytezos bug
         # that we should reproduce and create a bug upstream.

--- a/scripts/generate-entrypoints.rb
+++ b/scripts/generate-entrypoints.rb
@@ -26,7 +26,6 @@ open CheckerTypes
 open Checker
 open Kit
 open Lqt
-open Tok
 open LiquidationAuctionTypes
 open LiquidationAuctionPrimitiveTypes
 open Ctez

--- a/scripts/generate-entrypoints.rb
+++ b/scripts/generate-entrypoints.rb
@@ -26,6 +26,7 @@ open CheckerTypes
 open Checker
 open Kit
 open Lqt
+open Tok
 open LiquidationAuctionTypes
 open LiquidationAuctionPrimitiveTypes
 open Ctez

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -958,18 +958,11 @@ let view_is_burrow_liquidatable (burrow_id, state: burrow_id * checker) : bool =
   let burrow = burrow_touch state.parameters burrow in
   burrow_is_liquidatable state.parameters burrow
 
-let view_current_liquidation_auction_minimum_bid ((), state: unit * checker) : view_current_liquidation_auction_minimum_bid_result =
-  assert_checker_invariants state;
-  let auction = liquidation_auction_get_current_auction state.liquidation_auctions in
-  { auction_id = auction.contents
-  ; minimum_bid = liquidation_auction_current_auction_minimum_bid auction
-  }
-
 let view_current_liquidation_auction_details ((), state: unit * checker) : view_current_liquidation_auction_details_result =
   assert_checker_invariants state;
   let auction = liquidation_auction_get_current_auction state.liquidation_auctions in
   let current_bid, blocks, seconds = match auction.state with
-    | Descending _ -> None, None, None
+    | Descending _ -> (None: (bid option)), (None: (Ligo.int option)), (None: (Ligo.int option))
     | Ascending (current_bid, bid_time_seconds, bid_level) ->
       (
         Some current_bid,

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -973,14 +973,21 @@ let view_current_liquidation_auction_id ((), state: unit * checker) : liquidatio
 
 let view_current_liquidation_auction_winning_bid ((), state: unit * checker) : bid option =
   assert_checker_invariants state;
-  match state.liquidation_auctions.current_auction with
-  | None -> (None : bid option)
-  | Some current_auction ->
-    let bid = match current_auction.state with
-      | Descending _ -> (None : bid option)
-      | Ascending (bid, _, _) -> Some bid
-    in
-    bid
+  let current_auction = liquidation_auction_get_current_auction state.liquidation_auctions in
+  match current_auction.state with
+  | Descending _ -> (None: bid option)
+  | Ascending (bid, _, _) -> Some bid
+
+let view_current_liquidation_auction_remaining_duration ((), state: unit * checker) : view_current_liquidation_auction_remaining_duration_result option =
+  assert_checker_invariants state;
+  let auction = liquidation_auction_get_current_auction state.liquidation_auctions in
+  match auction.state with
+  | Descending _ -> (None : view_current_liquidation_auction_remaining_duration_result option)
+  | Ascending (_, bid_time_seconds, bid_level) ->
+    Some {
+      seconds=Ligo.sub_timestamp_timestamp (Ligo.add_timestamp_int bid_time_seconds max_bid_interval_in_seconds) !Ligo.Tezos.now;
+      blocks=Ligo.sub_nat_nat (Ligo.add_nat_nat bid_level max_bid_interval_in_blocks) !Ligo.Tezos.level;
+    }
 
 (* ************************************************************************* *)
 (**                            FA2_VIEWS                                     *)

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -965,36 +965,6 @@ let view_current_liquidation_auction_minimum_bid ((), state: unit * checker) : v
   ; minimum_bid = liquidation_auction_current_auction_minimum_bid auction
   }
 
-let view_current_liquidation_auction_id ((), state: unit * checker) : liquidation_auction_id option =
-  assert_checker_invariants state;
-  match state.liquidation_auctions.current_auction with
-  | None -> None
-  | Some current_auction -> Some current_auction.contents
-
-let view_current_liquidation_auction_winning_bid ((), state: unit * checker) : bid option =
-  assert_checker_invariants state;
-  let current_auction = liquidation_auction_get_current_auction state.liquidation_auctions in
-  match current_auction.state with
-  | Descending _ -> (None: bid option)
-  | Ascending (bid, _, _) -> Some bid
-
-let view_current_liquidation_auction_remaining_duration ((), state: unit * checker) : view_current_liquidation_auction_remaining_duration_result option =
-  assert_checker_invariants state;
-  let auction = liquidation_auction_get_current_auction state.liquidation_auctions in
-  match auction.state with
-  | Descending _ -> (None : view_current_liquidation_auction_remaining_duration_result option)
-  | Ascending (_, bid_time_seconds, bid_level) ->
-    Some {
-      seconds=Ligo.sub_timestamp_timestamp (Ligo.add_timestamp_int bid_time_seconds max_bid_interval_in_seconds) !Ligo.Tezos.now;
-      blocks=Ligo.sub_nat_nat (Ligo.add_nat_nat bid_level max_bid_interval_in_blocks) !Ligo.Tezos.level;
-    }
-
-let view_current_liquidation_auction_collateral ((), state: unit * checker) : tok option =
-  assert_checker_invariants state;
-  match state.liquidation_auctions.current_auction with
-  | None -> (None: tok option)
-  | Some auction -> Some (avl_tok state.liquidation_auctions.avl_storage auction.contents)
-
 let view_current_liquidation_auction_details ((), state: unit * checker) : view_current_liquidation_auction_details_result =
   assert_checker_invariants state;
   let auction = liquidation_auction_get_current_auction state.liquidation_auctions in

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -965,6 +965,23 @@ let view_current_liquidation_auction_minimum_bid ((), state: unit * checker) : v
   ; minimum_bid = liquidation_auction_current_auction_minimum_bid auction
   }
 
+let view_current_liquidation_auction_id ((), state: unit * checker) : liquidation_auction_id option =
+  assert_checker_invariants state;
+  match state.liquidation_auctions.current_auction with
+  | None -> None
+  | Some current_auction -> Some current_auction.contents
+
+let view_current_liquidation_auction_winning_bid ((), state: unit * checker) : bid option =
+  assert_checker_invariants state;
+  match state.liquidation_auctions.current_auction with
+  | None -> (None : bid option)
+  | Some current_auction ->
+    let bid = match current_auction.state with
+      | Descending _ -> (None : bid option)
+      | Ascending (bid, _, _) -> Some bid
+    in
+    bid
+
 (* ************************************************************************* *)
 (**                            FA2_VIEWS                                     *)
 (* ************************************************************************* *)

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -991,7 +991,9 @@ let view_current_liquidation_auction_remaining_duration ((), state: unit * check
 
 let view_current_liquidation_auction_collateral ((), state: unit * checker) : tok option =
   assert_checker_invariants state;
-  liquidation_auction_current_auction_tok state.liquidation_auctions
+  match state.liquidation_auctions.current_auction with
+  | None -> (None: tok option)
+  | Some auction -> Some (avl_tok state.liquidation_auctions.avl_storage auction.contents)
 
 (* ************************************************************************* *)
 (**                            FA2_VIEWS                                     *)

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -995,6 +995,27 @@ let view_current_liquidation_auction_collateral ((), state: unit * checker) : to
   | None -> (None: tok option)
   | Some auction -> Some (avl_tok state.liquidation_auctions.avl_storage auction.contents)
 
+let view_current_liquidation_auction_details ((), state: unit * checker) : view_current_liquidation_auction_details_result =
+  assert_checker_invariants state;
+  let auction = liquidation_auction_get_current_auction state.liquidation_auctions in
+  let current_bid, blocks, seconds = match auction.state with
+    | Descending _ -> None, None, None
+    | Ascending (current_bid, bid_time_seconds, bid_level) ->
+      (
+        Some current_bid,
+        Some (Ligo.sub_nat_nat (Ligo.add_nat_nat bid_level max_bid_interval_in_blocks) !Ligo.Tezos.level),
+        Some (Ligo.sub_timestamp_timestamp (Ligo.add_timestamp_int bid_time_seconds max_bid_interval_in_seconds) !Ligo.Tezos.now)
+      )
+  in
+  {
+    auction_id = auction.contents;
+    collateral = avl_tok state.liquidation_auctions.avl_storage auction.contents;
+    minimum_bid = liquidation_auction_current_auction_minimum_bid auction;
+    current_bid = current_bid;
+    remaining_blocks = blocks;
+    remaining_seconds = seconds;
+  }
+
 (* ************************************************************************* *)
 (**                            FA2_VIEWS                                     *)
 (* ************************************************************************* *)

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -989,6 +989,10 @@ let view_current_liquidation_auction_remaining_duration ((), state: unit * check
       blocks=Ligo.sub_nat_nat (Ligo.add_nat_nat bid_level max_bid_interval_in_blocks) !Ligo.Tezos.level;
     }
 
+let view_current_liquidation_auction_collateral ((), state: unit * checker) : tok option =
+  assert_checker_invariants state;
+  liquidation_auction_current_auction_tok state.liquidation_auctions
+
 (* ************************************************************************* *)
 (**                            FA2_VIEWS                                     *)
 (* ************************************************************************* *)

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -1,6 +1,5 @@
 open Ctez
 open Kit
-open Tok
 open Lqt
 open LiquidationAuctionTypes
 open LiquidationAuctionPrimitiveTypes
@@ -261,11 +260,6 @@ val view_add_liquidity_min_lqt_minted : (ctez * checker) -> lqt
 val view_remove_liquidity_min_ctez_withdrawn : (lqt * checker) -> ctez
 val view_remove_liquidity_min_kit_withdrawn : (lqt * checker) -> kit
 
-val view_current_liquidation_auction_minimum_bid : (unit * checker) -> view_current_liquidation_auction_minimum_bid_result
-val view_current_liquidation_auction_id : (unit * checker) -> liquidation_auction_id option
-val view_current_liquidation_auction_winning_bid : (unit * checker) -> bid option
-val view_current_liquidation_auction_remaining_duration : (unit * checker) -> view_current_liquidation_auction_remaining_duration_result option
-val view_current_liquidation_auction_collateral : (unit * checker) -> tok option
 val view_current_liquidation_auction_details: (unit * checker) -> view_current_liquidation_auction_details_result
 val view_burrow_max_mintable_kit : (burrow_id * checker) -> kit
 val view_is_burrow_overburrowed : (burrow_id * checker) -> bool

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -1,5 +1,6 @@
 open Ctez
 open Kit
+open Tok
 open Lqt
 open LiquidationAuctionTypes
 open LiquidationAuctionPrimitiveTypes
@@ -264,6 +265,7 @@ val view_current_liquidation_auction_minimum_bid : (unit * checker) -> view_curr
 val view_current_liquidation_auction_id : (unit * checker) -> liquidation_auction_id option
 val view_current_liquidation_auction_winning_bid : (unit * checker) -> bid option
 val view_current_liquidation_auction_remaining_duration : (unit * checker) -> view_current_liquidation_auction_remaining_duration_result option
+val view_current_liquidation_auction_collateral : (unit * checker) -> tok option
 
 val view_burrow_max_mintable_kit : (burrow_id * checker) -> kit
 val view_is_burrow_overburrowed : (burrow_id * checker) -> bool

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -266,7 +266,7 @@ val view_current_liquidation_auction_id : (unit * checker) -> liquidation_auctio
 val view_current_liquidation_auction_winning_bid : (unit * checker) -> bid option
 val view_current_liquidation_auction_remaining_duration : (unit * checker) -> view_current_liquidation_auction_remaining_duration_result option
 val view_current_liquidation_auction_collateral : (unit * checker) -> tok option
-
+val view_current_liquidation_auction_details: (unit * checker) -> view_current_liquidation_auction_details_result
 val view_burrow_max_mintable_kit : (burrow_id * checker) -> kit
 val view_is_burrow_overburrowed : (burrow_id * checker) -> bool
 val view_is_burrow_liquidatable : (burrow_id * checker) -> bool

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -263,6 +263,7 @@ val view_remove_liquidity_min_kit_withdrawn : (lqt * checker) -> kit
 val view_current_liquidation_auction_minimum_bid : (unit * checker) -> view_current_liquidation_auction_minimum_bid_result
 val view_current_liquidation_auction_id : (unit * checker) -> liquidation_auction_id option
 val view_current_liquidation_auction_winning_bid : (unit * checker) -> bid option
+val view_current_liquidation_auction_remaining_duration : (unit * checker) -> view_current_liquidation_auction_remaining_duration_result option
 
 val view_burrow_max_mintable_kit : (burrow_id * checker) -> kit
 val view_is_burrow_overburrowed : (burrow_id * checker) -> bool

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -260,7 +260,9 @@ val view_add_liquidity_min_lqt_minted : (ctez * checker) -> lqt
 val view_remove_liquidity_min_ctez_withdrawn : (lqt * checker) -> ctez
 val view_remove_liquidity_min_kit_withdrawn : (lqt * checker) -> kit
 
-val view_current_liquidation_auction_minimum_bid: (unit * checker) -> view_current_liquidation_auction_minimum_bid_result
+val view_current_liquidation_auction_minimum_bid : (unit * checker) -> view_current_liquidation_auction_minimum_bid_result
+val view_current_liquidation_auction_id : (unit * checker) -> liquidation_auction_id option
+val view_current_liquidation_auction_winning_bid : (unit * checker) -> bid option
 
 val view_burrow_max_mintable_kit : (burrow_id * checker) -> kit
 val view_is_burrow_overburrowed : (burrow_id * checker) -> bool

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -1,4 +1,5 @@
 open Kit
+open Tok
 open Burrow
 open CfmmTypes
 open Parameters
@@ -50,21 +51,9 @@ type wrapper =
 
 [@@@coverage off]
 
-type view_current_liquidation_auction_minimum_bid_result =
-  { auction_id: liquidation_auction_id
-  ; minimum_bid: kit
-  }
-[@@deriving show]
-
-type view_current_liquidation_auction_remaining_duration_result =
-  { blocks: Ligo.int
-  ; seconds: Ligo.int
-  }
-[@@deriving show]
-
 type view_current_liquidation_auction_details_result =
   { auction_id: liquidation_auction_id
-  ; collateral: Tok.tok
+  ; collateral: tok
   ; minimum_bid: kit
   ; current_bid: bid option
   ; remaining_blocks: Ligo.int option

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -56,4 +56,10 @@ type view_current_liquidation_auction_minimum_bid_result =
   }
 [@@deriving show]
 
+type view_current_liquidation_auction_remaining_duration_result =
+  { blocks: Ligo.int
+  ; seconds: Ligo.int
+  }
+[@@deriving show]
+
 [@@@coverage on]

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -62,4 +62,14 @@ type view_current_liquidation_auction_remaining_duration_result =
   }
 [@@deriving show]
 
+type view_current_liquidation_auction_details_result =
+  { auction_id: liquidation_auction_id
+  ; collateral: Tok.tok
+  ; minimum_bid: kit
+  ; current_bid: bid option
+  ; remaining_blocks: Ligo.int option
+  ; remaining_seconds: Ligo.int option
+  }
+[@@deriving show]
+
 [@@@coverage on]

--- a/src/ligo.mligo
+++ b/src/ligo.mligo
@@ -1,6 +1,7 @@
 [@inline] let add_int_int (i: int) (j: int) : int = i + j
 [@inline] let add_nat_nat (i: nat) (j: nat) : nat = i + j
 [@inline] let add_tez_tez (i: tez) (j: tez) : tez = i + j
+[@inline] let add_timestamp_int (i: timestamp) (j: int) : timestamp = i + j
 
 [@inline] let sub_int_int (i: int) (j: int) : int = i - j
 [@inline] let sub_tez_tez (i: tez) (j: tez) : tez = i - j

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -2107,12 +2107,13 @@ let suite =
        assert_liquidation_auction_id_option_equal ~expected:expected_auction_id ~real:current_auction_id
     );
 
-    ("view_current_liquidation_auction_winning_bid - expected value for state with no current auction" >::
+    ("view_current_liquidation_auction_winning_bid - raises error when there is no current auction" >::
      fun _ ->
        Ligo.Tezos.reset ();
        let checker = empty_checker in
-       let winning_bid = Checker.view_current_liquidation_auction_winning_bid ((), checker) in
-       assert_bid_option_equal ~expected:None ~real:winning_bid
+       assert_raises
+         (Failure (Ligo.string_of_int error_NoOpenAuction))
+         (fun _ -> Checker.view_current_liquidation_auction_winning_bid ((), checker))
     );
 
     ("view_current_liquidation_auction_winning_bid - expected value for descending auction" >::
@@ -2142,6 +2143,45 @@ let suite =
        let winning_bid = Checker.view_current_liquidation_auction_winning_bid ((), checker) in
        let expected_winning_bid = Some LiquidationAuctionPrimitiveTypes.({address=bidder; kit=bid;}) in
        assert_bid_option_equal ~expected:expected_winning_bid ~real:winning_bid
+    );
+
+    ("view_current_liquidation_auction_remaining_duration - raises error when there is no current auction" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let checker = empty_checker in
+       assert_raises
+         (Failure (Ligo.string_of_int error_NoOpenAuction))
+         (fun _ -> Checker.view_current_liquidation_auction_remaining_duration ((), checker))
+    );
+
+    ("view_current_liquidation_auction_remaining_duration - expected value for descending auction" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let checker = checker_with_active_auction () in
+       let remaining_duration = Checker.view_current_liquidation_auction_remaining_duration ((), checker) in
+       assert_view_current_liquidation_auction_remaining_duration_result_option_equal ~expected:None ~real:remaining_duration
+    );
+
+    ("view_current_liquidation_auction_remaining_duration - expected value for ascending auction" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let checker = checker_with_active_auction () in
+       (* Place a bid to turn the descending auction into an ascending one *)
+       let current_auction_id = Option.get (Checker.view_current_liquidation_auction_id ((), checker)) in
+       let auction_details = Checker.view_current_liquidation_auction_minimum_bid ((), checker) in
+       let bidder = bob_addr in
+       let bid = auction_details.minimum_bid in
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:bidder ~amount:(Ligo.tez_from_literal "1_000_000_000mutez");
+       let _, checker = Checker.entrypoint_create_burrow (checker, (Ligo.nat_from_literal "1n", None)) in
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:bidder ~amount:(Ligo.tez_from_literal "0mutez");
+       let _, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "1n", bid)) in
+       Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:bidder ~amount:(Ligo.tez_from_literal "0mutez");
+       let _, checker = Checker.entrypoint_liquidation_auction_place_bid (checker, (current_auction_id, auction_details.minimum_bid)) in
+
+       Ligo.Tezos.new_transaction ~seconds_passed:500 ~blocks_passed:22 ~sender:bidder ~amount:(Ligo.tez_from_literal "0mutez");
+       let remaining_duration = Checker.view_current_liquidation_auction_remaining_duration ((), checker) in
+       let expected_remaining_duration = (Some {blocks=(Ligo.int_from_literal "-2"); seconds=(Ligo.int_from_literal "700")}) in
+       assert_view_current_liquidation_auction_remaining_duration_result_option_equal ~expected:expected_remaining_duration ~real:remaining_duration
     );
   ]
 

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -2183,6 +2183,22 @@ let suite =
        let expected_remaining_duration = (Some {blocks=(Ligo.int_from_literal "-2"); seconds=(Ligo.int_from_literal "700")}) in
        assert_view_current_liquidation_auction_remaining_duration_result_option_equal ~expected:expected_remaining_duration ~real:remaining_duration
     );
+
+    ("view_current_liquidation_auction_collateral - expected value for state with no current auction" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let checker = empty_checker in
+       let auction_collateral = Checker.view_current_liquidation_auction_collateral ((), checker) in
+       assert_tok_option_equal ~expected:None ~real:auction_collateral
+    );
+
+    ("view_current_liquidation_auction_collateral - expected value for state with current auction" >::
+     fun _ ->
+       Ligo.Tezos.reset ();
+       let checker = checker_with_active_auction () in
+       let auction_collateral = Checker.view_current_liquidation_auction_collateral ((), checker) in
+       assert_tok_option_equal ~expected:(Some (tok_of_denomination (Ligo.nat_from_literal "23_669_648n"))) ~real:auction_collateral
+    );
   ]
 
 let () =

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -165,7 +165,7 @@ let checker_with_active_auction () =
 let checker_with_completed_auction () =
   let checker = checker_with_active_auction () in
   (* Get the current auction minimum bid *)
-  let auction_details = Checker.view_current_liquidation_auction_minimum_bid ((), checker) in
+  let auction_details = Checker.view_current_liquidation_auction_details ((), checker) in
   (* Mint enough kit to bid *)
   let bidder = alice_addr in
   let new_burrow_no = Ligo.nat_from_literal "100n" in
@@ -471,7 +471,7 @@ let suite =
        Ligo.Tezos.reset ();
        let checker = checker_with_active_auction () in
        (* Lookup the current minimum bid *)
-       let auction_details = Checker.view_current_liquidation_auction_minimum_bid ((), checker) in
+       let auction_details = Checker.view_current_liquidation_auction_details ((), checker) in
        (* Mint some kit to be able to bid *)
        let new_burrow_no = Ligo.nat_from_literal "100n" in
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "1_000_000_000mutez");
@@ -1435,7 +1435,7 @@ let suite =
        let _, checker = Checker.entrypoint_mark_for_liquidation (checker, (alice_addr, Ligo.nat_from_literal "0n")) in
        let _, checker = Checker.entrypoint_touch (checker, ()) in
 
-       let res = Checker.view_current_liquidation_auction_minimum_bid ((), checker) in
+       let res = Checker.view_current_liquidation_auction_details ((), checker) in
        let other_ptr = match res.auction_id with AVLPtr i -> Ptr.ptr_next i in
 
        assert_raises
@@ -1602,7 +1602,7 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:(5*60) ~blocks_passed:5 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
        assert_raises
          (Failure (Ligo.string_of_int error_NoOpenAuction))
-         (fun () -> Checker.view_current_liquidation_auction_minimum_bid ((), checker));
+         (fun () -> Checker.view_current_liquidation_auction_details ((), checker));
 
        let kit_before_reward = get_balance_of checker bob_addr kit_token_id in
        let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_200_000n") in
@@ -1624,7 +1624,7 @@ let suite =
        let kit_after_reward = get_balance_of checker alice_addr kit_token_id in
 
        let touch_reward = Ligo.sub_nat_nat kit_after_reward kit_before_reward in
-       let min_bid = Checker.view_current_liquidation_auction_minimum_bid ((), checker) in
+       let min_bid = Checker.view_current_liquidation_auction_details ((), checker) in
 
        let auction_id =
          min_bid.auction_id in

--- a/tests/testCheckerEntrypoints.ml
+++ b/tests/testCheckerEntrypoints.ml
@@ -72,9 +72,9 @@ let suite =
        (fun (init_wrapper) -> CheckerEntrypoints.wrapper_view_remove_liquidity_min_kit_withdrawn (Lqt.lqt_zero, init_wrapper));
     );
 
-    ("wrapper_view_current_liquidation_auction_minimum_bid - unsealed" >::
+    ("wrapper_view_current_liquidation_auction_details - unsealed" >::
      assert_unsealed_contract_raises_not_deployed_error
-       (fun (init_wrapper) -> CheckerEntrypoints.wrapper_view_current_liquidation_auction_minimum_bid ((), init_wrapper));
+       (fun (init_wrapper) -> CheckerEntrypoints.wrapper_view_current_liquidation_auction_details ((), init_wrapper));
     );
 
     ("wrapper_view_burrow_max_mintable_kit - unsealed" >::
@@ -223,12 +223,12 @@ let suite =
        )
     );
 
-    ("wrapper_view_current_liquidation_auction_minimum_bid - sealed" >::
+    ("wrapper_view_current_liquidation_auction_details - sealed" >::
      with_sealed_wrapper
        (fun sealed_wrapper ->
           assert_raises
             (Failure (Ligo.string_of_int error_NoOpenAuction))
-            (fun () -> CheckerEntrypoints.wrapper_view_current_liquidation_auction_minimum_bid ((), sealed_wrapper))
+            (fun () -> CheckerEntrypoints.wrapper_view_current_liquidation_auction_details ((), sealed_wrapper))
        )
     );
 

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -409,7 +409,7 @@ let suite =
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
           (* Liquidation_auction_place_bid *)
-          let min_bid = CheckerEntrypoints.wrapper_view_current_liquidation_auction_minimum_bid ((), sealed_wrapper) in
+          let min_bid = CheckerEntrypoints.wrapper_view_current_liquidation_auction_details ((), sealed_wrapper) in
           Ligo.Tezos.new_transaction ~seconds_passed:394 ~blocks_passed:6 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
           let op = CheckerMain.(CheckerEntrypoint (LazyParams (Liquidation_auction_place_bid (min_bid.auction_id, min_bid.minimum_bid)))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
@@ -457,7 +457,7 @@ let suite =
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
           (* Liquidation_auction_place_bid *)
-          let min_bid = CheckerEntrypoints.wrapper_view_current_liquidation_auction_minimum_bid ((), sealed_wrapper) in
+          let min_bid = CheckerEntrypoints.wrapper_view_current_liquidation_auction_details ((), sealed_wrapper) in
           Ligo.Tezos.new_transaction ~seconds_passed:394 ~blocks_passed:6 ~sender:user_addr ~amount:(Ligo.tez_from_literal "0mutez");
           let op = CheckerMain.(CheckerEntrypoint (LazyParams (Liquidation_auction_place_bid (min_bid.auction_id, min_bid.minimum_bid)))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -32,6 +32,10 @@ let assert_ctez_equal ~expected ~real = OUnit2.assert_equal ~printer:Ctez.show_c
 let assert_parameters_equal ~expected ~real = OUnit2.assert_equal ~printer:Parameters.show_parameters expected real (* FIXME: contains a ratio *)
 let assert_liquidation_slice_contents_equal ~expected ~real = OUnit2.assert_equal ~printer:LiquidationAuctionPrimitiveTypes.show_liquidation_slice_contents expected real
 
+(* Note: This name is a real mouthful but follows the convention we are using in checkerTypes.ml *)
+type view_current_liquidation_auction_remaining_duration_result_option = CheckerTypes.view_current_liquidation_auction_remaining_duration_result option [@@deriving show]
+let assert_view_current_liquidation_auction_remaining_duration_result_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_view_current_liquidation_auction_remaining_duration_result_option expected real
+
 type liquidation_auction_id_option = liquidation_auction_id option [@@deriving show]
 let assert_liquidation_auction_id_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_liquidation_auction_id_option expected real
 

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -23,11 +23,17 @@ type key_hash_option = Ligo.key_hash option [@@deriving show]
 let assert_key_hash_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_key_hash_option expected real
 let assert_address_equal ~expected ~real = OUnit2.assert_equal ~printer:Ligo.string_of_address expected real
 let assert_fixedpoint_equal ~expected ~real = OUnit2.assert_equal ~printer:FixedPoint.show_fixedpoint_raw expected real
+let assert_bid_equal ~expected ~real = OUnit2.assert_equal ~printer:LiquidationAuctionPrimitiveTypes.show_bid expected real
+type bid_option = bid option [@@deriving show]
+let assert_bid_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_bid_option expected real
 let assert_liquidation_result_equal ~expected ~real = OUnit2.assert_equal ~printer:Burrow.show_liquidation_result expected real
 let assert_avl_ptr_equal ~expected ~real = OUnit2.assert_equal ~printer:LiquidationAuctionPrimitiveTypes.show_avl_ptr expected real
 let assert_ctez_equal ~expected ~real = OUnit2.assert_equal ~printer:Ctez.show_ctez expected real
 let assert_parameters_equal ~expected ~real = OUnit2.assert_equal ~printer:Parameters.show_parameters expected real (* FIXME: contains a ratio *)
 let assert_liquidation_slice_contents_equal ~expected ~real = OUnit2.assert_equal ~printer:LiquidationAuctionPrimitiveTypes.show_liquidation_slice_contents expected real
+
+type liquidation_auction_id_option = liquidation_auction_id option [@@deriving show]
+let assert_liquidation_auction_id_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_liquidation_auction_id_option expected real
 
 type kit_option = Kit.kit option [@@deriving show]
 let assert_kit_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_kit_option expected real

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -31,10 +31,6 @@ let assert_avl_ptr_equal ~expected ~real = OUnit2.assert_equal ~printer:Liquidat
 let assert_ctez_equal ~expected ~real = OUnit2.assert_equal ~printer:Ctez.show_ctez expected real
 let assert_parameters_equal ~expected ~real = OUnit2.assert_equal ~printer:Parameters.show_parameters expected real (* FIXME: contains a ratio *)
 let assert_liquidation_slice_contents_equal ~expected ~real = OUnit2.assert_equal ~printer:LiquidationAuctionPrimitiveTypes.show_liquidation_slice_contents expected real
-
-(* Note: This name is a real mouthful but follows the convention we are using in checkerTypes.ml *)
-type view_current_liquidation_auction_remaining_duration_result_option = CheckerTypes.view_current_liquidation_auction_remaining_duration_result option [@@deriving show]
-let assert_view_current_liquidation_auction_remaining_duration_result_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_view_current_liquidation_auction_remaining_duration_result_option expected real
 let assert_view_current_liquidation_auction_details_result_equal ~expected ~real = OUnit2.assert_equal ~printer:CheckerTypes.show_view_current_liquidation_auction_details_result expected real
 
 type liquidation_auction_id_option = liquidation_auction_id option [@@deriving show]

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -35,6 +35,7 @@ let assert_liquidation_slice_contents_equal ~expected ~real = OUnit2.assert_equa
 (* Note: This name is a real mouthful but follows the convention we are using in checkerTypes.ml *)
 type view_current_liquidation_auction_remaining_duration_result_option = CheckerTypes.view_current_liquidation_auction_remaining_duration_result option [@@deriving show]
 let assert_view_current_liquidation_auction_remaining_duration_result_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_view_current_liquidation_auction_remaining_duration_result_option expected real
+let assert_view_current_liquidation_auction_details_result_equal ~expected ~real = OUnit2.assert_equal ~printer:CheckerTypes.show_view_current_liquidation_auction_details_result expected real
 
 type liquidation_auction_id_option = liquidation_auction_id option [@@deriving show]
 let assert_liquidation_auction_id_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_liquidation_auction_id_option expected real


### PR DESCRIPTION
This PR adds an off-chain view which returns the following current auction data (some of which are listed in #150):
- auction_id
- total collateral in auction lot
- current winning bid
- minimum bid
- remaining duration in seconds and blocks

I think that this should be the minimal information a prospective user would need to query to be able to understand and interact with a given "current" auction.
