### PR TITLE
More accurate calculation of the price of kit in tez

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -8,6 +8,16 @@
 #
 # Then set the `Secret Key` as the aforementioned secret. It should be of the form: unencrypted:edsk****
 
+# FIXME: The default values for ctez-fa12 and ctez-cfmm for the ctez contract
+# below come from the following ctez instance:
+#
+#   https://better-call.dev/granadanet/KT1QqSAj6krgr3pqg7aqd1ukVZYwJoQ8HYCS/storage
+#
+# However, this instance does not expose an entrypoint for receiving the
+# marginal price of ctez in tez, so deploying with it as the default will
+# certainly fail. Once the next branch becomes the main one and a new ctez
+# instance is deployed, we should change these defaults.
+
 name: Deploy to the testnet
 on:
   workflow_dispatch:
@@ -23,7 +33,7 @@ on:
       ctez-cfmm:
         description: 'Ctez CFMM contract'
         required: true
-        default: 'KT1XaQyVJHKzr1qXPMoLawi56esqKzyzeuhE' # FIXME: This is the wrong address.
+        default: 'KT1K7mXY1YjAdqYETwNfgYL4qe6frWvSGJSu'
       oracle:
         description: 'Oracle contract'
         required: true

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -16,10 +16,14 @@ on:
         description: 'Node to connect to'
         required: true
         default: 'https://rpczero.tzbeta.net/'
-      ctez:
-        description: 'Ctez contract'
+      ctez-fa12:
+        description: 'Ctez FA1.2 contract'
         required: true
         default: 'KT1XaQyVJHKzr1qXPMoLawi56esqKzyzeuhE'
+      ctez-cfmm:
+        description: 'Ctez CFMM contract'
+        required: true
+        default: 'KT1XaQyVJHKzr1qXPMoLawi56esqKzyzeuhE' # FIXME: This is the wrong address.
       oracle:
         description: 'Oracle contract'
         required: true
@@ -57,5 +61,6 @@ jobs:
               --port 443 \
               --key "$TESTNET_KEY" \
               checker \
-              --ctez "${{ github.event.inputs.ctez }}" \
+              --ctez-fa12 "${{ github.event.inputs.ctez-fa12 }}" \
+              --ctez-cfmm "${{ github.event.inputs.ctez-cfmm }}" \
               --oracle "${{ github.event.inputs.oracle }}"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "vendor/ctez"]
 	path = vendor/ctez
-	url = https://github.com/murbard/ctez
+	url = https://github.com/gkaracha/ctez
+	branch = main
+	# FIXME: eventually this should be replaced by:
+	#   url = https://github.com/tezos-checker/ctez

--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ key file is `./my-account.json`):
       --port <node-port> \
       --key /my-account.json \
       checker \
-      --ctez <ctez-fa12-address> \
+      --ctez-fa12 <ctez-fa12-address> \
+      --ctez-cfmm <ctez-cfmm-address> \
       --oracle <oracle-address>
 ```
 
@@ -254,7 +255,8 @@ To deploy local copies of the contract (e.g. in `./generated/michelson`):
       --port <node-port> \
       --key /my-account.json \
       checker \
-      --ctez <ctez-fa12-address> \
+      --ctez-fa12 <ctez-fa12-address> \
+      --ctez-cfmm <ctez-cfmm-address> \
       --oracle <oracle-address> \
       --src /generated/michelson
 ```

--- a/client/checker_client/checker.py
+++ b/client/checker_client/checker.py
@@ -450,15 +450,17 @@ def deploy_ctez(tz: PyTezosClient, ctez_dir, ttl: Optional[int] = None):
 
         print("Deploying ctez CFMM contract...")
         cfmm_storage = {
-            "tokenPool": 1,
+            "tezPool": 1,
             "cashPool": 1,
+            "target": 281474976710656,  # Bitwise.shift_left 1n 48n
             "lqtTotal": 1,
-            "pendingPoolUpdates": 0,
-            "tokenAddress": fa12_ctez.context.address,
+            "ctez_address": ctez.context.address,
+            "cashAddress": fa12_ctez.context.address,
             "lqtAddress": "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU",
             "lastOracleUpdate": math.floor(time.time()),
-            "consumerEntrypoint": ctez.context.address,
+            "consumerEntrypoint": ctez.context.address,  # FIXME: This looks like it needs a %cfmm_price attached to it
         }
+
         cfmm = deploy_contract(
             tz,
             source_file=str(cfmm_michelson),

--- a/client/checker_client/checker.py
+++ b/client/checker_client/checker.py
@@ -458,7 +458,7 @@ def deploy_ctez(tz: PyTezosClient, ctez_dir, ttl: Optional[int] = None):
             "cashAddress": fa12_ctez.context.address,
             "lqtAddress": "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU",
             "lastOracleUpdate": math.floor(time.time()),
-            "consumerEntrypoint": ctez.context.address,  # FIXME: This looks like it needs a %cfmm_price attached to it
+            "consumerEntrypoint": f"{ctez.context.address}%cfmm_price",
         }
 
         cfmm = deploy_contract(

--- a/client/checker_client/checker.py
+++ b/client/checker_client/checker.py
@@ -312,7 +312,8 @@ def deploy_checker(
     *,
     oracle,
     tez_wrapper,
-    ctez,
+    ctez_fa12,
+    ctez_cfmm,
     ttl: Optional[int] = None,
     checker_config_path: Optional[Path] = None,
 ):
@@ -376,7 +377,7 @@ def deploy_checker(
     print("Sealing.")
     inject(
         tz,
-        checker.sealContract((oracle, tez_wrapper, ctez))
+        checker.sealContract((oracle, tez_wrapper, ctez_fa12, ctez_cfmm))
         .as_transaction()
         .autofill(ttl=ttl)
         .sign(),

--- a/docs/spec/functional_spec.rst
+++ b/docs/spec/functional_spec.rst
@@ -607,4 +607,4 @@ Prior to sealing, the bytecode for all metadata must be deployed.
 Seal the contract and make it ready for use
 -------------------------------------------
 
-``sealContract: (pair (pair address address) address)``
+``sealContract: (pair (pair (pair address address) address) address)``

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -660,7 +660,7 @@ class LiquidationsStressTest(SandboxedTestCase):
             oracle=oracle.context.address,
             tez_wrapper=tez_wrapper.context.address,
             ctez_fa12=ctez["fa12_ctez"].context.address,
-            ctez_cfmm=ctez["fa12_ctez"].context.address,
+            ctez_cfmm=ctez["cfmm"].context.address,
             ttl=MAX_OPERATIONS_TTL,
         )
 

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -326,7 +326,8 @@ class E2ETest(SandboxedTestCase):
             checker_dir=CHECKER_DIR,
             oracle=oracle.context.address,
             tez_wrapper=tez_wrapper.context.address,
-            ctez=ctez["fa12_ctez"].context.address,
+            ctez_fa12=ctez["fa12_ctez"].context.address,
+            ctez_cfmm=ctez["cfmm"].context.address,
             ttl=MAX_OPERATIONS_TTL,
         )
 
@@ -658,7 +659,8 @@ class LiquidationsStressTest(SandboxedTestCase):
             checker_dir=CHECKER_DIR,
             oracle=oracle.context.address,
             tez_wrapper=tez_wrapper.context.address,
-            ctez=ctez["fa12_ctez"].context.address,
+            ctez_fa12=ctez["fa12_ctez"].context.address,
+            ctez_cfmm=ctez["fa12_ctez"].context.address,
             ttl=MAX_OPERATIONS_TTL,
         )
 

