### PR TITLE
Switch to FA2 for collateral, exclusively

### DIFF
--- a/client/checker_client/checker.py
+++ b/client/checker_client/checker.py
@@ -379,7 +379,7 @@ def deploy_checker(
     print("Sealing.")
     inject(
         tz,
-        checker.sealContract((oracle, ctez, tez_wrapper))
+        checker.sealContract((oracle, tez_wrapper, ctez))
         .as_transaction()
         .autofill(ttl=ttl)
         .sign(),

--- a/client/checker_client/checker.py
+++ b/client/checker_client/checker.py
@@ -312,8 +312,8 @@ def deploy_checker(
     tz,
     checker_dir,
     *,
-    tez_wrapper,
     oracle,
+    tez_wrapper,
     ctez,
     ttl: Optional[int] = None,
     token_metadata_file=None,
@@ -383,7 +383,7 @@ def deploy_checker(
         .as_transaction()
         .autofill(ttl=ttl)
         .sign(),
-    )  # TODO: Here we need the freshly deployed tez wrapper contract
+    )
 
     return checker
 

--- a/client/checker_client/checker.py
+++ b/client/checker_client/checker.py
@@ -312,6 +312,7 @@ def deploy_checker(
     tz,
     checker_dir,
     *,
+    tez_wrapper,
     oracle,
     ctez,
     ttl: Optional[int] = None,
@@ -376,7 +377,13 @@ def deploy_checker(
             print("  deployed: chunk {}.".format(chunk_no))
 
     print("Sealing.")
-    inject(tz, checker.sealContract((oracle, ctez)).as_transaction().autofill(ttl=ttl).sign())
+    inject(
+        tz,
+        checker.sealContract((oracle, ctez, tez_wrapper))
+        .as_transaction()
+        .autofill(ttl=ttl)
+        .sign(),
+    )  # TODO: Here we need the freshly deployed tez wrapper contract
 
     return checker
 

--- a/client/checker_client/cli.py
+++ b/client/checker_client/cli.py
@@ -176,6 +176,7 @@ def deploy(config: Config, address=None, port=None, key=None):
     show_default=True,
 )
 @click.option("--oracle", type=str, help="Oracle contract address")
+@click.option("--tez_wrapper", type=str, help="TezWrapper contract address")
 @click.option("--ctez", type=str, help="ctez contract address")
 @click.option(
     "--token-metadata",
@@ -183,13 +184,17 @@ def deploy(config: Config, address=None, port=None, key=None):
     help="optional JSON file containing the TZIP-12 token_metadata.",
 )
 @click.pass_obj
-def checker(config: Config, checker_dir, oracle, ctez, token_metadata):
+def checker(config: Config, checker_dir, oracle, tez_wrapper, ctez, token_metadata):
     """
     Deploy checker. Requires addresses for oracle and ctez contracts.
     """
     if not config.oracle_address and not oracle:
         raise ValueError(
             "Oracle address was neither specified in the CLI config or provided as an argument."
+        )
+    if not config.tez_wrapper and not tez_wrapper:
+        raise ValueError(
+            "TezWrapper address was neither specified in the CLI config or provided as an argument."
         )
     if not config.ctez_address and not ctez:
         raise ValueError(
@@ -206,6 +211,7 @@ def checker(config: Config, checker_dir, oracle, ctez, token_metadata):
     checker = checker_lib.deploy_checker(
         client,
         checker_dir,
+        tez_wrapper=config.tez_wrapper_address,
         oracle=config.oracle_address,
         ctez=config.ctez_address,
         ttl=_patch_operation_ttl(config),

--- a/client/checker_client/cli.py
+++ b/client/checker_client/cli.py
@@ -190,15 +190,15 @@ def checker(config: Config, checker_dir, oracle, tez_wrapper, ctez, token_metada
     """
     if not config.oracle_address and not oracle:
         raise ValueError(
-            "Oracle address was neither specified in the CLI config or provided as an argument."
+            "Oracle address was neither specified in the CLI config nor provided as an argument."
         )
     if not config.tez_wrapper and not tez_wrapper:
         raise ValueError(
-            "TezWrapper address was neither specified in the CLI config or provided as an argument."
+            "TezWrapper address was neither specified in the CLI config nor provided as an argument."
         )
     if not config.ctez_address and not ctez:
         raise ValueError(
-            "ctez address was neither specified in the CLI config or provided as an argument."
+            "ctez address was neither specified in the CLI config nor provided as an argument."
         )
     if oracle:
         config.oracle_address = oracle

--- a/client/checker_client/cli.py
+++ b/client/checker_client/cli.py
@@ -211,8 +211,8 @@ def checker(config: Config, checker_dir, oracle, tez_wrapper, ctez, token_metada
     checker = checker_lib.deploy_checker(
         client,
         checker_dir,
-        tez_wrapper=config.tez_wrapper_address,
         oracle=config.oracle_address,
+        tez_wrapper=config.tez_wrapper_address,
         ctez=config.ctez_address,
         ttl=_patch_operation_ttl(config),
         token_metadata_file=token_metadata,

--- a/docs/spec/functional_spec.rst
+++ b/docs/spec/functional_spec.rst
@@ -12,11 +12,13 @@ supply. These numbers need not be contiguous.
 Create a burrow
 ---------------
 
-Create and return a new burrow containing the supplied tez as collateral, minus
-the creation deposit. Fails if the tez is not enough to cover the creation
-deposit.
+Create and return a new burrow containing the supplied amount of token as
+collateral, minus the creation deposit. Fails if the collateral given is not
+enough to cover the creation deposit, if the sender does not own said amount of
+collateral, or if Checker is not authorized to transfer said amount of
+collateral.
 
-``create_burrow: (pair nat (option key_hash))``
+``create_burrow: (pair (pair nat (option key_hash)) nat)``
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
@@ -25,37 +27,43 @@ deposit.
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | delegate      | option key_hash       | An optional delegate for the created burrow contract                    |
 +---------------+-----------------------+-------------------------------------------------------------------------+
+| tok           | nat                   | The amount of token supplied as collateral (including creation deposit) |
++---------------+-----------------------+-------------------------------------------------------------------------+
 
 
 Deposit collateral in a burrow
 ------------------------------
 
-Deposit an amount of tez as collateral to a burrow. Fails if the burrow does
-not exist, or if the sender is not the burrow owner.
+Deposit an amount of token as collateral to a burrow. Fails if the burrow does
+not exist, if the sender does not own said collateral, or if Checker is not
+authorized to transfer said collateral.
 
-``deposit_collateral: nat``
+``deposit_collateral: (pair nat nat)``
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
 +===============+=======================+=========================================================================+
 | id            | nat                   | The caller's ID for the burrow in which to deposit the tez              |
 +---------------+-----------------------+-------------------------------------------------------------------------+
+| tok           | nat                   | The amount of token supplied to be used as collateral                   |
++---------------+-----------------------+-------------------------------------------------------------------------+
 
 
 Withdraw collateral from a burrow
 ---------------------------------
 
-Withdraw an amount of tez from a burrow. Fails if the burrow does not exist, if
-this action would overburrow it, or if the sender is not the burrow owner.
+Withdraw an amount of collateral from a burrow. Fails if the burrow does not
+exist, if this action would overburrow it, or if the sender is not the burrow
+owner.
 
-``withdraw_collateral: (pair nat mutez)``
+``withdraw_collateral: (pair nat nat)``
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
 +===============+=======================+=========================================================================+
 | id            | nat                   | The caller's ID for the burrow from which to withdraw the tez           |
 +---------------+-----------------------+-------------------------------------------------------------------------+
-| amount        | mutez                 | The amount of collateral to withdraw                                    |
+| amount        | nat                   | The amount of collateral to withdraw                                    |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 
 
@@ -99,16 +107,19 @@ the burrow owner.
 Activate an inactive burrow
 ---------------------------
 
-Activate a currently inactive burrow. Fails if the burrow does not exist, if the
-burrow is already active, if the amount of tez given is less than the creation
-deposit, or if the sender is not the burrow owner.
+Activate a currently inactive burrow. Fails if the burrow does not exist, if
+the burrow is already active, if the amount of collateral given is not enough
+to cover the creation deposit, if the sender does not own said collateral, or
+if Checker is not authorized to transfer said collateral.
 
-``activate_burrow: nat``
+``activate_burrow: (pair nat nat)``
 
 +---------------+-----------------------+-------------------------------------------------------------------------+
 | Parameter     |      Field Type       | Description                                                             |
 +===============+=======================+=========================================================================+
 | id            | nat                   | The caller's ID for the burrow to activate                              |
++---------------+-----------------------+-------------------------------------------------------------------------+
+| tok           | nat                   | The amount of token supplied as collateral (including creation deposit) |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 
 
@@ -116,9 +127,9 @@ Deactivate a burrow
 -------------------
 
 Deactivate a currently active burrow. Fails if the burrow does not exist, if it
-is already inactive, if it is overburrowed, if it has kit outstanding, if it
-has collateral sent off to auctions, or if the sender is not the burrow owner.
-If deactivation is successful, make a tez payment to the given address.
+is already inactive, if it is overburrowed, if it has kit outstanding, or if it
+has collateral sent off to auctions. If deactivation is successful, emits an
+FA2 transfer to the given address.
 
 ``deactivate_burrow: (pair nat address)``
 
@@ -152,7 +163,8 @@ burrow was operated on). Fails if the burrow does not exist.
 Set the delegate for a burrow
 -----------------------------
 
-Set the delegate of a burrow. Fails if if the sender is not the burrow owner.
+Set the delegate of a burrow. Fails if if the sender is not the burrow owner or
+if the deployed checker instance does not use tez as collateral.
 
 ``set_burrow_delegate: (pair nat (option key_hash))``
 
@@ -260,8 +272,8 @@ Mark a burrow for liquidation
 -----------------------------
 
 Mark a burrow for liquidation. Fails if the the burrow does not exist, or if it
-is not a candidate for liquidation. If the operation is successful, a tez
-payment is made to ``Tezos.sender`` with the liquidation reward.
+is not a candidate for liquidation. If the operation is successful, a payment
+is made to ``Tezos.sender`` with the liquidation reward.
 
 ``mark_for_liquidation: (pair address nat)``
 
@@ -340,22 +352,6 @@ winnings.
 | Parameter     |      Field Type       | Description                                                             |
 +===============+=======================+=========================================================================+
 | auction_id    | nat                   | The unique identifier of the completed auction                          |
-+---------------+-----------------------+-------------------------------------------------------------------------+
-
-
-Gather won collateral for a subsequent claim
---------------------------------------------
-
-Internal. Receive a liquidation slice (tez) from a burrow.
-
-``receive_slice_from_burrow: (pair address nat)``
-
-+---------------+-----------------------+-------------------------------------------------------------------------+
-| Parameter     |      Field Type       | Description                                                             |
-+===============+=======================+=========================================================================+
-| owner         | address               | The burrow owner's address                                              |
-+---------------+-----------------------+-------------------------------------------------------------------------+
-| id            | nat                   | The caller's ID for the burrow sending the slice                        |
 +---------------+-----------------------+-------------------------------------------------------------------------+
 
 
@@ -611,4 +607,4 @@ Prior to sealing, the bytecode for all metadata must be deployed.
 Seal the contract and make it ready for use
 -------------------------------------------
 
-``sealContract: (pair address address)``
+``sealContract: pair ((pair address address) address)``

--- a/docs/spec/functional_spec.rst
+++ b/docs/spec/functional_spec.rst
@@ -271,9 +271,9 @@ Liquidation Auctions
 Mark a burrow for liquidation
 -----------------------------
 
-Mark a burrow for liquidation. Fails if the the burrow does not exist, or if it
-is not a candidate for liquidation. If the operation is successful, a payment
-is made to ``Tezos.sender`` with the liquidation reward.
+Mark a burrow for liquidation. Fails if the burrow does not exist, or if it is
+not a candidate for liquidation. If the operation is successful, a payment is
+made to ``Tezos.sender`` with the liquidation reward.
 
 ``mark_for_liquidation: (pair address nat)``
 
@@ -607,4 +607,4 @@ Prior to sealing, the bytecode for all metadata must be deployed.
 Seal the contract and make it ready for use
 -------------------------------------------
 
-``sealContract: pair ((pair address address) address)``
+``sealContract: (pair (pair address address) address)``

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -323,8 +323,8 @@ class E2ETest(SandboxedTestCase):
         checker = deploy_checker(
             self.client,
             checker_dir=CHECKER_DIR,
-            tez_wrapper=tez_wrapper.context.address,
             oracle=oracle.context.address,
+            tez_wrapper=tez_wrapper.context.address,
             ctez=ctez["fa12_ctez"].context.address,
             ttl=MAX_OPERATIONS_TTL,
         )
@@ -645,8 +645,8 @@ class LiquidationsStressTest(SandboxedTestCase):
         checker = deploy_checker(
             self.client,
             checker_dir=CHECKER_DIR,
-            tez_wrapper=tez_wrapper.context.address,
             oracle=oracle.context.address,
+            tez_wrapper=tez_wrapper.context.address,
             ctez=ctez["fa12_ctez"].context.address,
             ttl=MAX_OPERATIONS_TTL,
         )

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -828,7 +828,7 @@ class LiquidationsStressTest(SandboxedTestCase):
             flattened_cancel_ops += [op1, op2]
         call_bulk(
             flattened_cancel_ops,
-            batch_size=170,
+            batch_size=100,
             profiler=cancel_liquidation_slice_profiler,
         )
 

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -554,7 +554,11 @@ class TezWrapperTest(SandboxedTestCase):
                 }
             ]
 
-        # Edge case: this call should succeed, according to the FA2 spec
+        # Edge case: this call should succeed, according to the FA2 spec. It
+        # must come first: by trying to transfer zero tokens before either the
+        # source or the target account is created, we ensure that
+        # TezWrapper.transfer does not fail due to non-originated vault
+        # contracts.
         call_endpoint("transfer", single_fa2_transfer(account, account_alice, 0))
 
         # ===============================================================================

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -554,6 +554,9 @@ class TezWrapperTest(SandboxedTestCase):
                 }
             ]
 
+        # Edge case: this call should succeed, according to the FA2 spec
+        call_endpoint("transfer", single_fa2_transfer(account, account_alice, 0))
+
         # ===============================================================================
         # Wrapper-specific entrypoints
         # ===============================================================================

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -355,8 +355,8 @@ class E2ETest(SandboxedTestCase):
             update_operators = [
                 {
                     "add_operator": {
-                        "owner": account,  # bob?
-                        "operator": checker.context.address,  # checker
+                        "owner": account,
+                        "operator": checker.context.address,
                         "token_id": COLLATERAL_TOKEN_ID,
                     }
                 },
@@ -694,8 +694,8 @@ class LiquidationsStressTest(SandboxedTestCase):
             update_operators = [
                 {
                     "add_operator": {
-                        "owner": self.client.key.public_key_hash(),  # account,  # bob?
-                        "operator": checker.context.address,  # checker
+                        "owner": self.client.key.public_key_hash(),
+                        "operator": checker.context.address,
                         "token_id": COLLATERAL_TOKEN_ID,
                     }
                 },

--- a/scripts/builder/checker_builder/templates/tok.ml.jinja
+++ b/scripts/builder/checker_builder/templates/tok.ml.jinja
@@ -36,17 +36,6 @@ let tok_of_fraction_floor (x_num: Ligo.int) (x_den: Ligo.int) : tok =
   then (Ligo.failwith internalError_TokOfFractionFloorNegative : tok)
   else Ligo.abs (fdiv_int_int (Ligo.mul_int_int x_num tok_scaling_factor_int) x_den)
 
-(* TOKFIX: temporary, compatibility layer *)
-let tok_of_tez (tz: Ligo.tez) : tok =
-  tok_of_fraction_floor
-    (Ligo.int (Ligo.div_tez_tez tz (Ligo.tez_from_literal "1mutez")))
-    tez_scaling_factor_int
-
-let tez_of_tok (tk: tok) : Ligo.tez =
-  fraction_to_tez_floor
-    (tok_to_denomination_int tk)
-    tok_scaling_factor_int
-
 let[@inline] geq_tok_tok = Ligo.geq_nat_nat
 let[@inline] leq_tok_tok = Ligo.leq_nat_nat
 

--- a/scripts/generate-entrypoints.rb
+++ b/scripts/generate-entrypoints.rb
@@ -26,6 +26,7 @@ open CheckerTypes
 open Checker
 open Kit
 open Lqt
+open Tok
 open LiquidationAuctionTypes
 open LiquidationAuctionPrimitiveTypes
 open Ctez

--- a/src/burrowTypes.ml
+++ b/src/burrowTypes.ml
@@ -1,17 +1,14 @@
-open LiquidationAuctionTypes
 [@@@coverage off]
 
 type burrow_storage =
   { checker_address: Ligo.address;
-    burrow_id: burrow_id
+    collateral_fa2: Ligo.address;
   }
 [@@deriving show]
 
 type burrow_parameter =
   | BurrowSetDelegate of Ligo.key_hash option
-  | BurrowStoreTez
-  | BurrowSendTezTo of (Ligo.tez * Ligo.address)
-  | BurrowSendSliceToChecker of Ligo.tez
+  | BurrowTransfer of (Ligo.address * Ligo.nat)
 [@@deriving show]
 
 [@@@coverage on]

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -158,8 +158,6 @@ let[@inline] entrypoint_create_burrow (state, (burrow_no, delegate_opt, tok): ch
            match p with
            | BurrowSetDelegate kho ->
              (* NOTE: this deviates slightly from the design in the issue. *)
-             (* TODO: Also, I am not happy that an FA2 contract could "pretend"
-              * to have a set_delegate entrypoint and succeed here. *)
              let op = match (LigoOp.Tezos.get_entrypoint_opt "%set_delegate" storage.collateral_fa2 : Ligo.key_hash option Ligo.contract option) with
                | Some c -> LigoOp.Tezos.opt_key_hash_transaction kho (Ligo.tez_from_literal "0mutez") c
                | None -> (Ligo.failwith (Ligo.int_from_literal "-3") : LigoOp.operation) in (* i.e., set_delegate not supported *)

--- a/src/checkerMain.ml
+++ b/src/checkerMain.ml
@@ -18,7 +18,7 @@ type checker_params =
 type params =
   | DeployFunction of (lazy_function_id * Ligo.bytes)
   | DeployMetadata of Ligo.bytes
-  | SealContract of (Ligo.address * Ligo.address)
+  | SealContract of (Ligo.address * Ligo.address * Ligo.address)
   | CheckerEntrypoint of checker_params
 
 (*
@@ -67,12 +67,13 @@ let main (op, state: params * wrapper): LigoOp.operation list * wrapper =
                 | None -> Ligo.Big_map.add "m" bs metadata
                 | Some prev -> Ligo.Big_map.add "m" (Ligo.Bytes.concat prev bs) metadata in
               (([]: LigoOp.operation list), lazy_functions, metadata, Unsealed deployer)
-            | SealContract (oracle_addr, ctez_addr) ->
-              let external_contracts = { oracle = oracle_addr; ctez = ctez_addr; } in
+            | SealContract (oracle_addr, ctez_addr, collateral_fa2_addr) ->
+              let external_contracts = { oracle = oracle_addr; ctez = ctez_addr; collateral_fa2 = collateral_fa2_addr; } in
 
-              (* check if the given oracle and ctez contracts have the entrypoints we need *)
+              (* check if the given oracle, ctez, and collateral_fa2 contracts have the entrypoints we need *)
               let _ = get_transfer_ctez_entrypoint external_contracts in
               let _ = get_oracle_entrypoint external_contracts in
+              let _ = get_transfer_collateral_fa2_entrypoint external_contracts in
 
               (* emit a touch operation to checker *)
               let touchOp =

--- a/src/checkerMain.ml
+++ b/src/checkerMain.ml
@@ -67,13 +67,13 @@ let main (op, state: params * wrapper): LigoOp.operation list * wrapper =
                 | None -> Ligo.Big_map.add "m" bs metadata
                 | Some prev -> Ligo.Big_map.add "m" (Ligo.Bytes.concat prev bs) metadata in
               (([]: LigoOp.operation list), lazy_functions, metadata, Unsealed deployer)
-            | SealContract (oracle_addr, ctez_addr, collateral_fa2_addr) ->
-              let external_contracts = { oracle = oracle_addr; ctez = ctez_addr; collateral_fa2 = collateral_fa2_addr; } in
+            | SealContract (oracle_addr, collateral_fa2_addr, ctez_addr) ->
+              let external_contracts = { oracle = oracle_addr; collateral_fa2 = collateral_fa2_addr; ctez = ctez_addr; } in
 
-              (* check if the given oracle, ctez, and collateral_fa2 contracts have the entrypoints we need *)
-              let _ = get_transfer_ctez_entrypoint external_contracts in
+              (* check if the given oracle, collateral_fa2, and ctez contracts have the entrypoints we need *)
               let _ = get_oracle_entrypoint external_contracts in
               let _ = get_transfer_collateral_fa2_entrypoint external_contracts in
+              let _ = get_transfer_ctez_entrypoint external_contracts in
 
               (* emit a touch operation to checker *)
               let touchOp =

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -11,8 +11,8 @@ type burrow_map = (burrow_id, burrow) Ligo.big_map
 
 type external_contracts = {
   oracle : Ligo.address;
-  ctez : Ligo.address;
   collateral_fa2 : Ligo.address;
+  ctez : Ligo.address;
 }
 
 type checker =

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -12,6 +12,7 @@ type burrow_map = (burrow_id, burrow) Ligo.big_map
 type external_contracts = {
   oracle : Ligo.address;
   ctez : Ligo.address;
+  collateral_fa2 : Ligo.address;
 }
 
 type checker =

--- a/src/common.ml
+++ b/src/common.ml
@@ -63,6 +63,7 @@ let[@inline] tez_of_mutez_nat (amnt: Ligo.nat) = Ligo.mul_nat_tez amnt (Ligo.tez
 
 let tez_to_mutez (x: Ligo.tez) = Ligo.int (tez_to_mutez_nat x)
 
+let tez_zero : Ligo.tez = Ligo.tez_from_literal "0mutez"
 let tez_scaling_factor_int : Ligo.int = Ligo.int_from_literal "1_000_000"
 let tez_scaling_factor_nat : Ligo.nat = Ligo.nat_from_literal "1_000_000n"
 

--- a/src/common.mli
+++ b/src/common.mli
@@ -18,6 +18,7 @@ val tez_to_mutez_nat : Ligo.tez -> Ligo.nat
 val tez_of_mutez_nat : Ligo.nat -> Ligo.tez
 val tez_to_mutez : Ligo.tez -> Ligo.int
 
+val tez_zero : Ligo.tez
 val tez_scaling_factor_int : Ligo.int
 val tez_scaling_factor_nat : Ligo.nat
 

--- a/src/error.ml
+++ b/src/error.ml
@@ -52,15 +52,14 @@ let[@inline] error_InvalidLiquidationAuction                            : Ligo.i
 
 let[@inline] error_GetContractOptFailure                                : Ligo.int = Ligo.int_from_literal "95"
 
-let[@inline] error_GetEntrypointOptFailureTransferAddress               : Ligo.int = Ligo.int_from_literal "102"
-let[@inline] error_GetEntrypointOptFailureBurrowStoreTez                : Ligo.int = Ligo.int_from_literal "103"
-let[@inline] error_GetEntrypointOptFailureBurrowSendTezTo               : Ligo.int = Ligo.int_from_literal "105"
 let[@inline] error_GetEntrypointOptFailureBurrowSetDelegate             : Ligo.int = Ligo.int_from_literal "106"
-let[@inline] error_GetEntrypointOptFailureBurrowSendSliceToChecker      : Ligo.int = Ligo.int_from_literal "107"
+let[@inline] error_GetEntrypointOptFailureBurrowTransfer                : Ligo.int = Ligo.int_from_literal "108"
+
 let[@inline] error_UnauthorisedCaller                                   : Ligo.int = Ligo.int_from_literal "111"
 let[@inline] error_GetEntrypointOptFailureReceivePrice                  : Ligo.int = Ligo.int_from_literal "112"
 let[@inline] error_GetEntrypointOptFailureOracleEntrypoint              : Ligo.int = Ligo.int_from_literal "113"
 let[@inline] error_GetEntrypointOptFailureFA12Transfer                  : Ligo.int = Ligo.int_from_literal "114"
+let[@inline] error_GetEntrypointOptFailureFA2Transfer                   : Ligo.int = Ligo.int_from_literal "115"
 
 let[@inline] error_ContractNotDeployed                                  : Ligo.int = Ligo.int_from_literal "134"
 let[@inline] error_ContractAlreadyDeployed                              : Ligo.int = Ligo.int_from_literal "135"

--- a/src/error.ml
+++ b/src/error.ml
@@ -76,7 +76,8 @@ let[@inline] error_GetEntrypointOptFailureVaultSetDelegate              : Ligo.i
 
 let[@inline] error_GetEntrypointOptFailureCallVaultReceiveTez           : Ligo.int = Ligo.int_from_literal "170"
 let[@inline] error_GetEntrypointOptFailureCallVaultSendTezToContract    : Ligo.int = Ligo.int_from_literal "171"
-let[@inline] error_GetEntrypointOptFailureCallVaultSetDelegate          : Ligo.int = Ligo.int_from_literal "172"
+let[@inline] error_GetEntrypointOptFailureCallVaultSendTezToVault       : Ligo.int = Ligo.int_from_literal "172"
+let[@inline] error_GetEntrypointOptFailureCallVaultSetDelegate          : Ligo.int = Ligo.int_from_literal "173"
 
 (* INTERNAL ERRORS *)
 

--- a/src/fa2Interface.ml
+++ b/src/fa2Interface.ml
@@ -22,6 +22,7 @@ type fa2_transfer_destination =
     token_id : fa2_token_id;
     amount : Ligo.nat;
   }
+[@@deriving show]
 
 type fa2_transfer =
   (* BEGIN_LIGO [@layout:comb] END_LIGO *)
@@ -29,6 +30,7 @@ type fa2_transfer =
     from_ : Ligo.address;
     txs : fa2_transfer_destination list;
   }
+[@@deriving show]
 
 type fa2_balance_of_request =
   (* BEGIN_LIGO [@layout:comb] END_LIGO *)
@@ -145,6 +147,9 @@ type fa2_token_sender =
 [@@@coverage off]
 
 type fa2_balance_of_response_list = fa2_balance_of_response list
+[@@deriving show]
+
+type fa2_transfer_list = fa2_transfer list
 [@@deriving show]
 
 [@@@coverage on]

--- a/src/ligoOp.ml
+++ b/src/ligoOp.ml
@@ -11,9 +11,9 @@ type 'parameter transaction_value = (* GADT *)
   | AddressNatTransactionValue : (address * nat) -> (address * nat) transaction_value
   | TezAddressTransactionValue : (tez * address) -> (tez * address) transaction_value
   | OptKeyHashTransactionValue : key_hash option -> key_hash option transaction_value
-  | TezTransactionValue : tez -> tez transaction_value
   | NatContractTransactionValue : nat contract -> nat contract transaction_value
   | FA12TransferTransactionValue : Fa12Interface.fa12_transfer -> Fa12Interface.fa12_transfer transaction_value
+  | FA2TransferTransactionValue : Fa2Interface.fa2_transfer list -> Fa2Interface.fa2_transfer list transaction_value
   | FA2BalanceOfResponseTransactionValue : Fa2Interface.fa2_balance_of_response list -> Fa2Interface.fa2_balance_of_response list transaction_value
   | AddressTezTransactionValue : (address * tez) -> (address * tez) transaction_value
   | AddressTezAddressTransactionValue : (address * tez * address) -> (address * tez * address) transaction_value
@@ -44,9 +44,9 @@ let show_transaction_value : type parameter. parameter transaction_value -> Stri
   | AddressNatTransactionValue p -> show_address_and_nat p
   | TezAddressTransactionValue ta -> show_tez_and_address ta
   | OptKeyHashTransactionValue kho -> show_key_hash_option kho
-  | TezTransactionValue tz -> string_of_tez tz
   | NatContractTransactionValue c -> show_contract c
   | FA12TransferTransactionValue t -> Fa12Interface.show_fa12_transfer t
+  | FA2TransferTransactionValue t -> Fa2Interface.show_fa2_transfer_list t
   | FA2BalanceOfResponseTransactionValue xs -> Fa2Interface.show_fa2_balance_of_response_list xs
   | AddressTezTransactionValue at -> show_address_and_tez at
   | AddressTezAddressTransactionValue ata -> show_address_and_tez_and_address ata
@@ -94,9 +94,9 @@ module Tezos = struct
   let address_nat_transaction p tez contract = Transaction (AddressNatTransactionValue p, tez, contract)
   let tez_address_transaction value tez contract = Transaction (TezAddressTransactionValue value, tez, contract)
   let opt_key_hash_transaction value tez contract = Transaction (OptKeyHashTransactionValue value, tez, contract)
-  let tez_transaction value tez contract = Transaction (TezTransactionValue value, tez, contract)
   let nat_contract_transaction value tez contract = Transaction (NatContractTransactionValue value, tez, contract)
   let fa12_transfer_transaction value tez contract = Transaction (FA12TransferTransactionValue value, tez, contract)
+  let fa2_transfer_transaction value tez contract = Transaction (FA2TransferTransactionValue value, tez, contract)
   let fa2_balance_of_response_transaction value tez contract = Transaction (FA2BalanceOfResponseTransactionValue value, tez, contract)
   let address_tez_transaction value tez contract = Transaction (AddressTezTransactionValue value, tez, contract)
   let address_tez_address_transaction value tez contract = Transaction (AddressTezAddressTransactionValue value, tez, contract)

--- a/src/ligoOp.mli
+++ b/src/ligoOp.mli
@@ -7,9 +7,9 @@ type 'parameter transaction_value = (* GADT *)
   | AddressNatTransactionValue : (address * nat) -> (address * nat) transaction_value
   | TezAddressTransactionValue : (tez * address) -> (tez * address) transaction_value
   | OptKeyHashTransactionValue : key_hash option -> key_hash option transaction_value
-  | TezTransactionValue : tez -> tez transaction_value
   | NatContractTransactionValue : nat contract -> nat contract transaction_value
   | FA12TransferTransactionValue : Fa12Interface.fa12_transfer -> Fa12Interface.fa12_transfer transaction_value
+  | FA2TransferTransactionValue : Fa2Interface.fa2_transfer list -> Fa2Interface.fa2_transfer list transaction_value
   | FA2BalanceOfResponseTransactionValue : Fa2Interface.fa2_balance_of_response list -> Fa2Interface.fa2_balance_of_response list transaction_value
   | AddressTezTransactionValue : (address * tez) -> (address * tez) transaction_value
   | AddressTezAddressTransactionValue : (address * tez * address) -> (address * tez * address) transaction_value
@@ -47,10 +47,10 @@ module Tezos : sig
   val address_nat_transaction : address * nat -> tez -> (address * nat) contract -> operation
   val tez_address_transaction : (tez * address) -> tez -> (tez * address) contract -> operation
   val opt_key_hash_transaction : key_hash option -> tez -> key_hash option contract -> operation
-  val tez_transaction : tez -> tez -> tez contract -> operation
   val nat_contract_transaction : nat contract -> tez -> nat contract contract -> operation
   val fa12_transfer_transaction : Fa12Interface.fa12_transfer -> tez -> Fa12Interface.fa12_transfer contract -> operation
-  val fa2_balance_of_response_transaction : Fa2Interface.fa2_balance_of_response list -> tez-> Fa2Interface.fa2_balance_of_response list contract -> operation
+  val fa2_transfer_transaction : Fa2Interface.fa2_transfer list -> tez -> Fa2Interface.fa2_transfer list contract -> operation
+  val fa2_balance_of_response_transaction : Fa2Interface.fa2_balance_of_response list -> tez -> Fa2Interface.fa2_balance_of_response list contract -> operation
   val address_tez_transaction : (address * tez) -> tez -> (address * tez) contract -> operation
   val address_tez_address_transaction : (address * tez * address) -> tez -> (address * tez * address) contract -> operation
   val address_opt_key_hash_transaction : (address * key_hash option) -> tez -> (address * key_hash option) contract -> operation

--- a/src/tezWrapper.ml
+++ b/src/tezWrapper.ml
@@ -10,7 +10,7 @@ open Error
   * originate vaults pretty easily, everytime we look one up: if it's not
   * there, just originate it now. *)
 (* TODO: Investigate whether we should or should not inline this one. *)
-let originate_vault (owner: Ligo.address) : LigoOp.operation * Ligo.address =
+let[@inline] originate_vault (owner: Ligo.address) : LigoOp.operation * Ligo.address =
   LigoOp.Tezos.vault_create_contract
     (fun (p, storage : vault_parameter * vault_storage) ->
        match p with

--- a/src/tezWrapper.ml
+++ b/src/tezWrapper.ml
@@ -155,23 +155,10 @@ let[@inline] fa2_run_transfer (st, xs: tez_wrapper_state * fa2_transfer list) : 
            | None -> ops (* vault is already originated *)
            | Some origination -> (origination :: ops) in (* originate now *)
 
-         (* TODO: Revisit this; do we really need to restrict the from_ here? *)
-         let () =
-           if (from_ = !Ligo.Tezos.self_address) (* || (is_vault_address st.vaults from_) *) then
-             failwith "FA2_INVALID_ADDRESS" (* NOTE: CUSTOM MNEMONIC *)
-           else () in
-
-         (* TODO: Do we really need to restrict the to_ and from_ here? *)
          Ligo.List.fold_left
            (fun (((st, ops), x): (tez_wrapper_state * LigoOp.operation list) * fa2_transfer_destination) ->
               let fa2_st = st.fa2_state in
               let { to_ = to_; token_id = token_id; amount = amnt; } = x in
-
-              (* TODO: Revisit this; do we really need to restrict the to_ here? *)
-              let () =
-                if (to_ = !Ligo.Tezos.self_address) (* || (is_vault_address st.vaults to_) *) then
-                  failwith "FA2_INVALID_ADDRESS" (* NOTE: CUSTOM MNEMONIC *)
-                else () in
 
               if fa2_is_operator (fa2_st, !Ligo.Tezos.sender, from_, token_id)
               then

--- a/src/tok.mli
+++ b/src/tok.mli
@@ -16,10 +16,6 @@ val tok_of_denomination : Ligo.nat -> tok
 val tok_to_denomination_int : tok -> Ligo.int
 val tok_to_denomination_nat : tok -> Ligo.nat
 
-(* TOKFIX: temporary, compatibility layer *)
-val tok_of_tez : Ligo.tez -> tok
-val tez_of_tok : tok -> Ligo.tez
-
 val tok_of_fraction_ceil : Ligo.int -> Ligo.int -> tok
 val tok_of_fraction_floor : Ligo.int -> Ligo.int -> tok
 

--- a/tests/testCheckerEntrypoints.ml
+++ b/tests/testCheckerEntrypoints.ml
@@ -19,8 +19,8 @@ let with_sealed_state_and_cfmm_setup f =
        Ligo.Tezos.reset ();
        let burrow_id = Ligo.nat_from_literal "74n" in
        (* Create a burrow *)
-       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "10_000_000mutez");
-       let op = CheckerMain.(CheckerEntrypoint (LazyParams (Create_burrow (burrow_id, None)))) in
+       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:Common.tez_zero;
+       let op = CheckerMain.(CheckerEntrypoint (LazyParams (Create_burrow (burrow_id, None, tok_of_denomination (Ligo.nat_from_literal "10_000_000n"))))) in
        let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
        (* Mint some kit *)
        Ligo.Tezos.new_transaction ~seconds_passed:62 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
@@ -235,9 +235,9 @@ let suite =
     ("wrapper_view_burrow_max_mintable_kit - sealed" >::
      with_sealed_wrapper
        (fun sealed_wrapper ->
-          let initial_amount = tez_of_tok (tok_add Constants.creation_deposit Constants.creation_deposit) in
-          Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:bob_addr ~amount:initial_amount;
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Create_burrow (Ligo.nat_from_literal "0n", None)))) in
+          let initial_amount = tok_add Constants.creation_deposit Constants.creation_deposit in
+          Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:bob_addr ~amount:Common.tez_zero;
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Create_burrow (Ligo.nat_from_literal "0n", None, initial_amount)))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
           assert_kit_equal
             ~expected:(Kit.kit_of_denomination (Ligo.nat_from_literal "476_190n"))
@@ -248,8 +248,8 @@ let suite =
     ("wrapper_view_is_burrow_overburrowed - sealed" >::
      with_sealed_wrapper
        (fun sealed_wrapper ->
-          Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:bob_addr ~amount:(tez_of_tok Constants.creation_deposit);
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Create_burrow (Ligo.nat_from_literal "0n", None)))) in
+          Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:bob_addr ~amount:Common.tez_zero;
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Create_burrow (Ligo.nat_from_literal "0n", None, Constants.creation_deposit)))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
           assert_bool
             "burrow cannot be overburrowed already"
@@ -260,8 +260,8 @@ let suite =
     ("wrapper_view_is_burrow_liquidatable - sealed" >::
      with_sealed_wrapper
        (fun sealed_wrapper ->
-          Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:bob_addr ~amount:(tez_of_tok Constants.creation_deposit);
-          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Create_burrow (Ligo.nat_from_literal "0n", None)))) in
+          Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:bob_addr ~amount:Common.tez_zero;
+          let op = CheckerMain.(CheckerEntrypoint (LazyParams (Create_burrow (Ligo.nat_from_literal "0n", None, Constants.creation_deposit)))) in
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
           assert_bool
             "burrow cannot be liquidatable already"

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -7,6 +7,7 @@ let charles_key_hash = Ligo.key_hash_from_literal "charles_key_hash"
 
 let ctez_addr = Ligo.address_of_string "ctez_addr"
 let oracle_addr = Ligo.address_of_string "oracle_addr"
+let collateral_fa2_addr = Ligo.address_of_string "collateral_fa2_addr"
 
 let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
 let assert_stdlib_int_equal ~expected ~real = OUnit2.assert_equal ~printer:string_of_int expected real
@@ -52,6 +53,8 @@ let assert_slice_content_list_equal ~expected ~real = OUnit2.assert_equal ~print
 type liquidation_slice_list = LiquidationAuctionPrimitiveTypes.liquidation_slice list [@@deriving show]
 let assert_liquidation_slice_list_equal ~expected ~real = OUnit2.assert_equal ~printer:show_liquidation_slice_list expected real
 
+let assert_operation_equal ~expected ~real = OUnit2.assert_equal ~printer:LigoOp.show_operation expected real
+
 type operation_list = LigoOp.operation list [@@deriving show]
 let assert_operation_list_equal ~expected ~real = OUnit2.assert_equal ~printer:show_operation_list expected real
 
@@ -78,7 +81,7 @@ let with_sealed_wrapper f =
   Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:checker_deployer ~amount:(Ligo.tez_from_literal "0mutez");
 
   let wrapper = CheckerMain.initial_wrapper checker_deployer in (* unsealed *)
-  let op = CheckerMain.SealContract (oracle_addr, ctez_addr) in
+  let op = CheckerMain.SealContract (oracle_addr, ctez_addr, collateral_fa2_addr) in
   let _ops, wrapper = CheckerMain.main (op, wrapper) in (* sealed *)
   f wrapper
 


### PR DESCRIPTION
First part of #213: integration of the tez wrapper into checker's workflow (for details see section "Changes for Checker" in https://github.com/tezos-checker/checker/issues/213#issuecomment-919838046). In essence this PR makes checker deal with FA2 exclusively. To keep CI green, usage of the tez wrapper is hardwired; adding the switch to be able to change the collateral type should be part of a separate PR. This PR is already pretty big.

Other changes:
* Removed the restrictions on `from_` and `to_` in `TezWrapper.transfer` to save on gas costs (they were optional anyway).
* Fixed a bug in `TezWrapper.transfer` (transfer of zero tez should not fail due to non-originated vaults).
* Made `tezWrapper.ml` more verbose to significantly reduce its gas costs (see bot message below).

`TezWrapper.transfer` is still pretty expensive which makes Checker's entrypoints expensive too. This we can improve incrementally after merging this PR.