### PR TITLE
Integrate the ctez wrapper into Checker

### DIFF
--- a/checker.yaml
+++ b/checker.yaml
@@ -1,7 +1,8 @@
 ## Configurations for Checker builds and code generation
 
 tokens:
-  # Collateral token configuration
+  # Collateral token configuration (creates tok.ml)
+  # FIXME: Must be aligned with TezWrapper.tez_token_id when collateral = TEZ
   collateral:
     # The token's FA2 id
     token_id: 2
@@ -12,11 +13,10 @@ tokens:
     name: tok (checker dev)
     # Optional FA2 token symbol
     symbol: tok
-  # CFMM token configuration
+  # CFMM token configuration (creates ctok.ml)
+  # FIXME: Must be aligned with Wctez.wctez_token_id when collateral = TEZ
   cfmm_token:
     # The token's FA2 id
-    # FIXME: Currently FA12, actually.
-    # FIXME: No idea what ctez's token_id is, actually (we don't issue it).
     token_id: 3
     # Specifies the number of decimal digits used by the token
     # e.g. tez has 6 decimal digits.
@@ -24,9 +24,8 @@ tokens:
     # Optional FA2 display name
     name: ctok (checker dev)
     # Optional FA2 token symbol
-    # FIXME: Currently FA12, actually.
     symbol: ctok
-  # Collateral token configuration
+  # Issued token configuration (creates kit.ml)
   kit:
     # The token's FA2 id
     token_id: 0
@@ -36,7 +35,7 @@ tokens:
     name: kit (checker dev)
     # Optional FA2 token symbol
     symbol: kit
-  # Liquidity token configuration
+  # Liquidity token configuration (creates lqt.ml)
   liquidity:
     # The token's FA2 id
     token_id: 1

--- a/client/checker_client/checker.py
+++ b/client/checker_client/checker.py
@@ -335,6 +335,7 @@ def deploy_checker(
     tez_wrapper,
     ctez_fa12,
     ctez_cfmm,
+    wctez,
     ttl: Optional[int] = None,
     checker_config_path: Optional[Path] = None,
 ):