--- a/scripts/generate-ligo.sh
+++ b/scripts/generate-ligo.sh
@@ -36,6 +36,7 @@ checker_sources=(
   burrow
   checkerTypes
   cfmm
+  price
   sliceList
   liquidationAuction
   burrowOrigination

--- a/scripts/generate-ligo.sh
+++ b/scripts/generate-ligo.sh
@@ -36,10 +36,10 @@ checker_sources=(
   burrow
   checkerTypes
   cfmm
-  price
   sliceList
   liquidationAuction
   burrowOrigination
+  price
   checker
   checkerEntrypoints
   checkerMain

--- a/src/cfmm.ml
+++ b/src/cfmm.ml
@@ -44,7 +44,7 @@ let[@inline] cfmm_assert_initialized (u: cfmm) : cfmm =
     contract), as it was at the end of the last block. This is to be used when
     required for the calculation of the drift derivative instead of up-to-date
     kit_in_ctez, because it is a little harder to manipulate. *)
-let cfmm_kit_in_ctez_in_prev_block (cfmm: cfmm) : ratio = (* FIXME: this should have an inline pragma, actually *)
+let[@inline] cfmm_kit_in_ctez_in_prev_block (cfmm: cfmm) : ratio =
   let cfmm = cfmm_assert_initialized cfmm in
   cfmm.kit_in_ctez_in_prev_block
 

--- a/src/cfmm.ml
+++ b/src/cfmm.ml
@@ -44,7 +44,7 @@ let[@inline] cfmm_assert_initialized (u: cfmm) : cfmm =
     contract), as it was at the end of the last block. This is to be used when
     required for the calculation of the drift derivative instead of up-to-date
     kit_in_ctez, because it is a little harder to manipulate. *)
-let cfmm_kit_in_ctez_in_prev_block (cfmm: cfmm) =
+let cfmm_kit_in_ctez_in_prev_block (cfmm: cfmm) : ratio = (* FIXME: this should have an inline pragma, actually *)
   let cfmm = cfmm_assert_initialized cfmm in
   cfmm.kit_in_ctez_in_prev_block
 

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -88,8 +88,8 @@ let assert_checker_invariants (state: checker) : unit =
 (**                           EXTERNAL_CONTRACTS                             *)
 (* ************************************************************************* *)
 
-let[@inline] get_transfer_ctez_entrypoint (external_contracts: external_contracts): fa12_transfer Ligo.contract =
-  match (LigoOp.Tezos.get_entrypoint_opt "%transfer" external_contracts.ctez : fa12_transfer Ligo.contract option) with
+let[@inline] get_transfer_ctez_fa12_entrypoint (external_contracts: external_contracts): fa12_transfer Ligo.contract =
+  match (LigoOp.Tezos.get_entrypoint_opt "%transfer" external_contracts.ctez_fa12 : fa12_transfer Ligo.contract option) with
   | Some c -> c
   | None -> (Ligo.failwith error_GetEntrypointOptFailureFA12Transfer : fa12_transfer Ligo.contract)
 
@@ -520,7 +520,7 @@ let entrypoint_buy_kit (state, p: checker * (ctez * kit * Ligo.timestamp)) : Lig
   let op =
     LigoOp.Tezos.fa12_transfer_transaction
       transfer (Ligo.tez_from_literal "0mutez")
-      (get_transfer_ctez_entrypoint state.external_contracts) in
+      (get_transfer_ctez_fa12_entrypoint state.external_contracts) in
 
   let state_fa2_state =
     let state_fa2_state = state.fa2_state in
@@ -557,7 +557,7 @@ let entrypoint_sell_kit (state, p: checker * (kit * ctez * Ligo.timestamp)) : Li
     LigoOp.Tezos.fa12_transfer_transaction
       transfer
       (Ligo.tez_from_literal "0mutez")
-      (get_transfer_ctez_entrypoint state.external_contracts) in
+      (get_transfer_ctez_fa12_entrypoint state.external_contracts) in
 
   let state_fa2_state =
     let state_fa2_state = state.fa2_state in
