### PR TITLE
Update base Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install earthly
         run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.23/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       # Only push earthly cache from master
-      - if: github.ref == 'refs/heads/dorranh/baseImage' && github.event_name == 'push'
+      - if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         run: echo "push_flag=--push" >> $GITHUB_ENV
         name: Enable push to build cache
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.23/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       # Only push earthly cache from master
       - if: github.ref == 'refs/heads/dorranh/baseImage' && github.event_name == 'push'
-        run: echo "{push_flag}={--push}" >> $GITHUB_ENV
+        run: echo "push_flag=--push" >> $GITHUB_ENV
         name: Enable push to build cache
 
       - name: Build dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,9 @@ jobs:
       - name: Install earthly
         run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.23/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       # Only push earthly cache from master
-      - if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      - if: github.ref == 'refs/heads/dorranh/baseImage' && github.event_name == 'push'
         run: echo "{push_flag}={--push}" >> $GITHUB_ENV
+        name: Enable push to build cache
 
       - name: Build dependencies
         run: |

--- a/Earthfile
+++ b/Earthfile
@@ -10,7 +10,7 @@ all:
 # =============================================================================
 # Base image for building project
 builder:
-    FROM ubuntu:21.04
+    FROM ubuntu:20.04
     ENV DEBIAN_FRONTEND=noninteractive
     RUN apt update
     RUN apt install -y \
@@ -325,7 +325,7 @@ dev-container:
 # Note: Building CLI independently so that it doesn't include the full closure of all
 # of our dev dependencies
 cli:
-    FROM ubuntu:21.04
+    FROM ubuntu:20.04
 
     ENV DEBIAN_FRONTEND=noninteractive
     RUN apt update
@@ -376,7 +376,7 @@ zcash-params:
     SAVE IMAGE --push ghcr.io/tezos-checker/checker/earthly-cache:zcash-params
 
 flextesa:
-    FROM ubuntu:21.04
+    FROM ubuntu:20.04
 
     ENV DEBIAN_FRONTEND=noninteractive
     RUN apt update


### PR DESCRIPTION
Updates the base Docker image used in our builds / dev container to 20.04 (downgraded from 21.04). This allows commands to properly run on a wider variety of hosts due to the glibc - host compatibility issues introduced in the glibc version which ships with 21.04. 

Also fixed a small error in the CI workflow which was preventing cache pushes from occurring on master.