@@ -398,7 +399,7 @@ def deploy_checker(
     print("Sealing.")
     inject(
         tz,
-        checker.sealContract((oracle, tez_wrapper, ctez_fa12, ctez_cfmm))
+        checker.sealContract((oracle, tez_wrapper, wctez, ctez_cfmm))
         .as_transaction()
         .autofill(ttl=ttl)
         .sign(),

--- a/client/checker_client/cli.py
+++ b/client/checker_client/cli.py
@@ -183,6 +183,7 @@ def deploy(config: Config, address=None, port=None, key=None):
 @click.option("--tez_wrapper", type=str, help="TezWrapper contract address")
 @click.option("--ctez_fa12", type=str, help="ctez FA1.2 contract address")
 @click.option("--ctez_cfmm", type=str, help="ctez CFMM contract address")
+@click.option("--wctez", type=str, help="Wrapped ctez contract address")
 @click.option(
     "--checker_config",
     type=click.Path(exists=True),
@@ -191,7 +192,7 @@ def deploy(config: Config, address=None, port=None, key=None):
 )
 @click.pass_obj
 def checker(
-    config: Config, checker_dir, oracle, tez_wrapper, ctez_fa12, ctez_cfmm, checker_config
+    config: Config, checker_dir, oracle, tez_wrapper, ctez_fa12, ctez_cfmm, wctez, checker_config
 ):
     """
     Deploy checker. Requires addresses for oracle and ctez contracts.
@@ -212,6 +213,10 @@ def checker(
         raise ValueError(
             "ctez cfmm address was neither specified in the CLI config nor provided as an argument."
         )
+    if not config.wctez_address and not wctez:
+        raise ValueError(
+            "Wrapped ctez address was neither specified in the CLI config nor provided as an argument."
+        )
     if oracle:
         config.oracle_address = oracle
     if ctez_fa12:
@@ -220,6 +225,8 @@ def checker(
         config.ctez_cfmm_address = ctez_cfmm
     if tez_wrapper:
         config.tez_wrapper_address = tez_wrapper
+    if wctez:
+        config.wctez = wctez
 
     shell = construct_url(config.tezos_address, config.tezos_port)
     click.echo(f"Connecting to tezos node at: {shell}")
@@ -232,6 +239,7 @@ def checker(
         tez_wrapper=config.tez_wrapper_address,
         ctez_fa12=config.ctez_fa12_address,
         ctez_cfmm=config.ctez_cfmm_address,
+        wctez=config.wctez,
         ttl=_patch_operation_ttl(config),
         checker_config_path=checker_config,
     )

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -552,6 +552,7 @@ class E2ETest(SandboxedTestCase):
         if WRITE_GAS_COSTS:
             write_gas_costs(gas_costs, WRITE_GAS_COSTS)
 
+
 class TezWrapperTest(SandboxedTestCase):
     def test_e2e(self):
         gas_costs = {}

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -331,6 +331,14 @@ class E2ETest(SandboxedTestCase):
             ttl=MAX_OPERATIONS_TTL,
         )
 
+        print("Deploying wctez contract.")
+        wctez = deploy_wctez(
+            self.client,
+            checker_dir=CHECKER_DIR,
+            ctez_fa12=ctez["fa12_ctez"].context.address,
+            ttl=MAX_OPERATIONS_TTL,
+        )
+
         print("Deploying Checker.")
         checker = deploy_checker(
             self.client,
@@ -339,6 +347,7 @@ class E2ETest(SandboxedTestCase):
             tez_wrapper=tez_wrapper.context.address,
             ctez_fa12=ctez["fa12_ctez"].context.address,
             ctez_cfmm=ctez["cfmm"].context.address,
+            wctez=wctez.context.address,
             ttl=MAX_OPERATIONS_TTL,
         )
 
@@ -801,6 +810,14 @@ class LiquidationsStressTest(SandboxedTestCase):
             ttl=MAX_OPERATIONS_TTL,
         )
 
+        print("Deploying wctez contract.")
+        wctez = deploy_wctez(
+            self.client,
+            checker_dir=CHECKER_DIR,
+            ctez_fa12=ctez["fa12_ctez"].context.address,
+            ttl=MAX_OPERATIONS_TTL,
+        )
+
         print("Deploying Checker.")
         checker = deploy_checker(
             self.client,
@@ -809,6 +826,7 @@ class LiquidationsStressTest(SandboxedTestCase):
             tez_wrapper=tez_wrapper.context.address,
             ctez_fa12=ctez["fa12_ctez"].context.address,
             ctez_cfmm=ctez["cfmm"].context.address,
+            wctez=wctez.context.address,
             ttl=MAX_OPERATIONS_TTL,
         )
 

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -307,7 +307,7 @@ class E2ETest(SandboxedTestCase):
         kit_token_id = self.config.tokens.kit.token_id
         collateral_token_id = self.config.tokens.collateral.token_id
         # Hard-coded in contract, so also hard-coding here
-        wctez_token_id = 0
+        wctez_token_id = 3
         # ===============================================================================
         # Deploy contracts
         # ===============================================================================
@@ -526,7 +526,7 @@ class E2ETest(SandboxedTestCase):
         update_operators = [
             {
                 "add_operator": {
-                    "owner": self.client.key.public_key_hash(),
+                    "owner": account,
                     "operator": checker.context.address,
                     "token_id": wctez_token_id,
                 }
@@ -676,7 +676,7 @@ class WCtezTest(SandboxedTestCase):
     def test_wctez(self):
         gas_costs = {}
         # Hard-coded in contract, so also hard-coding here
-        wctez_token_id = 0
+        wctez_token_id = 3
 
         print("Deploying ctez contracts.")
         ctez = deploy_ctez(

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -375,7 +375,7 @@ class E2ETest(SandboxedTestCase):
             return ret
 
         def call_wctez_endpoint(
-            name, param, amount=0, client=wctez, client=self.client
+            name, param, amount=0, contract=wctez, client=self.client
         ):
             print("Calling", name, "with", param)
             ret = call_endpoint(contract, name, param, amount, client=client)

--- a/e2e/main.py
+++ b/e2e/main.py
@@ -809,287 +809,287 @@ class WCtezTest(SandboxedTestCase):
             write_gas_costs(gas_costs, WRITE_GAS_COSTS)
 
 
-# class LiquidationsStressTest(SandboxedTestCase):
-#     def test_liquidations(self):
-#         collateral_token_id = self.config.tokens.collateral.token_id
-#
-#         print("Deploying the mock oracle.")
-#         oracle = deploy_contract(
-#             self.client,
-#             source_file=os.path.join(PROJECT_ROOT, "util/mock_oracle.tz"),
-#             initial_storage=(self.client.key.public_key_hash(), 1000000),
-#             ttl=MAX_OPERATIONS_TTL,
-#         )
-#
-#         print("Deploying the tez wrapper.")
-#         tez_wrapper = deploy_tez_wrapper(
-#             self.client,
-#             checker_dir=CHECKER_DIR,
-#             ttl=MAX_OPERATIONS_TTL,
-#         )
-#
-#         print("Deploying ctez contract.")
-#         ctez = deploy_ctez(
-#             self.client,
-#             ctez_dir=os.path.join(PROJECT_ROOT, "vendor/ctez"),
-#             ttl=MAX_OPERATIONS_TTL,
-#         )
-#
-#         print("Deploying wctez contract.")
-#         wctez = deploy_wctez(
-#             self.client,
-#             checker_dir=CHECKER_DIR,
-#             ctez_fa12_address=ctez["fa12_ctez"].context.address,
-#             ttl=MAX_OPERATIONS_TTL,
-#         )
-#
-#         print("Deploying Checker.")
-#         checker = deploy_checker(
-#             self.client,
-#             checker_dir=CHECKER_DIR,
-#             oracle=oracle.context.address,
-#             tez_wrapper=tez_wrapper.context.address,
-#             ctez_fa12=ctez["fa12_ctez"].context.address,
-#             ctez_cfmm=ctez["cfmm"].context.address,
-#             wctez=wctez.context.address,
-#             ttl=MAX_OPERATIONS_TTL,
-#         )
-#
-#         print("Deployment finished.")
-#
-#         def call_endpoint(
-#             contract, name, param, amount=0, profiler=general_gas_profiler
-#         ):
-#             # Helper for calling contract endpoints with profiling
-#             print("Calling", contract.key.public_key_hash(), "/", name, "with", param)
-#             profile = profiler(
-#                 self.client,
-#                 contract,
-#                 [
-#                     getattr(contract, name)(param)
-#                     .with_amount(amount)
-#                     .as_transaction()
-#                     .autofill(ttl=MAX_OPERATIONS_TTL)
-#                     .sign()
-#                 ],
-#             )
-#             self.gas_profiles = merge_gas_profiles(self.gas_profiles, profile)
-#
-#         def call_bulk(bulks, *, batch_size, profiler=general_gas_profiler):
-#             # Helper for calling operations in batches
-#             batches = [
-#                 bulks[i : i + batch_size] for i in range(0, len(bulks), batch_size)
-#             ]
-#             for batch_no, batch in enumerate(batches, 1):
-#                 print(
-#                     "Sending",
-#                     len(batches),
-#                     "operations as bulk:",
-#                     "Batch",
-#                     batch_no,
-#                     "of",
-#                     len(batches),
-#                 )
-#                 profile = profiler(self.client, checker, batch)
-#                 self.gas_profiles = merge_gas_profiles(self.gas_profiles, profile)
-#
-#         def get_tez_tokens_and_make_checker_an_operator(checker, amnt):
-#             call_endpoint(tez_wrapper, "deposit", None, amount=amnt)
-#             update_operators = [
-#                 {
-#                     "add_operator": {
-#                         "owner": self.client.key.public_key_hash(),
-#                         "operator": checker.context.address,
-#                         "token_id": collateral_token_id,
-#                     }
-#                 },
-#             ]
-#             call_endpoint(tez_wrapper, "update_operators", update_operators)
-#
-#         # Note: the amount of kit minted here and the kit in all other burrows for this account
-#         # must be enough to bid on the liquidation auction later in the test.
-#         get_tez_tokens_and_make_checker_an_operator(checker, 200_000_000)
-#         call_endpoint(checker, "create_burrow", (0, None, 200_000_000))
-#         call_endpoint(checker, "mint_kit", (0, 80_000_000), amount=0)
-#
-#         call_endpoint(
-#             ctez["ctez"], "create", (1, None, {"any": None}), amount=2_000_000
-#         )
-#         call_endpoint(ctez["ctez"], "mint_or_burn", (1, 100_000))
-#         call_endpoint(ctez["fa12_ctez"], "approve", (checker.context.address, 100_000))
-#
-#         call_endpoint(
-#             checker,
-#             "add_liquidity",
-#             (100_000, 100_000, 5, int(datetime.now().timestamp()) + 20),
-#         )
-#
-#         burrows = list(range(1, 1001))
-#
-#         get_tez_tokens_and_make_checker_an_operator(
-#             checker, 100_000_000 * 1000
-#         )  # 1000 = number of burrows
-#         call_bulk(
-#             [
-#                 checker.create_burrow((burrow_id, None, 100_000_000))
-#                 for burrow_id in burrows
-#             ],
-#             batch_size=115,
-#         )
-#         # Mint as much as possible from the burrows. All should be identical, so we just query the
-#         # first burrow and mint that much kit from all of them.
-#         max_mintable_kit = checker.metadata.burrowMaxMintableKit(
-#             (self.client.key.public_key_hash(), 1)
-#         ).storage_view()
-#
-#         call_bulk(
-#             [checker.mint_kit(burrow_no, max_mintable_kit) for burrow_no in burrows],
-#             batch_size=350,
-#         )
-#
-#         # Change the index (kits are 10x valuable)
-#         #
-#         # Keep in mind that we're using a patched checker on tests where the protected index
-#         # is much faster to update.
-#         call_endpoint(oracle, "update", 10_000_000)
-#
-#         # Oracle updates lag one touch on checker
-#         call_endpoint(checker, "touch", None)
-#         call_endpoint(checker, "touch", None)
-#         time.sleep(20)
-#         call_endpoint(checker, "touch", None)
-#
-#         # Now burrows should be overburrowed, so we liquidate them all.
-#         #
-#         # This should use the push_back method of the AVL tree.
-#         call_bulk(
-#             [
-#                 checker.mark_for_liquidation(
-#                     (self.client.key.public_key_hash(), burrow_no)
-#                 )
-#                 for burrow_no in burrows
-#             ],
-#             batch_size=100,
-#             profiler=mark_for_liquidation_profiler,
-#         )
-#
-#         # This touch starts a liquidation auction
-#         #
-#         # This would use the split method of the AVL tree. However, if the entire queue
-#         # has less tez than the limit, the 'split' method would trivially return the entire
-#         # tree without much effort. Here we ensure that the liquidation queue has
-#         # more tez than the limit.
-#         queued_tez = 0
-#         for _, leaf in auction_avl_leaves(
-#             checker,
-#             checker.storage["deployment_state"]["sealed"]["liquidation_auctions"][
-#                 "queued_slices"
-#             ](),
-#         ):
-#             queued_tez += leaf["leaf"]["value"]["contents"]["tok"]
-#         assert (
-#             queued_tez > 10_000_000_000
-#         ), "queued tez in liquidation auction was not greater than Constants.max_lot_size which is required for this test"
-#         print(f"Auction queue currently has {queued_tez} mutez")
-#         call_endpoint(checker, "touch", None)
-#
-#         # Now that there is an auction started in a descending state, we can select a queued slice
-#         # and be confident that we can cancel it before it gets added to another auction.
-#         # To successfully do this, we also need to either move the index price such that the
-#         # cancellation is warranted or deposit extra collateral to the burrow. Here we do the latter.
-#         cancel_ops = []
-#         get_tez_tokens_and_make_checker_an_operator(
-#             checker, 1_000_000_000 * 895
-#         )  # the maximum amount of cancel_ops (see below)
-#         for i, (queued_leaf_ptr, leaf) in enumerate(
-#             auction_avl_leaves(
-#                 checker,
-#                 checker.storage["deployment_state"]["sealed"]["liquidation_auctions"][
-#                     "queued_slices"
-#                 ](),
-#             )
-#         ):
-#             cancel_ops.append(
-#                 (
-#                     checker.deposit_collateral(
-#                         (leaf["leaf"]["value"]["contents"]["burrow"][1], 1_000_000_000)
-#                     ),
-#                     checker.cancel_liquidation_slice(queued_leaf_ptr),
-#                 )
-#             )
-#             # Note: picking 895 here since it is close to the queue_size
-#             # at this point in the test. This number can be tweaked up
-#             # or down as desired.
-#             if len(cancel_ops) >= 895:
-#                 break
-#         # Shuffle so we aren't only cancelling the oldest slice
-#         shuffle(cancel_ops)
-#         flattened_cancel_ops = []
-#         for op1, op2 in cancel_ops:
-#             flattened_cancel_ops += [op1, op2]
-#         call_bulk(
-#             flattened_cancel_ops,
-#             batch_size=100,
-#             profiler=cancel_liquidation_slice_profiler,
-#         )
-#
-#         # And we place a bid for the auction we started earlier:
-#         auction_details = (
-#             checker.metadata.currentLiquidationAuctionDetails().storage_view()
-#         )
-#
-#         auction_id, minimum_bid = auction_details["contents"], auction_details["nat_3"]
-#         # FIXME: The return value is supposed to be annotated as "auction_id" and "minimum_bid", I
-#         # do not know why we get these names. I think there is an underlying pytezos bug
-#         # that we should reproduce and create a bug upstream.
-#
-#         # Note the auction ptr for later operations
-#         current_auctions_ptr = checker.storage["deployment_state"]["sealed"][
-#             "liquidation_auctions"
-#         ]["current_auction"]()["contents"]
-#         call_endpoint(
-#             checker, "liquidation_auction_place_bid", (auction_id, minimum_bid)
-#         )
-#
-#         # Once max(max_bid_interval_in_blocks, max_bid_interval_in_seconds) has elapsed, the liquidation auction we
-#         # bid on should be complete. Here we go off of level since the patched version of Checker we expect to use
-#         # sets max_bid_interval_in_blocks=1 and max_bid_interval_in_seconds=1.
-#         # Sleeping a bit extra to add a bit of a buffer.
-#         time.sleep(10)
-#
-#         call_endpoint(checker, "touch", None)
-#         assert (
-#             checker.storage["deployment_state"]["sealed"]["liquidation_auctions"][
-#                 "completed_auctions"
-#             ]()
-#             is not None
-#         )
-#
-#         # Before we can claim our winning bid, all of the slices in the completed auction must be touched
-#         auctioned_slices = []
-#         for leaf_ptr, leaf in auction_avl_leaves(checker, current_auctions_ptr):
-#             # Double check that we are only working with leaf ptrs
-#             assert "leaf" in leaf
-#             auctioned_slices.append(leaf_ptr)
-#
-#         # Note: using smaller batches here to increase the number of samples for profiling.
-#         for i in range(0, len(auctioned_slices), 5):
-#             slices_to_cancel = auctioned_slices[i : i + 5]
-#             call_endpoint(checker, "touch_liquidation_slices", slices_to_cancel)
-#
-#         # With all of the slices touched, we should now be able to claim our hard-earned winnings
-#         call_endpoint(checker, "liquidation_auction_claim_win", current_auctions_ptr)
-#
-#         # Extra calls for profiling purposes
-#         call_bulk(
-#             [checker.touch(None) for _ in range(5)],
-#             batch_size=2,
-#         )
-#
-#         # Optionally write out gas profile json
-#         if WRITE_GAS_PROFILES:
-#             with open(WRITE_GAS_PROFILES, "w") as f:
-#                 json.dump(self.gas_profiles, f, indent=4)
+class LiquidationsStressTest(SandboxedTestCase):
+    def test_liquidations(self):
+        collateral_token_id = self.config.tokens.collateral.token_id
+
+        print("Deploying the mock oracle.")
+        oracle = deploy_contract(
+            self.client,
+            source_file=os.path.join(PROJECT_ROOT, "util/mock_oracle.tz"),
+            initial_storage=(self.client.key.public_key_hash(), 1000000),
+            ttl=MAX_OPERATIONS_TTL,
+        )
+
+        print("Deploying the tez wrapper.")
+        tez_wrapper = deploy_tez_wrapper(
+            self.client,
+            checker_dir=CHECKER_DIR,
+            ttl=MAX_OPERATIONS_TTL,
+        )
+
+        print("Deploying ctez contract.")
+        ctez = deploy_ctez(
+            self.client,
+            ctez_dir=os.path.join(PROJECT_ROOT, "vendor/ctez"),
+            ttl=MAX_OPERATIONS_TTL,
+        )
+
+        print("Deploying wctez contract.")
+        wctez = deploy_wctez(
+            self.client,
+            checker_dir=CHECKER_DIR,
+            ctez_fa12_address=ctez["fa12_ctez"].context.address,
+            ttl=MAX_OPERATIONS_TTL,
+        )
+
+        print("Deploying Checker.")
+        checker = deploy_checker(
+            self.client,
+            checker_dir=CHECKER_DIR,
+            oracle=oracle.context.address,
+            tez_wrapper=tez_wrapper.context.address,
+            ctez_fa12=ctez["fa12_ctez"].context.address,
+            ctez_cfmm=ctez["cfmm"].context.address,
+            wctez=wctez.context.address,
+            ttl=MAX_OPERATIONS_TTL,
+        )
+
+        print("Deployment finished.")
+
+        def call_endpoint(
+            contract, name, param, amount=0, profiler=general_gas_profiler
+        ):
+            # Helper for calling contract endpoints with profiling
+            print("Calling", contract.key.public_key_hash(), "/", name, "with", param)
+            profile = profiler(
+                self.client,
+                contract,
+                [
+                    getattr(contract, name)(param)
+                    .with_amount(amount)
+                    .as_transaction()
+                    .autofill(ttl=MAX_OPERATIONS_TTL)
+                    .sign()
+                ],
+            )
+            self.gas_profiles = merge_gas_profiles(self.gas_profiles, profile)
+
+        def call_bulk(bulks, *, batch_size, profiler=general_gas_profiler):
+            # Helper for calling operations in batches
+            batches = [
+                bulks[i : i + batch_size] for i in range(0, len(bulks), batch_size)
+            ]
+            for batch_no, batch in enumerate(batches, 1):
+                print(
+                    "Sending",
+                    len(batches),
+                    "operations as bulk:",
+                    "Batch",
+                    batch_no,
+                    "of",
+                    len(batches),
+                )
+                profile = profiler(self.client, checker, batch)
+                self.gas_profiles = merge_gas_profiles(self.gas_profiles, profile)
+
+        def get_tez_tokens_and_make_checker_an_operator(checker, amnt):
+            call_endpoint(tez_wrapper, "deposit", None, amount=amnt)
+            update_operators = [
+                {
+                    "add_operator": {
+                        "owner": self.client.key.public_key_hash(),
+                        "operator": checker.context.address,
+                        "token_id": collateral_token_id,
+                    }
+                },
+            ]
+            call_endpoint(tez_wrapper, "update_operators", update_operators)
+
+        # Note: the amount of kit minted here and the kit in all other burrows for this account
+        # must be enough to bid on the liquidation auction later in the test.
+        get_tez_tokens_and_make_checker_an_operator(checker, 200_000_000)
+        call_endpoint(checker, "create_burrow", (0, None, 200_000_000))
+        call_endpoint(checker, "mint_kit", (0, 80_000_000), amount=0)
+
+        call_endpoint(
+            ctez["ctez"], "create", (1, None, {"any": None}), amount=2_000_000
+        )
+        call_endpoint(ctez["ctez"], "mint_or_burn", (1, 100_000))
+        call_endpoint(ctez["fa12_ctez"], "approve", (checker.context.address, 100_000))
+
+        call_endpoint(
+            checker,
+            "add_liquidity",
+            (100_000, 100_000, 5, int(datetime.now().timestamp()) + 20),
+        )
+
+        burrows = list(range(1, 1001))
+
+        get_tez_tokens_and_make_checker_an_operator(
+            checker, 100_000_000 * 1000
+        )  # 1000 = number of burrows
+        call_bulk(
+            [
+                checker.create_burrow((burrow_id, None, 100_000_000))
+                for burrow_id in burrows
+            ],
+            batch_size=115,
+        )
+        # Mint as much as possible from the burrows. All should be identical, so we just query the
+        # first burrow and mint that much kit from all of them.
+        max_mintable_kit = checker.metadata.burrowMaxMintableKit(
+            (self.client.key.public_key_hash(), 1)
+        ).storage_view()
+
+        call_bulk(
+            [checker.mint_kit(burrow_no, max_mintable_kit) for burrow_no in burrows],
+            batch_size=350,
+        )
+
+        # Change the index (kits are 10x valuable)
+        #
+        # Keep in mind that we're using a patched checker on tests where the protected index
+        # is much faster to update.
+        call_endpoint(oracle, "update", 10_000_000)
+
+        # Oracle updates lag one touch on checker
+        call_endpoint(checker, "touch", None)
+        call_endpoint(checker, "touch", None)
+        time.sleep(20)
+        call_endpoint(checker, "touch", None)
+
+        # Now burrows should be overburrowed, so we liquidate them all.
+        #
+        # This should use the push_back method of the AVL tree.
+        call_bulk(
+            [
+                checker.mark_for_liquidation(
+                    (self.client.key.public_key_hash(), burrow_no)
+                )
+                for burrow_no in burrows
+            ],
+            batch_size=100,
+            profiler=mark_for_liquidation_profiler,
+        )
+
+        # This touch starts a liquidation auction
+        #
+        # This would use the split method of the AVL tree. However, if the entire queue
+        # has less tez than the limit, the 'split' method would trivially return the entire
+        # tree without much effort. Here we ensure that the liquidation queue has
+        # more tez than the limit.
+        queued_tez = 0
+        for _, leaf in auction_avl_leaves(
+            checker,
+            checker.storage["deployment_state"]["sealed"]["liquidation_auctions"][
+                "queued_slices"
+            ](),
+        ):
+            queued_tez += leaf["leaf"]["value"]["contents"]["tok"]
+        assert (
+            queued_tez > 10_000_000_000
+        ), "queued tez in liquidation auction was not greater than Constants.max_lot_size which is required for this test"
+        print(f"Auction queue currently has {queued_tez} mutez")
+        call_endpoint(checker, "touch", None)
+
+        # Now that there is an auction started in a descending state, we can select a queued slice
+        # and be confident that we can cancel it before it gets added to another auction.
+        # To successfully do this, we also need to either move the index price such that the
+        # cancellation is warranted or deposit extra collateral to the burrow. Here we do the latter.
+        cancel_ops = []
+        get_tez_tokens_and_make_checker_an_operator(
+            checker, 1_000_000_000 * 895
+        )  # the maximum amount of cancel_ops (see below)
+        for i, (queued_leaf_ptr, leaf) in enumerate(
+            auction_avl_leaves(
+                checker,
+                checker.storage["deployment_state"]["sealed"]["liquidation_auctions"][
+                    "queued_slices"
+                ](),
+            )
+        ):
+            cancel_ops.append(
+                (
+                    checker.deposit_collateral(
+                        (leaf["leaf"]["value"]["contents"]["burrow"][1], 1_000_000_000)
+                    ),
+                    checker.cancel_liquidation_slice(queued_leaf_ptr),
+                )
+            )
+            # Note: picking 895 here since it is close to the queue_size
+            # at this point in the test. This number can be tweaked up
+            # or down as desired.
+            if len(cancel_ops) >= 895:
+                break
+        # Shuffle so we aren't only cancelling the oldest slice
+        shuffle(cancel_ops)
+        flattened_cancel_ops = []
+        for op1, op2 in cancel_ops:
+            flattened_cancel_ops += [op1, op2]
+        call_bulk(
+            flattened_cancel_ops,
+            batch_size=100,
+            profiler=cancel_liquidation_slice_profiler,
+        )
+
+        # And we place a bid for the auction we started earlier:
+        auction_details = (
+            checker.metadata.currentLiquidationAuctionDetails().storage_view()
+        )
+
+        auction_id, minimum_bid = auction_details["contents"], auction_details["nat_3"]
+        # FIXME: The return value is supposed to be annotated as "auction_id" and "minimum_bid", I
+        # do not know why we get these names. I think there is an underlying pytezos bug
+        # that we should reproduce and create a bug upstream.
+
+        # Note the auction ptr for later operations
+        current_auctions_ptr = checker.storage["deployment_state"]["sealed"][
+            "liquidation_auctions"
+        ]["current_auction"]()["contents"]
+        call_endpoint(
+            checker, "liquidation_auction_place_bid", (auction_id, minimum_bid)
+        )
+
+        # Once max(max_bid_interval_in_blocks, max_bid_interval_in_seconds) has elapsed, the liquidation auction we
+        # bid on should be complete. Here we go off of level since the patched version of Checker we expect to use
+        # sets max_bid_interval_in_blocks=1 and max_bid_interval_in_seconds=1.
+        # Sleeping a bit extra to add a bit of a buffer.
+        time.sleep(10)
+
+        call_endpoint(checker, "touch", None)
+        assert (
+            checker.storage["deployment_state"]["sealed"]["liquidation_auctions"][
+                "completed_auctions"
+            ]()
+            is not None
+        )
+
+        # Before we can claim our winning bid, all of the slices in the completed auction must be touched
+        auctioned_slices = []
+        for leaf_ptr, leaf in auction_avl_leaves(checker, current_auctions_ptr):
+            # Double check that we are only working with leaf ptrs
+            assert "leaf" in leaf
+            auctioned_slices.append(leaf_ptr)
+
+        # Note: using smaller batches here to increase the number of samples for profiling.
+        for i in range(0, len(auctioned_slices), 5):
+            slices_to_cancel = auctioned_slices[i : i + 5]
+            call_endpoint(checker, "touch_liquidation_slices", slices_to_cancel)
+
+        # With all of the slices touched, we should now be able to claim our hard-earned winnings
+        call_endpoint(checker, "liquidation_auction_claim_win", current_auctions_ptr)
+
+        # Extra calls for profiling purposes
+        call_bulk(
+            [checker.touch(None) for _ in range(5)],
+            batch_size=2,
+        )
+
+        # Optionally write out gas profile json
+        if WRITE_GAS_PROFILES:
+            with open(WRITE_GAS_PROFILES, "w") as f:
+                json.dump(self.gas_profiles, f, indent=4)
 
 
 if __name__ == "__main__":

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -5,7 +5,6 @@ open Tok
 open LiquidationAuctionTypes
 open LiquidationAuctionPrimitiveTypes
 open CheckerTypes
-open Fa12Interface
 open Fa2Interface
 
 (** Perform housekeeping tasks on the contract state. This includes:
@@ -31,7 +30,7 @@ val compute_outstanding_dissonance : checker -> kit (* "real" *) * kit (* approx
 (*****************************************************************************)
 
 (**/**)
-val get_transfer_ctok_fa12_entrypoint : external_contracts -> fa12_transfer Ligo.contract
+val get_transfer_ctok_fa2_entrypoint : external_contracts -> fa2_transfer list Ligo.contract
 val get_ctez_cfmm_price_entrypoint : external_contracts -> ((Ligo.nat * Ligo.nat) Ligo.contract) Ligo.contract
 val get_oracle_entrypoint : external_contracts -> (Ligo.nat Ligo.contract) Ligo.contract
 val get_transfer_collateral_fa2_entrypoint : external_contracts -> fa2_transfer list Ligo.contract

--- a/src/checkerMain.ml
+++ b/src/checkerMain.ml
@@ -70,18 +70,18 @@ let main (op, state: params * wrapper): LigoOp.operation list * wrapper =
                 | None -> Ligo.Big_map.add "m" bs metadata
                 | Some prev -> Ligo.Big_map.add "m" (Ligo.Bytes.concat prev bs) metadata in
               (([]: LigoOp.operation list), lazy_functions, metadata, Unsealed deployer)
-            | SealContract (oracle_addr, collateral_fa2_addr, ctok_fa12_addr, ctez_cfmm_addr) ->
+            | SealContract (oracle_addr, collateral_fa2_addr, ctok_fa2_addr, ctez_cfmm_addr) ->
               let external_contracts =
                 { oracle = oracle_addr;
                   collateral_fa2 = collateral_fa2_addr;
-                  ctok_fa12 = ctok_fa12_addr;
+                  ctok_fa2 = ctok_fa2_addr;
                   ctez_cfmm = ctez_cfmm_addr;
                 } in
 
               (* check if the given oracle, collateral_fa2, and ctez contracts have the entrypoints we need *)
               let _ = get_oracle_entrypoint external_contracts in
               let _ = get_transfer_collateral_fa2_entrypoint external_contracts in
-              let _ = get_transfer_ctok_fa12_entrypoint external_contracts in
+              let _ = get_transfer_ctok_fa2_entrypoint external_contracts in
               let _ = get_ctez_cfmm_price_entrypoint external_contracts in
 
               (* emit a touch operation to checker *)

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -13,7 +13,7 @@ type burrow_map = (burrow_id, burrow) Ligo.big_map
 type external_contracts = {
   oracle : Ligo.address;
   collateral_fa2 : Ligo.address;
-  ctok_fa12 : Ligo.address;
+  ctok_fa2 : Ligo.address;
   ctez_cfmm : Ligo.address;
 }
 

--- a/src/wctez.ml
+++ b/src/wctez.ml
@@ -15,7 +15,7 @@ type wctez_state =
   }
 
 (** Token id for wrapped ctez tokens. *)
-let[@inline] wctez_token_id : fa2_token_id = Ligo.nat_from_literal "0n"
+let[@inline] wctez_token_id : fa2_token_id = Ligo.nat_from_literal "3n"
 
 (*
 (** Number of decimal digits for wctez tokens, identical to that for ctez. *)

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -384,14 +384,14 @@ let suite =
        let expected_ops = [
          (LigoOp.Tezos.fa2_transfer_transaction
             [ Fa2Interface.{
-                from_ = alice_addr;
-                txs = [
-                  { to_ = checker_address;
-                    token_id = Ctok.ctok_token_id;
-                    amount = Ligo.nat_from_literal "5_000_000n";
-                  }
-                ]
-              }
+                  from_ = alice_addr;
+                  txs = [
+                    { to_ = checker_address;
+                      token_id = Ctok.ctok_token_id;
+                      amount = Ligo.nat_from_literal "5_000_000n";
+                    }
+                  ]
+                }
             ]
             (Ligo.tez_from_literal "0mutez")
             (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctok_fa2))
@@ -679,14 +679,14 @@ let suite =
        let expected_ops = [
          (LigoOp.Tezos.fa2_transfer_transaction
             [ Fa2Interface.{
-                from_ = checker_address;
-                txs = [
-                  { to_ = alice_addr;
-                    token_id = Ctok.ctok_token_id;
-                    amount = Ligo.nat_from_literal "5_000_000n";
-                  }
-                ]
-              }
+                  from_ = checker_address;
+                  txs = [
+                    { to_ = alice_addr;
+                      token_id = Ctok.ctok_token_id;
+                      amount = Ligo.nat_from_literal "5_000_000n";
+                    }
+                  ]
+                }
             ]
             (Ligo.tez_from_literal "0mutez")
             (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctok_fa2))
@@ -913,19 +913,19 @@ let suite =
 
       begin match ops with
         | [Transaction (FA2TransferTransactionValue transfer, _, _)] ->
-            assert_fa2_transfer_list_equal
-              ~expected:[
-                Fa2Interface.{
-                  from_ = sender;
-                  txs = [
-                    { to_ = checker_address;
-                      token_id = Ctok.ctok_token_id;
-                      amount = ctok_to_denomination_nat ctok_amount;
-                    }
-                  ]
-                }
-              ]
-              ~real:transfer
+          assert_fa2_transfer_list_equal
+            ~expected:[
+              Fa2Interface.{
+                from_ = sender;
+                txs = [
+                  { to_ = checker_address;
+                    token_id = Ctok.ctok_token_id;
+                    amount = ctok_to_denomination_nat ctok_amount;
+                  }
+                ]
+              }
+            ]
+            ~real:transfer
         | _ -> failwith ("Expected [Transaction (FA2TransferTransactionValue _, _, _)] but got " ^ show_operation_list ops)
       end;
 
@@ -958,19 +958,19 @@ let suite =
 
       begin match ops with
         | [Transaction (FA2TransferTransactionValue transfer, _, _)] ->
-            assert_fa2_transfer_list_equal
-              ~expected:[
-                Fa2Interface.{
-                  from_ = sender;
-                  txs = [
-                    { to_ = checker_address;
-                      token_id = Ctok.ctok_token_id;
-                      amount = ctok_to_denomination_nat ctok_amount;
-                    }
-                  ]
-                }
-              ]
-              ~real:transfer
+          assert_fa2_transfer_list_equal
+            ~expected:[
+              Fa2Interface.{
+                from_ = sender;
+                txs = [
+                  { to_ = checker_address;
+                    token_id = Ctok.ctok_token_id;
+                    amount = ctok_to_denomination_nat ctok_amount;
+                  }
+                ]
+              }
+            ]
+            ~real:transfer
         | _ -> failwith ("Expected [Transaction (FA2TransferTransactionValue _, _, _)] but got " ^ show_operation_list ops)
       end;
 
@@ -1133,19 +1133,19 @@ let suite =
 
       begin match ops with
         | [Transaction (FA2TransferTransactionValue transfer, _, _)] ->
-            assert_fa2_transfer_list_equal
-              ~expected:[
-                Fa2Interface.{
-                  from_ = sender;
-                  txs = [
-                    { to_ = checker_address;
-                      token_id = Ctok.ctok_token_id;
-                      amount = Ctok.ctok_to_denomination_nat ctok_provided;
-                    }
-                  ]
-                }
-              ]
-              ~real:transfer
+          assert_fa2_transfer_list_equal
+            ~expected:[
+              Fa2Interface.{
+                from_ = sender;
+                txs = [
+                  { to_ = checker_address;
+                    token_id = Ctok.ctok_token_id;
+                    amount = Ctok.ctok_to_denomination_nat ctok_provided;
+                  }
+                ]
+              }
+            ]
+            ~real:transfer
         | _ -> failwith ("Expected [Transaction (FA2TransferTransactionValue _, _, _)] but got " ^ show_operation_list ops)
       end;
 
@@ -1177,14 +1177,14 @@ let suite =
        let expected_ops = [
          (LigoOp.Tezos.fa2_transfer_transaction
             [ Fa2Interface.{
-                from_ = alice_addr;
-                txs = [
-                  { to_ = checker_address;
-                    token_id = Ctok.ctok_token_id;
-                    amount = Ligo.nat_from_literal "1_000_000n";
-                  }
-                ]
-              }
+                  from_ = alice_addr;
+                  txs = [
+                    { to_ = checker_address;
+                      token_id = Ctok.ctok_token_id;
+                      amount = Ligo.nat_from_literal "1_000_000n";
+                    }
+                  ]
+                }
             ]
             (Ligo.tez_from_literal "0mutez")
             (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctok_fa2))
@@ -1222,14 +1222,14 @@ let suite =
        let expected_ops = [
          (LigoOp.Tezos.fa2_transfer_transaction
             [ Fa2Interface.{
-                from_ = checker_address;
-                txs = [
-                  { to_ = alice_addr;
-                    token_id = Ctok.ctok_token_id;
-                    amount = Ligo.nat_from_literal "1n";
-                  }
-                ]
-              }
+                  from_ = checker_address;
+                  txs = [
+                    { to_ = alice_addr;
+                      token_id = Ctok.ctok_token_id;
+                      amount = Ligo.nat_from_literal "1n";
+                    }
+                  ]
+                }
             ]
             (Ligo.tez_from_literal "0mutez")
             (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctok_fa2))

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -23,7 +23,7 @@ let checker_address = !Ligo.Tezos.self_address
 
 let empty_checker =
   initial_checker
-    { ctok_fa12 = ctok_fa12_addr;
+    { ctok_fa2 = ctok_fa2_addr;
       ctez_cfmm = ctez_cfmm_addr;
       oracle = oracle_addr;
       collateral_fa2 = collateral_fa2_addr;
@@ -382,14 +382,19 @@ let suite =
            ) in
 
        let expected_ops = [
-         (LigoOp.Tezos.fa12_transfer_transaction
-            Fa12Interface.(
-              {address_to=checker_address;
-               address_from=alice_addr;
-               value=(Ligo.nat_from_literal "5_000_000n")}
-            )
+         (LigoOp.Tezos.fa2_transfer_transaction
+            [ Fa2Interface.{
+                from_ = alice_addr;
+                txs = [
+                  { to_ = checker_address;
+                    token_id = Ctok.ctok_token_id;
+                    amount = Ligo.nat_from_literal "5_000_000n";
+                  }
+                ]
+              }
+            ]
             (Ligo.tez_from_literal "0mutez")
-            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctok_fa12))
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctok_fa2))
          );
        ] in
        assert_operation_list_equal ~expected:expected_ops ~real:ops
@@ -672,14 +677,21 @@ let suite =
            ) in
 
        let expected_ops = [
-         (LigoOp.Tezos.fa12_transfer_transaction
-            Fa12Interface.(
-              {address_to=alice_addr;
-               address_from=checker_address;
-               value=(Ligo.nat_from_literal "5_000_000n")}
-            )
+         (LigoOp.Tezos.fa2_transfer_transaction
+            [ Fa2Interface.{
+                from_ = checker_address;
+                txs = [
+                  { to_ = alice_addr;
+                    token_id = Ctok.ctok_token_id;
+                    amount = Ligo.nat_from_literal "5_000_000n";
+                  }
+                ]
+              }
+            ]
             (Ligo.tez_from_literal "0mutez")
-            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctok_fa12))
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctok_fa2))
+
+
          );
        ] in
        assert_operation_list_equal ~expected:expected_ops ~real:ops
@@ -900,13 +912,21 @@ let suite =
       let senders_new_kit = Fa2Ledger.get_fa2_ledger_value checker.fa2_state.ledger (Kit.kit_token_id, sender) in (* after *)
 
       begin match ops with
-        | [Transaction (FA12TransferTransactionValue transfer, _, _)] ->
-          begin
-            assert_address_equal ~expected:sender ~real:transfer.address_from;
-            assert_address_equal ~expected:checker_address ~real:transfer.address_to;
-            assert_nat_equal ~expected:(ctok_to_denomination_nat ctok_amount) ~real:transfer.value;
-          end
-        | _ -> failwith ("Expected [Transaction (FA12TransferTransactionValue _, _, _)] but got " ^ show_operation_list ops)
+        | [Transaction (FA2TransferTransactionValue transfer, _, _)] ->
+            assert_fa2_transfer_list_equal
+              ~expected:[
+                Fa2Interface.{
+                  from_ = sender;
+                  txs = [
+                    { to_ = checker_address;
+                      token_id = Ctok.ctok_token_id;
+                      amount = ctok_to_denomination_nat ctok_amount;
+                    }
+                  ]
+                }
+              ]
+              ~real:transfer
+        | _ -> failwith ("Expected [Transaction (FA2TransferTransactionValue _, _, _)] but got " ^ show_operation_list ops)
       end;
 
       Ligo.geq_nat_nat
@@ -937,13 +957,21 @@ let suite =
       let senders_new_kit = Fa2Ledger.get_fa2_ledger_value checker.fa2_state.ledger (Kit.kit_token_id, sender) in (* after *)
 
       begin match ops with
-        | [Transaction (FA12TransferTransactionValue transfer, _, _)] ->
-          begin
-            assert_address_equal ~expected:sender ~real:transfer.address_from;
-            assert_address_equal ~expected:checker_address ~real:transfer.address_to;
-            assert_nat_equal ~expected:(ctok_to_denomination_nat ctok_amount) ~real:transfer.value;
-          end
-        | _ -> failwith ("Expected [Transaction (FA12TransferTransactionValue _, _, _)] but got " ^ show_operation_list ops)
+        | [Transaction (FA2TransferTransactionValue transfer, _, _)] ->
+            assert_fa2_transfer_list_equal
+              ~expected:[
+                Fa2Interface.{
+                  from_ = sender;
+                  txs = [
+                    { to_ = checker_address;
+                      token_id = Ctok.ctok_token_id;
+                      amount = ctok_to_denomination_nat ctok_amount;
+                    }
+                  ]
+                }
+              ]
+              ~real:transfer
+        | _ -> failwith ("Expected [Transaction (FA2TransferTransactionValue _, _, _)] but got " ^ show_operation_list ops)
       end;
 
       Ligo.eq_nat_nat
@@ -988,13 +1016,13 @@ let suite =
       Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:sender ~amount:(Ligo.tez_from_literal "0mutez");
       let ops, _ = Checker.entrypoint_sell_kit (checker, (kit_amount, min_ctok_expected, deadline)) in
       let bought_muctok = match ops with
-        | [Transaction (FA12TransferTransactionValue transfer, _, _)] ->
+        | [Transaction (FA2TransferTransactionValue [{from_=from_address; txs=[tx];}], _, _)] ->
           begin
-            assert_address_equal ~expected:checker_address ~real:transfer.address_from;
-            assert_address_equal ~expected:sender ~real:transfer.address_to;
-            transfer.value
+            assert_address_equal ~expected:checker_address ~real:from_address;
+            assert_address_equal ~expected:sender ~real:tx.to_;
+            tx.amount
           end
-        | _ -> failwith ("Expected [Transaction (FA12TransferTransactionValue _, _, _)] but got " ^ show_operation_list ops)
+        | _ -> failwith ("Expected [Transaction (FA2TransferTransactionValue [{from_=_; txs=[_];}], _, _)] but got " ^ show_operation_list ops)
       in
       ctok_of_denomination bought_muctok >= min_ctok_expected
     );
@@ -1046,13 +1074,13 @@ let suite =
       let ops, new_checker = Checker.entrypoint_sell_kit (checker, (kit_amount, min_ctok_expected, deadline)) in
 
       let bought_muctok = match ops with
-        | [Transaction (FA12TransferTransactionValue transfer, _, _)] ->
+        | [Transaction (FA2TransferTransactionValue [{from_=from_address; txs=[tx];}], _, _)] ->
           begin
-            assert_address_equal ~expected:checker_address ~real:transfer.address_from;
-            assert_address_equal ~expected:sender ~real:transfer.address_to;
-            transfer.value
+            assert_address_equal ~expected:checker_address ~real:from_address;
+            assert_address_equal ~expected:sender ~real:tx.to_;
+            tx.amount
           end
-        | _ -> failwith ("Expected [Transaction (FA12TransferTransactionValue _, _, _)] but got " ^ show_operation_list ops)
+        | _ -> failwith ("Expected [Transaction (FA2TransferTransactionValue [{from_=_; txs=[_];}], _, _)] but got " ^ show_operation_list ops)
       in
       ctok_add new_checker.cfmm.ctok (ctok_of_denomination bought_muctok) = checker.cfmm.ctok
     );
@@ -1104,13 +1132,21 @@ let suite =
       let ops, checker = Checker.entrypoint_buy_kit (checker, (ctok_provided, min_expected_kit, Ligo.timestamp_from_seconds_literal 1)) in
 
       begin match ops with
-        | [Transaction (FA12TransferTransactionValue transfer, _, _)] ->
-          begin
-            assert_address_equal ~expected:sender ~real:transfer.address_from;
-            assert_address_equal ~expected:checker_address ~real:transfer.address_to;
-            assert_nat_equal ~expected:(Ctok.ctok_to_denomination_nat ctok_provided) ~real:transfer.value;
-          end
-        | _ -> failwith ("Expected [Transaction (FA12TransferTransactionValue _, _, _)] but got " ^ show_operation_list ops)
+        | [Transaction (FA2TransferTransactionValue transfer, _, _)] ->
+            assert_fa2_transfer_list_equal
+              ~expected:[
+                Fa2Interface.{
+                  from_ = sender;
+                  txs = [
+                    { to_ = checker_address;
+                      token_id = Ctok.ctok_token_id;
+                      amount = Ctok.ctok_to_denomination_nat ctok_provided;
+                    }
+                  ]
+                }
+              ]
+              ~real:transfer
+        | _ -> failwith ("Expected [Transaction (FA2TransferTransactionValue _, _, _)] but got " ^ show_operation_list ops)
       end;
 
       let senders_new_kit = Fa2Ledger.get_fa2_ledger_value checker.fa2_state.ledger (Kit.kit_token_id, sender) in (* after *)
@@ -1139,14 +1175,19 @@ let suite =
        let kit = get_balance_of checker alice_addr kit_token_id in
 
        let expected_ops = [
-         (LigoOp.Tezos.fa12_transfer_transaction
-            Fa12Interface.(
-              {address_to=checker_address;
-               address_from=alice_addr;
-               value=(Ligo.nat_from_literal "1_000_000n")}
-            )
+         (LigoOp.Tezos.fa2_transfer_transaction
+            [ Fa2Interface.{
+                from_ = alice_addr;
+                txs = [
+                  { to_ = checker_address;
+                    token_id = Ctok.ctok_token_id;
+                    amount = Ligo.nat_from_literal "1_000_000n";
+                  }
+                ]
+              }
+            ]
             (Ligo.tez_from_literal "0mutez")
-            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctok_fa12))
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctok_fa2))
          );
        ] in
        assert_nat_equal ~expected:(Ligo.nat_from_literal "1n") ~real:kit;
@@ -1179,14 +1220,19 @@ let suite =
        let ops, _ = Checker.entrypoint_sell_kit (checker, (kit_to_sell, min_ctok_expected, Ligo.timestamp_from_seconds_literal 1)) in
 
        let expected_ops = [
-         (LigoOp.Tezos.fa12_transfer_transaction
-            Fa12Interface.(
-              {address_to=alice_addr;
-               address_from=checker_address;
-               value=(Ligo.nat_from_literal "1n")}
-            )
+         (LigoOp.Tezos.fa2_transfer_transaction
+            [ Fa2Interface.{
+                from_ = checker_address;
+                txs = [
+                  { to_ = alice_addr;
+                    token_id = Ctok.ctok_token_id;
+                    amount = Ligo.nat_from_literal "1n";
+                  }
+                ]
+              }
+            ]
             (Ligo.tez_from_literal "0mutez")
-            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctok_fa12))
+            (Option.get (LigoOp.Tezos.get_entrypoint_opt "%transfer" checker.external_contracts.ctok_fa2))
          );
        ] in
        assert_operation_list_equal ~expected:expected_ops ~real:ops
@@ -1222,12 +1268,13 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:sender ~amount:(Ligo.tez_from_literal "0mutez");
        let ops, checker = Checker.entrypoint_remove_liquidity (checker, (my_liquidity_tokens, min_ctok_expected, min_kit_expected, Ligo.timestamp_from_seconds_literal 1)) in
        let ctok = match ops with
-         | [ Transaction (FA12TransferTransactionValue transfer, _, _); ] ->
+         | [Transaction (FA2TransferTransactionValue [{from_=from_address; txs=[tx];}], _, _)] ->
            begin
-             assert_address_equal ~expected:checker_address ~real:transfer.address_from;
-             transfer.value
+             assert_address_equal ~expected:checker_address ~real:from_address;
+             assert_address_equal ~expected:sender ~real:tx.to_;
+             tx.amount
            end
-         | _ -> failwith ("Expected [Transaction (FA12TransferTransactionValue _, _, _); Transaction (KitTransactionValue _, _, _)] but got " ^ show_operation_list ops)
+         | _ -> failwith ("Expected [Transaction (FA2TransferTransactionValue [{from_=_; txs=[_];}], _, _)] but got " ^ show_operation_list ops)
        in
        let kit = get_balance_of checker sender kit_token_id in
 

--- a/tests/testCheckerEntrypoints.ml
+++ b/tests/testCheckerEntrypoints.ml
@@ -539,7 +539,7 @@ let suite =
     ("SealContract (main) - fails when unwanted tez is given - sealed state" >::
      assert_sealed_contract_fails_with_unwanted_tez
        (fun sealed_wrapper ->
-          let param = (oracle_addr, collateral_fa2_addr, ctok_fa12_addr, ctez_cfmm_addr) in
+          let param = (oracle_addr, collateral_fa2_addr, ctok_fa2_addr, ctez_cfmm_addr) in
           CheckerMain.(main (SealContract (param), sealed_wrapper))
        )
     );
@@ -755,7 +755,7 @@ let suite =
     ("SealContract (main) - fails when unwanted tez is given - unsealed state" >::
      assert_unsealed_contract_fails_with_unwanted_tez
        (fun unsealed_wrapper ->
-          let param = (oracle_addr, collateral_fa2_addr, ctok_fa12_addr, ctez_cfmm_addr) in
+          let param = (oracle_addr, collateral_fa2_addr, ctok_fa2_addr, ctez_cfmm_addr) in
           CheckerMain.(main (SealContract (param), unsealed_wrapper))
        )
     );

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -256,7 +256,7 @@ let suite =
        let wrapper = CheckerMain.initial_wrapper leena_addr in (* unsealed *)
 
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctok_fa12_addr, ctez_cfmm_addr) in
+       let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctok_fa2_addr, ctez_cfmm_addr) in
        assert_raises
          (Failure (Ligo.string_of_int error_UnauthorisedCaller))
          (fun () -> CheckerMain.main (op, wrapper))
@@ -602,7 +602,7 @@ let suite =
     ("SealContract - should fail if the contract is already sealed" >::
      with_sealed_wrapper
        (fun sealed_wrapper ->
-          let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctok_fa12_addr, ctez_cfmm_addr) in
+          let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctok_fa2_addr, ctez_cfmm_addr) in
           assert_raises
             (Failure (Ligo.string_of_int error_ContractAlreadyDeployed))
             (fun () -> CheckerMain.main (op, sealed_wrapper))

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -5,7 +5,7 @@ let bob_addr = Ligo.address_from_literal "bob_addr"
 let leena_addr = Ligo.address_from_literal "leena_addr"
 let charles_key_hash = Ligo.key_hash_from_literal "charles_key_hash"
 
-let ctok_fa12_addr = Ligo.address_of_string "ctok_fa12_addr"
+let ctok_fa2_addr = Ligo.address_of_string "ctok_fa2_addr"
 let ctez_cfmm_addr = Ligo.address_of_string "ctez_cfmm_addr"
 let oracle_addr = Ligo.address_of_string "oracle_addr"
 let collateral_fa2_addr = Ligo.address_of_string "collateral_fa2_addr"
@@ -34,6 +34,9 @@ let assert_ctok_equal ~expected ~real = OUnit2.assert_equal ~printer:Ctok.show_c
 let assert_parameters_equal ~expected ~real = OUnit2.assert_equal ~printer:Parameters.show_parameters expected real (* FIXME: contains a ratio *)
 let assert_liquidation_slice_contents_equal ~expected ~real = OUnit2.assert_equal ~printer:LiquidationAuctionPrimitiveTypes.show_liquidation_slice_contents expected real
 let assert_view_current_liquidation_auction_details_result_equal ~expected ~real = OUnit2.assert_equal ~printer:CheckerTypes.show_view_current_liquidation_auction_details_result expected real
+
+type fa2_transfer_list = Fa2Interface.fa2_transfer list [@@deriving show]
+let assert_fa2_transfer_list_equal ~expected ~real = OUnit2.assert_equal ~printer:show_fa2_transfer_list expected real
 
 type liquidation_auction_id_option = liquidation_auction_id option [@@deriving show]
 let assert_liquidation_auction_id_option_equal ~expected ~real = OUnit2.assert_equal ~printer:show_liquidation_auction_id_option expected real
@@ -82,7 +85,7 @@ let with_sealed_wrapper f =
   Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:checker_deployer ~amount:(Ligo.tez_from_literal "0mutez");
 
   let wrapper = CheckerMain.initial_wrapper checker_deployer in (* unsealed *)
-  let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctok_fa12_addr, ctez_cfmm_addr) in
+  let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctok_fa2_addr, ctez_cfmm_addr) in
   let _ops, wrapper = CheckerMain.main (op, wrapper) in (* sealed *)
   f wrapper
 


### PR DESCRIPTION
Fixes #279 by utilizing the FA2 ctez wrapper introduced in #286 as the de facto contract we use for the CFMM.