@@ -591,7 +591,7 @@ let entrypoint_add_liquidity (state, p: checker * (ctez * kit * lqt * Ligo.times
     LigoOp.Tezos.fa12_transfer_transaction
       transfer
       (Ligo.tez_from_literal "0mutez")
-      (get_transfer_ctez_entrypoint state.external_contracts) in
+      (get_transfer_ctez_fa12_entrypoint state.external_contracts) in
 
   let deposited_kit = kit_sub max_kit_deposited kit_tokens in
 
@@ -629,7 +629,7 @@ let entrypoint_remove_liquidity (state, p: checker * (lqt * ctez * kit * Ligo.ti
     LigoOp.Tezos.fa12_transfer_transaction
       transfer
       (Ligo.tez_from_literal "0mutez")
-      (get_transfer_ctez_entrypoint state.external_contracts) in
+      (get_transfer_ctez_fa12_entrypoint state.external_contracts) in
 
   let state_fa2_state =
     let state_fa2_state = state.fa2_state in

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -851,6 +851,11 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
         (Ligo.tez_from_literal "0mutez")
         (get_oracle_entrypoint state_external_contracts) in
 
+    (* FIXME: Create an operation to ask the ctez cfmm to send updated values.
+     * Emit this operation next to the one requesting prices from oracles, at
+     * the end, so that the system parameters do not change between touching
+     * different slices. *)
+
     (* TODO: Figure out how many slices we can process per checker entrypoint_touch.*)
     let ops, state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state =
       touch_oldest ([op], state_liquidation_auctions, state_burrows, state_parameters, state_fa2_state, number_of_slices_to_process) in
@@ -887,13 +892,14 @@ let entrypoint_receive_price (state, price: checker * Ligo.nat) : (LigoOp.operat
   else
     (([]: LigoOp.operation list), {state with last_index = Some price})
 
-let entrypoint_receive_ctez_marginal_price (state, price: checker * (Ligo.nat * Ligo.nat)) : (LigoOp.operation list * checker) =
+let entrypoint_receive_ctez_marginal_price (state, _price: checker * (Ligo.nat * Ligo.nat)) : (LigoOp.operation list * checker) =
   assert_checker_invariants state;
   if !Ligo.Tezos.sender <> state.external_contracts.ctez_cfmm then
     (Ligo.failwith error_UnauthorisedCaller : LigoOp.operation list * checker)
   else
-    (* FIXME: Figure out how to interpret the received fraction. *)
-    (([]: LigoOp.operation list), {state with last_ctez_in_tez = Some price})
+    (* FIXME: Figure out how to interpret the received fraction instead of
+     * hardwiring it to one_ratio. *)
+    (([]: LigoOp.operation list), {state with last_ctez_in_tez = Some one_ratio})
 
 
 (* ************************************************************************* *)

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -887,6 +887,15 @@ let entrypoint_receive_price (state, price: checker * Ligo.nat) : (LigoOp.operat
   else
     (([]: LigoOp.operation list), {state with last_index = Some price})
 
+let entrypoint_receive_ctez_marginal_price (state, price: checker * (Ligo.nat * Ligo.nat)) : (LigoOp.operation list * checker) =
+  assert_checker_invariants state;
+  if !Ligo.Tezos.sender <> state.external_contracts.ctez_cfmm then
+    (Ligo.failwith error_UnauthorisedCaller : LigoOp.operation list * checker)
+  else
+    (* FIXME: Figure out how to interpret the received fraction. *)
+    (([]: LigoOp.operation list), {state with last_ctez_in_tez = Some price})
+
+
 (* ************************************************************************* *)
 (**                               FA2                                        *)
 (* ************************************************************************* *)

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -490,6 +490,7 @@ let[@inline] entrypoint_touch_liquidation_slices (state, slices: checker * leaf_
       parameters = state_parameters;
       liquidation_auctions = state_liquidation_auctions;
       last_index = state_last_index;
+      last_ctez_price = state_last_ctez_price;
       fa2_state = state_fa2_state;
       external_contracts = state_external_contracts;
     } = state in
@@ -503,6 +504,7 @@ let[@inline] entrypoint_touch_liquidation_slices (state, slices: checker * leaf_
       parameters = state_parameters;
       liquidation_auctions = state_liquidation_auctions;
       last_index = state_last_index;
+      last_ctez_price = state_last_ctez_price;
       fa2_state = state_fa2_state;
       external_contracts = state_external_contracts;
     } in
@@ -797,6 +799,7 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
       parameters = state_parameters;
       liquidation_auctions = state_liquidation_auctions;
       last_index = state_last_index;
+      last_ctez_price = state_last_ctez_price;
       fa2_state = state_fa2_state;
       external_contracts = state_external_contracts;
     } = state in
@@ -858,6 +861,7 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
         parameters = state_parameters;
         liquidation_auctions = state_liquidation_auctions;
         last_index = state_last_index;
+        last_ctez_price = state_last_ctez_price;
         fa2_state = state_fa2_state;
         external_contracts = state_external_contracts;
       } in

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -821,7 +821,7 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
 
     (* 2: Update the system parameters and add accrued burrowing fees to the
      * cfmm sub-contract. *)
-    let kit_in_tez_in_prev_block = calculate_kit_in_tez state_cfmm state_last_ctez_in_tez state_external_contracts in
+    let kit_in_tez_in_prev_block = calculate_kit_in_tez state_cfmm state_last_ctez_in_tez in
     let total_accrual_to_cfmm, state_parameters = parameters_touch index kit_in_tez_in_prev_block state_parameters in
     (* Note: state_parameters.circulating kit here already includes the accrual to the CFMM. *)
     let state_cfmm = cfmm_add_accrued_kit state_cfmm total_accrual_to_cfmm in

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -20,6 +20,7 @@ open Fa2Ledger
 open Fa2Implementation
 open Mem
 open BurrowOrigination
+open Price
 
 (* BEGIN_OCAML *)
 [@@@coverage off]
@@ -810,11 +811,9 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
     let state_parameters = add_circulating_kit state_parameters reward in
     let state_fa2_state = ledger_issue_kit (state_fa2_state, !Ligo.Tezos.sender, reward) in
 
-    (* TODO: Generalize the price situation here too. *)
-
     (* 2: Update the system parameters and add accrued burrowing fees to the
      * cfmm sub-contract. *)
-    let kit_in_tez_in_prev_block = (cfmm_kit_in_ctez_in_prev_block state_cfmm) in (* FIXME: times ctez_in_tez *)
+    let kit_in_tez_in_prev_block = calculate_kit_in_tez state_cfmm state_external_contracts in
     let total_accrual_to_cfmm, state_parameters = parameters_touch index kit_in_tez_in_prev_block state_parameters in
     (* Note: state_parameters.circulating kit here already includes the accrual to the CFMM. *)
     let state_cfmm = cfmm_add_accrued_kit state_cfmm total_accrual_to_cfmm in

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -813,7 +813,7 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
 
     (* 2: Update the system parameters and add accrued burrowing fees to the
      * cfmm sub-contract. *)
-    let kit_in_tez_in_prev_block = calculate_kit_in_tez state_cfmm (* state_external_contracts *) in
+    let kit_in_tez_in_prev_block = calculate_kit_in_tez state_cfmm state_external_contracts in
     let total_accrual_to_cfmm, state_parameters = parameters_touch index kit_in_tez_in_prev_block state_parameters in
     (* Note: state_parameters.circulating kit here already includes the accrual to the CFMM. *)
     let state_cfmm = cfmm_add_accrued_kit state_cfmm total_accrual_to_cfmm in

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -813,7 +813,7 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
 
     (* 2: Update the system parameters and add accrued burrowing fees to the
      * cfmm sub-contract. *)
-    let kit_in_tez_in_prev_block = calculate_kit_in_tez state_cfmm state_external_contracts in
+    let kit_in_tez_in_prev_block = calculate_kit_in_tez state_cfmm (* state_external_contracts *) in
     let total_accrual_to_cfmm, state_parameters = parameters_touch index kit_in_tez_in_prev_block state_parameters in
     (* Note: state_parameters.circulating kit here already includes the accrual to the CFMM. *)
     let state_cfmm = cfmm_add_accrued_kit state_cfmm total_accrual_to_cfmm in

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -93,6 +93,11 @@ let[@inline] get_transfer_ctez_fa12_entrypoint (external_contracts: external_con
   | Some c -> c
   | None -> (Ligo.failwith error_GetEntrypointOptFailureFA12Transfer : fa12_transfer Ligo.contract)
 
+let[@inline] get_ctez_cfmm_price_entrypoint (external_contracts: external_contracts): ((Ligo.nat * Ligo.nat) Ligo.contract) Ligo.contract =
+  match (LigoOp.Tezos.get_entrypoint_opt "%getMarginalPrice" external_contracts.ctez_cfmm : ((Ligo.nat * Ligo.nat) Ligo.contract) Ligo.contract option) with
+  | Some c -> c
+  | None -> (Ligo.failwith error_GetEntrypointOptFailureCtezGetMarginalPrice : ((Ligo.nat * Ligo.nat) Ligo.contract) Ligo.contract)
+
 let[@inline] get_oracle_entrypoint (external_contracts: external_contracts): (Ligo.nat Ligo.contract) Ligo.contract =
   match (LigoOp.Tezos.get_entrypoint_opt "%getPrice" external_contracts.oracle: (Ligo.nat Ligo.contract) Ligo.contract option) with
   | Some c -> c

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -489,7 +489,7 @@ let[@inline] entrypoint_touch_liquidation_slices (state, slices: checker * leaf_
       cfmm = state_cfmm;
       parameters = state_parameters;
       liquidation_auctions = state_liquidation_auctions;
-      last_price = state_last_price;
+      last_index = state_last_index;
       fa2_state = state_fa2_state;
       external_contracts = state_external_contracts;
     } = state in
@@ -502,7 +502,7 @@ let[@inline] entrypoint_touch_liquidation_slices (state, slices: checker * leaf_
       cfmm = state_cfmm;
       parameters = state_parameters;
       liquidation_auctions = state_liquidation_auctions;
-      last_price = state_last_price;
+      last_index = state_last_index;
       fa2_state = state_fa2_state;
       external_contracts = state_external_contracts;
     } in
@@ -796,7 +796,7 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
       cfmm = state_cfmm;
       parameters = state_parameters;
       liquidation_auctions = state_liquidation_auctions;
-      last_price = state_last_price;
+      last_index = state_last_index;
       fa2_state = state_fa2_state;
       external_contracts = state_external_contracts;
     } = state in
@@ -857,7 +857,7 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
         cfmm = state_cfmm;
         parameters = state_parameters;
         liquidation_auctions = state_liquidation_auctions;
-        last_price = state_last_price;
+        last_index = state_last_index;
         fa2_state = state_fa2_state;
         external_contracts = state_external_contracts;
       } in
@@ -867,7 +867,7 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
     (ops, state)
 
 let entrypoint_touch (state, _: checker * unit) : (LigoOp.operation list * checker) =
-  let index = match state.last_price with
+  let index = match state.last_index with
     | None -> state.parameters.index (* use the old one *)
     | Some i -> i in (* FIXME: Is the nat supposed to represent tez? *)
   touch_with_index state index
@@ -881,7 +881,7 @@ let entrypoint_receive_price (state, price: checker * Ligo.nat) : (LigoOp.operat
   if !Ligo.Tezos.sender <> state.external_contracts.oracle then
     (Ligo.failwith error_UnauthorisedCaller : LigoOp.operation list * checker)
   else
-    (([]: LigoOp.operation list), {state with last_price = Some price})
+    (([]: LigoOp.operation list), {state with last_index = Some price})
 
 (* ************************************************************************* *)
 (**                               FA2                                        *)

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -490,7 +490,7 @@ let[@inline] entrypoint_touch_liquidation_slices (state, slices: checker * leaf_
       parameters = state_parameters;
       liquidation_auctions = state_liquidation_auctions;
       last_index = state_last_index;
-      last_ctez_price = state_last_ctez_price;
+      last_ctez_in_tez = state_last_ctez_in_tez;
       fa2_state = state_fa2_state;
       external_contracts = state_external_contracts;
     } = state in
@@ -504,7 +504,7 @@ let[@inline] entrypoint_touch_liquidation_slices (state, slices: checker * leaf_
       parameters = state_parameters;
       liquidation_auctions = state_liquidation_auctions;
       last_index = state_last_index;
-      last_ctez_price = state_last_ctez_price;
+      last_ctez_in_tez = state_last_ctez_in_tez;
       fa2_state = state_fa2_state;
       external_contracts = state_external_contracts;
     } in
@@ -799,7 +799,7 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
       parameters = state_parameters;
       liquidation_auctions = state_liquidation_auctions;
       last_index = state_last_index;
-      last_ctez_price = state_last_ctez_price;
+      last_ctez_in_tez = state_last_ctez_in_tez;
       fa2_state = state_fa2_state;
       external_contracts = state_external_contracts;
     } = state in
@@ -821,7 +821,7 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
 
     (* 2: Update the system parameters and add accrued burrowing fees to the
      * cfmm sub-contract. *)
-    let kit_in_tez_in_prev_block = calculate_kit_in_tez state_cfmm state_external_contracts in
+    let kit_in_tez_in_prev_block = calculate_kit_in_tez state_cfmm state_last_ctez_in_tez state_external_contracts in
     let total_accrual_to_cfmm, state_parameters = parameters_touch index kit_in_tez_in_prev_block state_parameters in
     (* Note: state_parameters.circulating kit here already includes the accrual to the CFMM. *)
     let state_cfmm = cfmm_add_accrued_kit state_cfmm total_accrual_to_cfmm in
@@ -861,7 +861,7 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
         parameters = state_parameters;
         liquidation_auctions = state_liquidation_auctions;
         last_index = state_last_index;
-        last_ctez_price = state_last_ctez_price;
+        last_ctez_in_tez = state_last_ctez_in_tez;
         fa2_state = state_fa2_state;
         external_contracts = state_external_contracts;
       } in

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -842,10 +842,10 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
     (* Create an operation to ask the oracles to send updated values. This
        should be the last operation we emit, so that the system parameters do
        not change between touching different slices. *)
-    let cb = match (LigoOp.Tezos.get_entrypoint_opt "%receive_price" !Ligo.Tezos.self_address : (Ligo.nat Ligo.contract) option) with
-      | Some cb -> cb
-      | None -> (Ligo.failwith error_GetEntrypointOptFailureReceivePrice : Ligo.nat Ligo.contract) in
     let op_oracle =
+      let cb = match (LigoOp.Tezos.get_entrypoint_opt "%receive_price" !Ligo.Tezos.self_address : (Ligo.nat Ligo.contract) option) with
+        | Some cb -> cb
+        | None -> (Ligo.failwith error_GetEntrypointOptFailureReceivePrice : Ligo.nat Ligo.contract) in
       LigoOp.Tezos.nat_contract_transaction
         cb
         (Ligo.tez_from_literal "0mutez")
@@ -855,10 +855,10 @@ let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.opera
      * this operation next to the one requesting prices from oracles, at the
      * end, so that the system parameters do not change between touching
      * different slices. *)
-    let cb = match (LigoOp.Tezos.get_entrypoint_opt "%receive_ctez_marginal_price" !Ligo.Tezos.self_address : ((Ligo.nat * Ligo.nat) Ligo.contract) option) with
-      | Some cb -> cb
-      | None -> (Ligo.failwith error_GetEntrypointOptFailureReceiveCtezMarginalPrice : (Ligo.nat * Ligo.nat) Ligo.contract) in
     let op_ctez_price =
+      let cb = match (LigoOp.Tezos.get_entrypoint_opt "%receive_ctez_marginal_price" !Ligo.Tezos.self_address : ((Ligo.nat * Ligo.nat) Ligo.contract) option) with
+        | Some cb -> cb
+        | None -> (Ligo.failwith error_GetEntrypointOptFailureReceiveCtezMarginalPrice : (Ligo.nat * Ligo.nat) Ligo.contract) in
       LigoOp.Tezos.nat_nat_contract_transaction
         cb
         (Ligo.tez_from_literal "0mutez")

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -32,6 +32,7 @@ val compute_outstanding_dissonance : checker -> kit (* "real" *) * kit (* approx
 
 (**/**)
 val get_transfer_ctez_fa12_entrypoint : external_contracts -> fa12_transfer Ligo.contract
+val get_ctez_cfmm_price_entrypoint : external_contracts -> ((Ligo.nat * Ligo.nat) Ligo.contract) Ligo.contract
 val get_oracle_entrypoint : external_contracts -> (Ligo.nat Ligo.contract) Ligo.contract
 val get_transfer_collateral_fa2_entrypoint : external_contracts -> fa2_transfer list Ligo.contract
 

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -31,7 +31,7 @@ val compute_outstanding_dissonance : checker -> kit (* "real" *) * kit (* approx
 (*****************************************************************************)
 
 (**/**)
-val get_transfer_ctez_entrypoint : external_contracts -> fa12_transfer Ligo.contract
+val get_transfer_ctez_fa12_entrypoint : external_contracts -> fa12_transfer Ligo.contract
 val get_oracle_entrypoint : external_contracts -> (Ligo.nat Ligo.contract) Ligo.contract
 val get_transfer_collateral_fa2_entrypoint : external_contracts -> fa2_transfer list Ligo.contract
 

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -242,6 +242,13 @@ val entrypoint_liquidation_auction_claim_win : checker * liquidation_auction_id 
 *)
 val entrypoint_receive_price : checker * Ligo.nat -> (LigoOp.operation list * checker)
 
+(** (INTERNAL) Receive a price from the ctez (CFMM) contract.
+
+    Parameters:
+    - The current price as a pair of the numerator and the denominator. FIXME: How to interpret exactly the given fraction?
+*)
+val entrypoint_receive_ctez_marginal_price : checker * (Ligo.nat * Ligo.nat) -> (LigoOp.operation list * checker)
+
 (*****************************************************************************)
 (**                             {1 FA2}                                      *)
 (*****************************************************************************)

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -245,7 +245,7 @@ val entrypoint_receive_price : checker * Ligo.nat -> (LigoOp.operation list * ch
 (** (INTERNAL) Receive a price from the ctez (CFMM) contract.
 
     Parameters:
-    - The current price as a pair of the numerator and the denominator. FIXME: How to interpret exactly the given fraction?
+    - The current price as a pair of the numerator and the denominator.
 *)
 val entrypoint_receive_ctez_marginal_price : checker * (Ligo.nat * Ligo.nat) -> (LigoOp.operation list * checker)
 

--- a/src/checkerMain.ml
+++ b/src/checkerMain.ml
@@ -19,7 +19,7 @@ type checker_params =
 type params =
   | DeployFunction of (lazy_function_id * Ligo.bytes)
   | DeployMetadata of Ligo.bytes
-  | SealContract of (Ligo.address * Ligo.address * Ligo.address)
+  | SealContract of (Ligo.address * Ligo.address * Ligo.address * Ligo.address)
   | CheckerEntrypoint of checker_params
 
 (*
@@ -70,13 +70,19 @@ let main (op, state: params * wrapper): LigoOp.operation list * wrapper =
                 | None -> Ligo.Big_map.add "m" bs metadata
                 | Some prev -> Ligo.Big_map.add "m" (Ligo.Bytes.concat prev bs) metadata in
               (([]: LigoOp.operation list), lazy_functions, metadata, Unsealed deployer)
-            | SealContract (oracle_addr, collateral_fa2_addr, ctez_fa12_addr) ->
-              let external_contracts = { oracle = oracle_addr; collateral_fa2 = collateral_fa2_addr; ctez_fa12 = ctez_fa12_addr; } in
+            | SealContract (oracle_addr, collateral_fa2_addr, ctez_fa12_addr, ctez_cfmm_addr) ->
+              let external_contracts =
+                { oracle = oracle_addr;
+                  collateral_fa2 = collateral_fa2_addr;
+                  ctez_fa12 = ctez_fa12_addr;
+                  ctez_cfmm = ctez_cfmm_addr;
+                } in
 
               (* check if the given oracle, collateral_fa2, and ctez contracts have the entrypoints we need *)
               let _ = get_oracle_entrypoint external_contracts in
               let _ = get_transfer_collateral_fa2_entrypoint external_contracts in
               let _ = get_transfer_ctez_fa12_entrypoint external_contracts in
+              (* FIXME: let _ = get_ctez_cfmm_price_entrypoint external_contracts in *)
 
               (* emit a touch operation to checker *)
               let touchOp =

--- a/src/checkerMain.ml
+++ b/src/checkerMain.ml
@@ -82,7 +82,7 @@ let main (op, state: params * wrapper): LigoOp.operation list * wrapper =
               let _ = get_oracle_entrypoint external_contracts in
               let _ = get_transfer_collateral_fa2_entrypoint external_contracts in
               let _ = get_transfer_ctez_fa12_entrypoint external_contracts in
-              (* FIXME: let _ = get_ctez_cfmm_price_entrypoint external_contracts in *)
+              let _ = get_ctez_cfmm_price_entrypoint external_contracts in
 
               (* emit a touch operation to checker *)
               let touchOp =

--- a/src/checkerMain.ml
+++ b/src/checkerMain.ml
@@ -70,13 +70,13 @@ let main (op, state: params * wrapper): LigoOp.operation list * wrapper =
                 | None -> Ligo.Big_map.add "m" bs metadata
                 | Some prev -> Ligo.Big_map.add "m" (Ligo.Bytes.concat prev bs) metadata in
               (([]: LigoOp.operation list), lazy_functions, metadata, Unsealed deployer)
-            | SealContract (oracle_addr, collateral_fa2_addr, ctez_addr) ->
-              let external_contracts = { oracle = oracle_addr; collateral_fa2 = collateral_fa2_addr; ctez = ctez_addr; } in
+            | SealContract (oracle_addr, collateral_fa2_addr, ctez_fa12_addr) ->
+              let external_contracts = { oracle = oracle_addr; collateral_fa2 = collateral_fa2_addr; ctez_fa12 = ctez_fa12_addr; } in
 
               (* check if the given oracle, collateral_fa2, and ctez contracts have the entrypoints we need *)
               let _ = get_oracle_entrypoint external_contracts in
               let _ = get_transfer_collateral_fa2_entrypoint external_contracts in
-              let _ = get_transfer_ctez_entrypoint external_contracts in
+              let _ = get_transfer_ctez_fa12_entrypoint external_contracts in
 
               (* emit a touch operation to checker *)
               let touchOp =

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -13,6 +13,7 @@ type external_contracts = {
   oracle : Ligo.address;
   collateral_fa2 : Ligo.address;
   ctez_fa12 : Ligo.address;
+  ctez_cfmm : Ligo.address;
 }
 
 type checker =

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -22,7 +22,7 @@ type checker =
     parameters : parameters;
     liquidation_auctions : liquidation_auctions;
     last_index : Ligo.nat option;
-    last_ctez_price : (Ligo.nat * Ligo.nat) option;
+    last_ctez_in_tez : (Ligo.nat * Ligo.nat) option;
     fa2_state : fa2_state;
     external_contracts : external_contracts;
   }
@@ -34,7 +34,7 @@ let initial_checker (external_contracts: external_contracts) =
     parameters = initial_parameters;
     liquidation_auctions = liquidation_auction_empty;
     last_index = (None : Ligo.nat option);
-    last_ctez_price = (None : (Ligo.nat * Ligo.nat) option);
+    last_ctez_in_tez = (None : (Ligo.nat * Ligo.nat) option);
     fa2_state = initial_fa2_state;
     external_contracts = external_contracts;
   }

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -21,7 +21,7 @@ type checker =
     cfmm : cfmm;
     parameters : parameters;
     liquidation_auctions : liquidation_auctions;
-    last_price : Ligo.nat option;
+    last_index : Ligo.nat option;
     fa2_state : fa2_state;
     external_contracts : external_contracts;
   }
