### PR TITLE
Updates to the mutation script

### DIFF
--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -47,7 +47,26 @@ MUTATION_GROUPS = [
     # KIT
     {"kit_zero", "kit_one"},
     {"kit_add", "kit_sub", "kit_min", "kit_max"},
-    {"gt_kit_kit", "geq_kit_kit", "eq_kit_kit", "lt_kit_kit"},
+    {"geq_kit_kit", "lt_kit_kit", "gt_kit_kit", "eq_kit_kit"},
+    {"kit_of_fraction_ceil", "kit_of_fraction_floor"},
+    # CTEZ
+    {"ctez_add", "ctez_sub"},
+    {"eq_ctez_ctez", "lt_ctez_ctez", "gt_ctez_ctez"},
+    {"ctez_of_fraction_ceil", "ctez_of_fraction_floor"},
+    # LQT
+    {"lqt_add", "lqt_sub"},
+    {"lqt_zero", "lqt_one"},
+    {"lqt_of_fraction_ceil", "lqt_of_fraction_floor"},
+    {"geq_lqt_lqt", "eq_lqt_lqt", "lt_lqt_lqt"},
+    # TOK
+    {"tok_add", "tok_sub", "max_tok"},
+    {"tok_zero", "tok_one"},
+    {"tok_of_fraction_ceil", "tok_of_fraction_floor"},
+    {"geq_tok_tok", "leq_tok_tok", "eq_tok_tok", "gt_tok_tok", "lt_tok_tok"},
+    # FIXEDPOINT
+    {"fixedpoint_zero", "fixedpoint_one"},
+    {"fixedpoint_add", "fixedpoint_sub"},
+    {"fixedpoint_of_ratio_ceil", "fixedpoint_of_ratio_floor"},
     # INT
     {"mul_int_int", "sub_int_int", "add_int_int", "div_int_int"},
     {"eq_int_int", "lt_int_int", "gt_int_int", "leq_int_int", "geq_int_int"},
@@ -57,9 +76,6 @@ MUTATION_GROUPS = [
     # TEZ
     {"sub_tez_tez", "add_tez_tez"},
     {"eq_tez_tez", "lt_tez_tez", "gt_tez_tez", "leq_tez_tez", "geq_tez_tez"},
-    # FIXED POINT
-    {"fixedpoint_add", "fixedpoint_sub"},
-    {"fixedpoint_of_ratio_ceil", "fixedpoint_of_ratio_floor"},
     # RATIO
     {
         "mul_ratio",

--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -225,20 +225,22 @@ def test_mutated_src(test_cmd):
     print("Checking validity of modified src code...")
     result = subprocess.run(["dune build"], capture_output=True, shell=True)
     if result.returncode != 0:
-        raise Exception(
+        print(
             "Failed to build mutated src with error: "
             + result.stdout.decode()
             + result.stderr.decode()
         )
-
-    print("Running tests...")
-    result = subprocess.run([test_cmd], capture_output=True, shell=True)
-    tests_fail = True
-    if result.returncode == 0:
-        tests_fail = False
-    # print(result.stderr)
-    print("Done.")
-    return tests_fail
+        print("Skipping.")
+        return True
+    else:
+        print("Running tests...")
+        result = subprocess.run([test_cmd], capture_output=True, shell=True)
+        tests_fail = True
+        if result.returncode == 0:
+            tests_fail = False
+        # print(result.stderr)
+        print("Done.")
+        return tests_fail
 
 
 @contextmanager


### PR DESCRIPTION
1. Extend `MUTATION_GROUPS` with more mutations. Until now we've
   had some entries for `fixedPoint.ml`, but other newtypes (e.g.,
   tok, kit, ..) did not have any rules.
2. Make `test_mutated_src` accept non-compiling mutations as tested.
   This silent recovery allows us to run the script on CI on more
   files without intervention.