### PR TITLE
Add some tests for src/ptr.ml

### DIFF
--- a/src/ptr.ml
+++ b/src/ptr.ml
@@ -4,7 +4,6 @@ type ptr = Ligo.nat
 [@@@coverage on]
 
 let[@inline] ptr_null = Ligo.nat_from_literal "0n"
-let[@inline] ptr_init = Ligo.nat_from_literal "1n"
 let[@inline] ptr_next (t: ptr) = Ligo.add_nat_nat t (Ligo.nat_from_literal "1n")
 
 (* BEGIN_OCAML *)

--- a/src/ptr.mli
+++ b/src/ptr.mli
@@ -1,7 +1,6 @@
 type ptr (* George: perhaps I'd prefer a phantom parameter to not mix up pointers. *)
 
 val ptr_null : ptr
-val ptr_init : ptr
 val ptr_next : ptr -> ptr
 
 val compare_ptr : ptr -> ptr -> int

--- a/tests/dune
+++ b/tests/dune
@@ -21,6 +21,7 @@
    testAvlModel
    testLiquidationAuction
    testSliceList
+   testPtr
  )
  (libraries checker core_kernel ounit2 qcheck)
  (preprocess
@@ -42,6 +43,7 @@
 (rule (alias run-fast-tests) (action (run %{exe:testLqt.exe})))
 (rule (alias run-fast-tests) (action (run %{exe:testTok.exe})))
 (rule (alias run-fast-tests) (action (run %{exe:testMem.exe})))
+(rule (alias run-fast-tests) (action (run %{exe:testPtr.exe})))
 (rule (alias run-fast-tests) (action (run %{exe:testParameters.exe})))
 (rule (alias run-fast-tests) (action (run %{exe:testLiquidation.exe})))
 (rule (alias run-fast-tests) (action (run %{exe:testCfmm.exe})))

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -149,7 +149,7 @@ let suite =
     ("If checker is not sealed, the deployer should be able to call DeployFunction - Cancel_liquidation_slice" >::
      fun _ ->
        test_deploy_function_with_lazy_params_succeeds
-         (Cancel_liquidation_slice (LeafPtr (Ptr.(ptr_next (ptr_next ptr_init))))) (* note: values randomly chosen *)
+         (Cancel_liquidation_slice (LeafPtr (Ptr.(ptr_next (ptr_next (ptr_next ptr_null)))))) (* note: values randomly chosen *)
     );
 
     ("If checker is not sealed, the deployer should be able to call DeployFunction - Touch_burrow" >::
@@ -204,7 +204,7 @@ let suite =
 
     ("If checker is not sealed, the deployer should be able to call DeployFunction - Liquidation_auction_place_bid" >::
      fun _ ->
-       let auction_id = AVLPtr (Ptr.(ptr_next ptr_init)) in (* 2 *)
+       let auction_id = AVLPtr (Ptr.(ptr_next (ptr_next ptr_null))) in (* 2 *)
        let kit = Kit.kit_of_denomination (Ligo.nat_from_literal "98n") in
        test_deploy_function_with_lazy_params_succeeds
          (Liquidation_auction_place_bid (auction_id, kit)) (* note: values randomly chosen *)
@@ -212,7 +212,7 @@ let suite =
 
     ("If checker is not sealed, the deployer should be able to call DeployFunction - Liquidation_auction_claim_win" >::
      fun _ ->
-       let auction_id = AVLPtr (Ptr.(ptr_next (ptr_next (ptr_next ptr_init)))) in (* 4 *)
+       let auction_id = AVLPtr (Ptr.(ptr_next (ptr_next (ptr_next (ptr_next ptr_null))))) in (* 4 *)
        test_deploy_function_with_lazy_params_succeeds
          (Liquidation_auction_claim_win (auction_id)) (* note: values randomly chosen *)
     );
@@ -543,7 +543,7 @@ let suite =
           assert_raises
             (Failure (Ligo.string_of_int error_InvalidLeafPtr))
             (fun () ->
-               let op = CheckerMain.(CheckerEntrypoint (LazyParams (Cancel_liquidation_slice (LeafPtr (Ptr.(ptr_next (ptr_next ptr_init))))))) in  (* note: values randomly chosen *)
+               let op = CheckerMain.(CheckerEntrypoint (LazyParams (Cancel_liquidation_slice (LeafPtr (Ptr.(ptr_next (ptr_next (ptr_next ptr_null)))))))) in  (* note: values randomly chosen *)
                Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
                CheckerMain.main (op, sealed_wrapper)
             )
@@ -558,7 +558,7 @@ let suite =
           assert_raises
             (Failure (Ligo.string_of_int error_InvalidAvlPtr))
             (fun () ->
-               let op = CheckerMain.(CheckerEntrypoint (LazyParams (Liquidation_auction_claim_win (AVLPtr (Ptr.(ptr_next ptr_init)))))) in  (* note: values randomly chosen *)
+               let op = CheckerMain.(CheckerEntrypoint (LazyParams (Liquidation_auction_claim_win (AVLPtr (Ptr.(ptr_next (ptr_next ptr_null))))))) in  (* note: values randomly chosen *)
                Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
                CheckerMain.main (op, sealed_wrapper)
             )

--- a/tests/testMem.ml
+++ b/tests/testMem.ml
@@ -8,7 +8,7 @@ let suite =
     (fun _ ->
        assert_raises
          (Failure (Ligo.string_of_int internalError_MemGetElementNotFound))
-         (fun _ -> mem_get mem_empty (Ptr.ptr_init))
+         (fun _ -> mem_get mem_empty (Ptr.ptr_next Ptr.ptr_null))
     )
   ]
 

--- a/tests/testPtr.ml
+++ b/tests/testPtr.ml
@@ -1,0 +1,73 @@
+open OUnit2
+open TestLib
+
+let property_test_count = 100
+let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
+
+(* NOTE: Ideally we want the definition of ptr to be opaque. A sensible
+ * property to expect would be the following:
+ *
+ *   forall (n: nat) (m: nat).
+ *     n <> m =>
+ *     ptr_next (..n_times (ptr_next ptr_null)..) <> ptr_next (..m_times (ptr_next ptr_null)..)
+ *
+ * But that can be satisfied in many ways (hashing, adding a non-zero value,
+ * etc.), not just by adding 1 every time we call ptr_next. The simplest way to
+ * address the mutation is to use the show instance for pointers for writing a
+ * test tied to our current implementation.
+*)
+
+(* Perhaps move this to a shared location? Only when needed. *)
+let apply_times f n e = List.fold_left (fun x _ -> f x) e (List.init n (fun x -> x + 1))
+
+let coerce_ptr_to_int (p : Ptr.ptr) : int = Stdlib.int_of_string (Ptr.show_ptr p)
+
+(* ptr_next must be injective *)
+let test_ptr_next_injective =
+  qcheck_to_ounit
+  @@ QCheck.Test.make
+    ~name:"test_ptr_next_injective"
+    ~count:property_test_count
+    (QCheck.pair QCheck.small_nat QCheck.small_nat) (* must be small_nat or it will run for a very long time *)
+  @@ fun (n, m) ->
+  QCheck.(
+    (apply_times Ptr.ptr_next n Ptr.ptr_null = apply_times Ptr.ptr_next m Ptr.ptr_null)
+    ==>
+    (n = m)
+  )
+
+(* too tight (to catch mutations): null = 0 *)
+let test_ptr_null_is_zero =
+  "test_ptr_null_is_zero" >:: fun _ ->
+    assert_string_equal
+      ~expected:"0"
+      ~real:(Ptr.show_ptr Ptr.ptr_null)
+
+(* too tight (to catch mutations): next ptr - ptr = 1 *)
+let test_ptr_next_difference =
+  qcheck_to_ounit
+  @@ QCheck.Test.make
+    ~name:"test_ptr_next_difference"
+    ~count:property_test_count
+    QCheck.small_nat (* must be small_nat or it will run for a very long time *)
+  @@ fun n ->
+  let ptr = apply_times Ptr.ptr_next n Ptr.ptr_null in
+  let difference = coerce_ptr_to_int (Ptr.ptr_next ptr) - coerce_ptr_to_int ptr in
+  assert_stdlib_int_equal
+    ~expected:1
+    ~real:difference;
+  true
+
+let suite =
+  "Ptr tests" >::: [
+    (* property-based random tests *)
+    test_ptr_next_injective;
+    test_ptr_next_difference;
+
+    (* unit tests *)
+    test_ptr_null_is_zero;
+  ]
+
+let () =
+  run_test_tt_main
+    suite


### PR DESCRIPTION
Two of those (`test_ptr_null_is_zero` and `test_ptr_next_difference`)
are tied to our implementation of ptr, and the other one is the
most important property to have (`test_ptr_next_injective`).

The tight tests are used primarily to catch untested mutations.

Also remove `Ptr.ptr_init` since it is not used at all in src/ (though
it was used a little in tests/). This reduces the surface area to
mutate.