@@ -32,7 +32,7 @@ let initial_checker (external_contracts: external_contracts) =
     cfmm = initial_cfmm ();
     parameters = initial_parameters;
     liquidation_auctions = liquidation_auction_empty;
-    last_price = (None : Ligo.nat option);
+    last_index = (None : Ligo.nat option);
     fa2_state = initial_fa2_state;
     external_contracts = external_contracts;
   }

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -6,6 +6,7 @@ open Parameters
 open LiquidationAuctionTypes
 open LiquidationAuctionPrimitiveTypes
 open Fa2Ledger
+open Common
 
 type burrow_map = (burrow_id, burrow) Ligo.big_map
 
@@ -22,7 +23,7 @@ type checker =
     parameters : parameters;
     liquidation_auctions : liquidation_auctions;
     last_index : Ligo.nat option;
-    last_ctez_in_tez : (Ligo.nat * Ligo.nat) option;
+    last_ctez_in_tez : ratio option;
     fa2_state : fa2_state;
     external_contracts : external_contracts;
   }
@@ -34,7 +35,7 @@ let initial_checker (external_contracts: external_contracts) =
     parameters = initial_parameters;
     liquidation_auctions = liquidation_auction_empty;
     last_index = (None : Ligo.nat option);
-    last_ctez_in_tez = (None : (Ligo.nat * Ligo.nat) option);
+    last_ctez_in_tez = (None : ratio option);
     fa2_state = initial_fa2_state;
     external_contracts = external_contracts;
   }

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -22,6 +22,7 @@ type checker =
     parameters : parameters;
     liquidation_auctions : liquidation_auctions;
     last_index : Ligo.nat option;
