### PR TITLE
Add end to end tests for tez wrapper

### DIFF
--- a/e2e/main.py
+++ b/e2e/main.py
@@ -566,7 +566,7 @@ class TezWrapperTest(SandboxedTestCase):
             contract=wrapper_alice,
         )
 
-        # Send some kit back to the main test account
+        # Send some tez tokens back to the main test account
         call_endpoint("transfer", single_fa2_transfer(account_alice, account, 80))
         assert_wrapped_tez_balance(wrapper, account, 1_999_890)
         # `balance_of` requires a contract callback when executing on-chain. To make tests


### PR DESCRIPTION
Adds end to end tests which call all of the tez wrapper's entrypoints. In order to avoid further changes to our bot, etc. I updated the end to end tests to merge their gas costs, adding an identifier before each entrypoint (e.g. `checker%mint_kit`) to distinguish between overlapping entrypoint names. This might cause the github actions bot to produce some weird diff messages for this PR.

Closes #267 