+    last_ctez_price : (Ligo.nat * Ligo.nat) option;
     fa2_state : fa2_state;
     external_contracts : external_contracts;
   }
@@ -33,6 +34,7 @@ let initial_checker (external_contracts: external_contracts) =
     parameters = initial_parameters;
     liquidation_auctions = liquidation_auction_empty;
     last_index = (None : Ligo.nat option);
+    last_ctez_price = (None : (Ligo.nat * Ligo.nat) option);
     fa2_state = initial_fa2_state;
     external_contracts = external_contracts;
   }

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -12,7 +12,7 @@ type burrow_map = (burrow_id, burrow) Ligo.big_map
 type external_contracts = {
   oracle : Ligo.address;
   collateral_fa2 : Ligo.address;
-  ctez : Ligo.address;
+  ctez_fa12 : Ligo.address;
 }
 
 type checker =

--- a/src/error.ml
+++ b/src/error.ml
@@ -60,6 +60,7 @@ let[@inline] error_GetEntrypointOptFailureReceivePrice                  : Ligo.i
 let[@inline] error_GetEntrypointOptFailureOracleEntrypoint              : Ligo.int = Ligo.int_from_literal "113"
 let[@inline] error_GetEntrypointOptFailureFA12Transfer                  : Ligo.int = Ligo.int_from_literal "114"
 let[@inline] error_GetEntrypointOptFailureFA2Transfer                   : Ligo.int = Ligo.int_from_literal "115"
+let[@inline] error_GetEntrypointOptFailureCtezGetMarginalPrice          : Ligo.int = Ligo.int_from_literal "116"
 
 let[@inline] error_ContractNotDeployed                                  : Ligo.int = Ligo.int_from_literal "134"
 let[@inline] error_ContractAlreadyDeployed                              : Ligo.int = Ligo.int_from_literal "135"

--- a/src/error.ml
+++ b/src/error.ml
@@ -61,6 +61,7 @@ let[@inline] error_GetEntrypointOptFailureOracleEntrypoint              : Ligo.i
 let[@inline] error_GetEntrypointOptFailureFA12Transfer                  : Ligo.int = Ligo.int_from_literal "114"
 let[@inline] error_GetEntrypointOptFailureFA2Transfer                   : Ligo.int = Ligo.int_from_literal "115"
 let[@inline] error_GetEntrypointOptFailureCtezGetMarginalPrice          : Ligo.int = Ligo.int_from_literal "116"
+let[@inline] error_GetEntrypointOptFailureReceiveCtezMarginalPrice      : Ligo.int = Ligo.int_from_literal "117"
 
 let[@inline] error_ContractNotDeployed                                  : Ligo.int = Ligo.int_from_literal "134"
 let[@inline] error_ContractAlreadyDeployed                              : Ligo.int = Ligo.int_from_literal "135"

--- a/src/ligoOp.ml
+++ b/src/ligoOp.ml
@@ -18,6 +18,7 @@ type 'parameter transaction_value = (* GADT *)
   | AddressTezTransactionValue : (address * tez) -> (address * tez) transaction_value
   | AddressTezAddressTransactionValue : (address * tez * address) -> (address * tez * address) transaction_value
   | AddressOptKeyHashTransactionValue : (address * key_hash option) -> (address * key_hash option) transaction_value
+  | NatNatContractTransactionValue : (nat * nat) contract -> (nat * nat) contract transaction_value
 
 type address_and_nat = (address * nat)
 [@@deriving show]
@@ -51,6 +52,7 @@ let show_transaction_value : type parameter. parameter transaction_value -> Stri
   | AddressTezTransactionValue at -> show_address_and_tez at
   | AddressTezAddressTransactionValue ata -> show_address_and_tez_and_address ata
   | AddressOptKeyHashTransactionValue akho -> show_address_and_key_hash_option akho
+  | NatNatContractTransactionValue c -> show_contract c
 
 (* operation *)
 
@@ -101,6 +103,7 @@ module Tezos = struct
   let address_tez_transaction value tez contract = Transaction (AddressTezTransactionValue value, tez, contract)
   let address_tez_address_transaction value tez contract = Transaction (AddressTezAddressTransactionValue value, tez, contract)
   let address_opt_key_hash_transaction value tez contract = Transaction (AddressOptKeyHashTransactionValue value, tez, contract)
+  let nat_nat_contract_transaction value tez contract = Transaction (NatNatContractTransactionValue value, tez, contract)
 
   let get_entrypoint_opt ep address = (* Sad, giving always Some, I know, but I know of no other way. *)
     Some (contract_of_address (address_of_string (string_of_address address ^ ep))) (* ep includes the % character *)

--- a/src/ligoOp.mli
+++ b/src/ligoOp.mli
@@ -14,6 +14,7 @@ type 'parameter transaction_value = (* GADT *)
   | AddressTezTransactionValue : (address * tez) -> (address * tez) transaction_value
   | AddressTezAddressTransactionValue : (address * tez * address) -> (address * tez * address) transaction_value
   | AddressOptKeyHashTransactionValue : (address * key_hash option) -> (address * key_hash option) transaction_value
+  | NatNatContractTransactionValue : (nat * nat) contract -> (nat * nat) contract transaction_value
 
 (* operation *)
 
@@ -54,6 +55,7 @@ module Tezos : sig
   val address_tez_transaction : (address * tez) -> tez -> (address * tez) contract -> operation
   val address_tez_address_transaction : (address * tez * address) -> tez -> (address * tez * address) contract -> operation
   val address_opt_key_hash_transaction : (address * key_hash option) -> tez -> (address * key_hash option) contract -> operation
+  val nat_nat_contract_transaction : (nat * nat) contract -> tez -> (nat * nat) contract contract -> operation
 
   val get_entrypoint_opt : string -> address -> 'parameter contract option
   val get_contract_opt : address -> unit contract option (* could also leave it as a parameter *)

--- a/src/price.ml
+++ b/src/price.ml
@@ -1,9 +1,9 @@
 open Cfmm
 open CfmmTypes
-open CheckerTypes
+(* open CheckerTypes *)
 open Common
 
-let[@inline] calculate_kit_in_tez (state_cfmm: cfmm) (_state_external_contracts: external_contracts) : ratio =
+let[@inline] calculate_kit_in_tez (state_cfmm: cfmm) (* (_state_external_contracts: external_contracts) *) : ratio =
   (* 1. Get the price of kit in ctez from the cfmm. To avoid having cfmm users
    *    trying to manipulate the price, we use the last price of kit in ctez
    *    observed, not the one in the current block. *)

--- a/src/price.ml
+++ b/src/price.ml
@@ -1,12 +1,10 @@
 open Cfmm
 open CfmmTypes
-open CheckerTypes
 open Common
 
 let[@inline] calculate_kit_in_tez
     (state_cfmm: cfmm)
     (state_last_ctez_in_tez: ratio option)
-    (_state_external_contracts: external_contracts)
   : ratio =
   (* 1. Get the price of kit in ctez from the cfmm. To avoid having cfmm users
    *    trying to manipulate the price, we use the last price of kit in ctez

--- a/src/price.ml
+++ b/src/price.ml
@@ -5,11 +5,19 @@ open Common
 
 let[@inline] calculate_kit_in_tez
     (state_cfmm: cfmm)
+    (state_last_ctez_in_tez: (Ligo.nat * Ligo.nat) option)
     (_state_external_contracts: external_contracts)
   : ratio =
   (* 1. Get the price of kit in ctez from the cfmm. To avoid having cfmm users
    *    trying to manipulate the price, we use the last price of kit in ctez
    *    observed, not the one in the current block. *)
-  let kit_in_ctez_in_prev_block = cfmm_kit_in_ctez_in_prev_block state_cfmm in
-  let kit_in_tez_in_prev_block = kit_in_ctez_in_prev_block in (* FIXME: times ctez_in_tez *)
-  kit_in_tez_in_prev_block
+  let { num = num_ctez; den = den_kit; } = cfmm_kit_in_ctez_in_prev_block state_cfmm in
+  (* 2. Get the price of ctez in tez from storage (last observed). Use tez/ctez
+   *    = 1 as the default price if none was observed. *)
+  let { num = num_tez; den = den_ctez; } = match state_last_ctez_in_tez with
+    | None -> one_ratio
+    | Some (n, d) -> make_ratio (Ligo.int n) (Ligo.int d) in
+  (* FIXME: Emit an operation asking to update the price *)
+  { num = Ligo.mul_int_int num_ctez num_tez;
+    den = Ligo.mul_int_int den_kit den_ctez;
+  }

--- a/src/price.ml
+++ b/src/price.ml
@@ -1,9 +1,12 @@
 open Cfmm
 open CfmmTypes
-(* open CheckerTypes *)
+open CheckerTypes
 open Common
 
-let[@inline] calculate_kit_in_tez (state_cfmm: cfmm) (* (_state_external_contracts: external_contracts) *) : ratio =
+let[@inline] calculate_kit_in_tez
+    (state_cfmm: cfmm)
+    (_state_external_contracts: external_contracts)
+  : ratio =
   (* 1. Get the price of kit in ctez from the cfmm. To avoid having cfmm users
    *    trying to manipulate the price, we use the last price of kit in ctez
    *    observed, not the one in the current block. *)

--- a/src/price.ml
+++ b/src/price.ml
@@ -1,0 +1,12 @@
+open Cfmm
+open CfmmTypes
+open CheckerTypes
+open Common
+
+let[@inline] calculate_kit_in_tez (state_cfmm: cfmm) (_state_external_contracts: external_contracts) : ratio =
+  (* 1. Get the price of kit in ctez from the cfmm. To avoid having cfmm users
+   *    trying to manipulate the price, we use the last price of kit in ctez
+   *    observed, not the one in the current block. *)
+  let kit_in_ctez_in_prev_block = cfmm_kit_in_ctez_in_prev_block state_cfmm in
+  let kit_in_tez_in_prev_block = kit_in_ctez_in_prev_block in (* FIXME: times ctez_in_tez *)
+  kit_in_tez_in_prev_block

--- a/src/price.ml
+++ b/src/price.ml
@@ -5,7 +5,7 @@ open Common
 
 let[@inline] calculate_kit_in_tez
     (state_cfmm: cfmm)
-    (state_last_ctez_in_tez: (Ligo.nat * Ligo.nat) option)
+    (state_last_ctez_in_tez: ratio option)
     (_state_external_contracts: external_contracts)
   : ratio =
   (* 1. Get the price of kit in ctez from the cfmm. To avoid having cfmm users
@@ -16,8 +16,8 @@ let[@inline] calculate_kit_in_tez
    *    = 1 as the default price if none was observed. *)
   let { num = num_tez; den = den_ctez; } = match state_last_ctez_in_tez with
     | None -> one_ratio
-    | Some (n, d) -> make_ratio (Ligo.int n) (Ligo.int d) in
-  (* FIXME: Emit an operation asking to update the price *)
+    | Some price -> price in
+  (* 3. kit_in_tez = kit_in_ctez * ctez_in_tez *)
   { num = Ligo.mul_int_int num_ctez num_tez;
     den = Ligo.mul_int_int den_kit den_ctez;
   }

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -23,7 +23,8 @@ let checker_address = !Ligo.Tezos.self_address
 
 let empty_checker =
   initial_checker
-    { ctez_fa12 = ctez_addr;
+    { ctez_fa12 = ctez_fa12_addr;
+      ctez_cfmm = ctez_cfmm_addr;
       oracle = oracle_addr;
       collateral_fa2 = collateral_fa2_addr;
     }

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -1366,7 +1366,7 @@ let suite =
     ("entrypoint_liquidation_auction_place_bid: should only allow the current auction" >::
      fun _ ->
        Ligo.Tezos.reset ();
-       let checker = { empty_checker with last_price = Some (Ligo.nat_from_literal "1_000_000n") } in
+       let checker = { empty_checker with last_index = Some (Ligo.nat_from_literal "1_000_000n") } in
 
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _, checker = Checker.entrypoint_touch (checker, ()) in
@@ -1377,7 +1377,7 @@ let suite =
 
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", max_kit)) in
-       let checker = { checker with last_price = Some (Ligo.nat_from_literal "10_000_000n") } in
+       let checker = { checker with last_index = Some (Ligo.nat_from_literal "10_000_000n") } in
        let _, checker = Checker.entrypoint_touch (checker, ()) in
 
        Ligo.Tezos.new_transaction ~seconds_passed:1_000_000 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -23,7 +23,7 @@ let checker_address = !Ligo.Tezos.self_address
 
 let empty_checker =
   initial_checker
-    { ctez = ctez_addr;
+    { ctez_fa12 = ctez_addr;
       oracle = oracle_addr;
       collateral_fa2 = collateral_fa2_addr;
     }
@@ -388,7 +388,7 @@ let suite =
                value=(Ligo.nat_from_literal "5_000_000n")}
             )
             (Ligo.tez_from_literal "0mutez")
-            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctez))
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctez_fa12))
          );
        ] in
        assert_operation_list_equal ~expected:expected_ops ~real:ops
@@ -678,7 +678,7 @@ let suite =
                value=(Ligo.nat_from_literal "5_000_000n")}
             )
             (Ligo.tez_from_literal "0mutez")
-            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctez))
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctez_fa12))
          );
        ] in
        assert_operation_list_equal ~expected:expected_ops ~real:ops
@@ -1140,7 +1140,7 @@ let suite =
                value=(Ligo.nat_from_literal "1_000_000n")}
             )
             (Ligo.tez_from_literal "0mutez")
-            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctez))
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctez_fa12))
          );
        ] in
        assert_nat_equal ~expected:(Ligo.nat_from_literal "1n") ~real:kit;
@@ -1180,7 +1180,7 @@ let suite =
                value=(Ligo.nat_from_literal "1n")}
             )
             (Ligo.tez_from_literal "0mutez")
-            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctez))
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctez_fa12))
          );
        ] in
        assert_operation_list_equal ~expected:expected_ops ~real:ops

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -698,6 +698,11 @@ let suite =
             (Ligo.tez_from_literal "0mutez")
             (Checker.get_oracle_entrypoint checker.external_contracts)
          );
+         (LigoOp.Tezos.nat_nat_contract_transaction
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%receive_ctez_marginal_price" !Ligo.Tezos.self_address))
+            (Ligo.tez_from_literal "0mutez")
+            (Checker.get_ctez_cfmm_price_entrypoint checker.external_contracts)
+         );
        ] in
        assert_operation_list_equal ~expected:expected_ops ~real:ops
     );
@@ -1652,8 +1657,9 @@ let suite =
         * request to the oracle to update the index. *)
        begin match ops with
          | [
-           Transaction (AddressNatTransactionValue _, _, _);  (* send tez requests *)
-           Transaction (NatContractTransactionValue _, _, _); (* oracle call *)
+           Transaction (AddressNatTransactionValue _, _, _);     (* send tez requests *)
+           Transaction (NatContractTransactionValue _, _, _);    (* oracle call *)
+           Transaction (NatNatContractTransactionValue _, _, _); (* ctez cfmm call *)
          ] -> ()
          | _ -> assert_failure ("Unexpected operations/operation order: " ^ show_operation_list ops)
        end;

--- a/tests/testCheckerEntrypoints.ml
+++ b/tests/testCheckerEntrypoints.ml
@@ -539,7 +539,7 @@ let suite =
     ("SealContract (main) - fails when unwanted tez is given - sealed state" >::
      assert_sealed_contract_fails_with_unwanted_tez
        (fun sealed_wrapper ->
-          let param = (Ligo.address_from_literal "oracle address", Ligo.address_from_literal "col fa2 address", Ligo.address_from_literal "ctez fa2 address") in
+          let param = (oracle_addr, collateral_fa2_addr, ctez_fa12_addr, ctez_cfmm_addr) in
           CheckerMain.(main (SealContract (param), sealed_wrapper))
        )
     );
@@ -755,7 +755,7 @@ let suite =
     ("SealContract (main) - fails when unwanted tez is given - unsealed state" >::
      assert_unsealed_contract_fails_with_unwanted_tez
        (fun unsealed_wrapper ->
-          let param = (Ligo.address_from_literal "oracle address", Ligo.address_from_literal "col fa2 address", Ligo.address_from_literal "ctez fa2 address") in
+          let param = (oracle_addr, collateral_fa2_addr, ctez_fa12_addr, ctez_cfmm_addr) in
           CheckerMain.(main (SealContract (param), unsealed_wrapper))
        )
     );

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -43,12 +43,12 @@ let lift_to_sealed_wrapper (f: CheckerTypes.checker -> 'a) : CheckerTypes.wrappe
     | Sealed state -> f state
   )
 
-let set_last_price_in_wrapper wrapper price_option =
+let set_last_index_in_wrapper wrapper index_option =
   CheckerTypes.(
     match wrapper.deployment_state with
     | Unsealed _ -> wrapper
     | Sealed state ->
-      {wrapper with deployment_state = Sealed {state with last_price = price_option}}
+      {wrapper with deployment_state = Sealed {state with last_index = index_option}}
   )
 
 let find_burrow_in_sealed_wrapper sealed_wrapper burrow_id =
@@ -379,7 +379,7 @@ let suite =
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
           (* setup: increase the index significantly (emulate the effects of Receive_price) *)
-          let sealed_wrapper = set_last_price_in_wrapper sealed_wrapper (Some (Ligo.nat_from_literal "100_000_000n")) in
+          let sealed_wrapper = set_last_index_in_wrapper sealed_wrapper (Some (Ligo.nat_from_literal "100_000_000n")) in
 
           (* setup: let enough time pass so that the burrow becomes liquidatable *)
           let blocks_passed = 191 in
@@ -432,7 +432,7 @@ let suite =
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
           (* setup: increase the index significantly (emulate the effects of Receive_price) *)
-          let sealed_wrapper = set_last_price_in_wrapper sealed_wrapper (Some (Ligo.nat_from_literal "1_357_906n")) in (* lowest value I could get, assuming the rest of the setting. *)
+          let sealed_wrapper = set_last_index_in_wrapper sealed_wrapper (Some (Ligo.nat_from_literal "1_357_906n")) in (* lowest value I could get, assuming the rest of the setting. *)
 
           (* setup: let enough time pass so that the burrow becomes liquidatable *)
           let blocks_passed = 191 in
@@ -487,7 +487,7 @@ let suite =
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
           (* setup: increase the index significantly (emulate the effects of Receive_price) *)
-          let sealed_wrapper = set_last_price_in_wrapper sealed_wrapper (Some (Ligo.nat_from_literal "1_357_906n")) in (* lowest value I could get, assuming the rest of the setting. *)
+          let sealed_wrapper = set_last_index_in_wrapper sealed_wrapper (Some (Ligo.nat_from_literal "1_357_906n")) in (* lowest value I could get, assuming the rest of the setting. *)
 
           (* setup: let enough time pass so that the burrow becomes liquidatable *)
           let blocks_passed = 191 in

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -256,7 +256,7 @@ let suite =
        let wrapper = CheckerMain.initial_wrapper leena_addr in (* unsealed *)
 
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctez_addr) in
+       let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctez_fa12_addr, ctez_cfmm_addr) in
        assert_raises
          (Failure (Ligo.string_of_int error_UnauthorisedCaller))
          (fun () -> CheckerMain.main (op, wrapper))
@@ -602,7 +602,7 @@ let suite =
     ("SealContract - should fail if the contract is already sealed" >::
      with_sealed_wrapper
        (fun sealed_wrapper ->
-          let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctez_addr) in
+          let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctez_fa12_addr, ctez_cfmm_addr) in
           assert_raises
             (Failure (Ligo.string_of_int error_ContractAlreadyDeployed))
             (fun () -> CheckerMain.main (op, sealed_wrapper))

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -5,7 +5,8 @@ let bob_addr = Ligo.address_from_literal "bob_addr"
 let leena_addr = Ligo.address_from_literal "leena_addr"
 let charles_key_hash = Ligo.key_hash_from_literal "charles_key_hash"
 
-let ctez_addr = Ligo.address_of_string "ctez_addr"
+let ctez_fa12_addr = Ligo.address_of_string "ctez_fa12_addr"
+let ctez_cfmm_addr = Ligo.address_of_string "ctez_cfmm_addr"
 let oracle_addr = Ligo.address_of_string "oracle_addr"
 let collateral_fa2_addr = Ligo.address_of_string "collateral_fa2_addr"
 
@@ -81,7 +82,7 @@ let with_sealed_wrapper f =
   Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:checker_deployer ~amount:(Ligo.tez_from_literal "0mutez");
 
   let wrapper = CheckerMain.initial_wrapper checker_deployer in (* unsealed *)
-  let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctez_addr) in
+  let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctez_fa12_addr, ctez_cfmm_addr) in
   let _ops, wrapper = CheckerMain.main (op, wrapper) in (* sealed *)
   f wrapper
 


### PR DESCRIPTION
This PR addresses #239, for now sidestepping tezos-checker/ctez#30. In order for the changes to work the vendored ctez version is switched to [my fork][gkaracha-fork], which currently points to the currently unmerged tezos-checker/ctez#30. Once tezos-checker/ctez#30 is merged, we should change the url of the submodule to `https://github.com/tezos-checker/ctez`.

- [X] Move price calculation into a separate module. (When adding the FA2/TEZ switch we should turn this into a jinja template and allow for different price calculations.)
- [x] Extend `external_contracts` and all relevant places with the address of the ctez cfmm (`cfmm_tez_ctez.mligo`). Why another ctez address? The price entrypoint comes from ctez's cfmm subcontract, not it's FA1.2 subcontract whose address we currently store.
- [X] Add a new entrypoint `%receive_ctez_marginal_price`, to be passed to [`%getMarginalPrice`](https://github.com/tezos-checker/ctez/pull/30). A callback should be able to update the price in Checker's storage.
- [X] Change `touch` to use the most recent ctez price, and emit an additional operation for updating the ctez price for the next `touch`. Unfortunately this seems to increase gas costs significantly (~11K), for `touch`. No way around it probably, since the costs come primarily from the internal operation that requires the deserialization of ctez's cfmm. **NOTE**: the price we receive is currently ignored (we still use ctez/tez=1); I am not sure how to interpret it. I've added a `FIXME`, but we shall fix this independently of this PR.
- [X] Update the ctez deployment script to account for the storage differences between ctez `main` and `next` branches ([my fork][gkaracha-fork] extends `next`)—fix a bug in there as well.
- [X] Add an inline pragma to `cfmm_kit_in_ctez_in_prev_block` since it's supposed to be a noop in the LIGO world (it asserts properties on the OCaml side).
- [X] Rename `last_price` to `last_index`; we now have two prices in storage: `last_index` (TEZ/USD) and `last_ctez_in_tez` (TEZ/CTEZ).


[gkaracha-fork]: https://github.com/gkaracha/ctez