### PR TITLE
Cleaner sealing

### DIFF
--- a/client/checker_client/checker.py
+++ b/client/checker_client/checker.py
@@ -419,12 +419,17 @@ def deploy_checker(
             print("  deployed: chunk {}.".format(chunk_no))
 
     print("Sealing.")
+
+    external_contracts = {
+        "oracle": oracle,
+        "collateral_fa2": collateral_fa2,
+        "ctok_fa2": cfmm_token_fa2,
+        "ctez_cfmm": ctez_cfmm,
+    }
+
     inject(
         tz,
-        checker.sealContract((oracle, collateral_fa2, cfmm_token_fa2, ctez_cfmm))
-        .as_transaction()
-        .autofill(ttl=ttl)
-        .sign(),
+        checker.sealContract(external_contracts).as_transaction().autofill(ttl=ttl).sign(),
     )
 
     return checker

--- a/src/checkerMain.ml
+++ b/src/checkerMain.ml
@@ -19,7 +19,7 @@ type checker_params =
 type params =
   | DeployFunction of (lazy_function_id * Ligo.bytes)
   | DeployMetadata of Ligo.bytes
-  | SealContract of (Ligo.address * Ligo.address * Ligo.address * Ligo.address)
+  | SealContract of external_contracts
   | CheckerEntrypoint of checker_params
 
 (*
@@ -70,14 +70,7 @@ let main (op, state: params * wrapper): LigoOp.operation list * wrapper =
                 | None -> Ligo.Big_map.add "m" bs metadata
                 | Some prev -> Ligo.Big_map.add "m" (Ligo.Bytes.concat prev bs) metadata in
               (([]: LigoOp.operation list), lazy_functions, metadata, Unsealed deployer)
-            | SealContract (oracle_addr, collateral_fa2_addr, ctok_fa2_addr, ctez_cfmm_addr) ->
-              let external_contracts =
-                { oracle = oracle_addr;
-                  collateral_fa2 = collateral_fa2_addr;
-                  ctok_fa2 = ctok_fa2_addr;
-                  ctez_cfmm = ctez_cfmm_addr;
-                } in
-
+            | SealContract external_contracts ->
               (* check if the given oracle, collateral_fa2, and ctez contracts have the entrypoints we need *)
               let _ = get_oracle_entrypoint external_contracts in
               let _ = get_transfer_collateral_fa2_entrypoint external_contracts in

--- a/tests/testCheckerEntrypoints.ml
+++ b/tests/testCheckerEntrypoints.ml
@@ -539,7 +539,7 @@ let suite =
     ("SealContract (main) - fails when unwanted tez is given - sealed state" >::
      assert_sealed_contract_fails_with_unwanted_tez
        (fun sealed_wrapper ->
-          let param = (oracle_addr, collateral_fa2_addr, ctok_fa2_addr, ctez_cfmm_addr) in
+          let param = external_contracts in
           CheckerMain.(main (SealContract (param), sealed_wrapper))
        )
     );
@@ -755,7 +755,7 @@ let suite =
     ("SealContract (main) - fails when unwanted tez is given - unsealed state" >::
      assert_unsealed_contract_fails_with_unwanted_tez
        (fun unsealed_wrapper ->
-          let param = (oracle_addr, collateral_fa2_addr, ctok_fa2_addr, ctez_cfmm_addr) in
+          let param = external_contracts in
           CheckerMain.(main (SealContract (param), unsealed_wrapper))
        )
     );

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -256,7 +256,7 @@ let suite =
        let wrapper = CheckerMain.initial_wrapper leena_addr in (* unsealed *)
 
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctok_fa2_addr, ctez_cfmm_addr) in
+       let op = CheckerMain.SealContract (external_contracts) in
        assert_raises
          (Failure (Ligo.string_of_int error_UnauthorisedCaller))
          (fun () -> CheckerMain.main (op, wrapper))
@@ -602,7 +602,7 @@ let suite =
     ("SealContract - should fail if the contract is already sealed" >::
      with_sealed_wrapper
        (fun sealed_wrapper ->
-          let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctok_fa2_addr, ctez_cfmm_addr) in
+          let op = CheckerMain.SealContract (external_contracts) in
           assert_raises
             (Failure (Ligo.string_of_int error_ContractAlreadyDeployed))
             (fun () -> CheckerMain.main (op, sealed_wrapper))

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -11,11 +11,11 @@ let oracle_addr = Ligo.address_of_string "oracle_addr"
 let collateral_fa2_addr = Ligo.address_of_string "collateral_fa2_addr"
 
 let external_contracts = CheckerTypes.{
-  oracle = oracle_addr;
-  collateral_fa2 = collateral_fa2_addr;
-  ctok_fa2 = ctok_fa2_addr;
-  ctez_cfmm = ctez_cfmm_addr;
-}
+    oracle = oracle_addr;
+    collateral_fa2 = collateral_fa2_addr;
+    ctok_fa2 = ctok_fa2_addr;
+    ctez_cfmm = ctez_cfmm_addr;
+  }
 
 let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
 let assert_stdlib_int_equal ~expected ~real = OUnit2.assert_equal ~printer:string_of_int expected real

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -10,6 +10,13 @@ let ctez_cfmm_addr = Ligo.address_of_string "ctez_cfmm_addr"
 let oracle_addr = Ligo.address_of_string "oracle_addr"
 let collateral_fa2_addr = Ligo.address_of_string "collateral_fa2_addr"
 
+let external_contracts = CheckerTypes.{
+  oracle = oracle_addr;
+  collateral_fa2 = collateral_fa2_addr;
+  ctok_fa2 = ctok_fa2_addr;
+  ctez_cfmm = ctez_cfmm_addr;
+}
+
 let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
 let assert_stdlib_int_equal ~expected ~real = OUnit2.assert_equal ~printer:string_of_int expected real
 let assert_string_equal ~expected ~real = OUnit2.assert_equal ~printer:(fun x -> x) expected real
@@ -85,7 +92,7 @@ let with_sealed_wrapper f =
   Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:checker_deployer ~amount:(Ligo.tez_from_literal "0mutez");
 
   let wrapper = CheckerMain.initial_wrapper checker_deployer in (* unsealed *)
-  let op = CheckerMain.SealContract (oracle_addr, collateral_fa2_addr, ctok_fa2_addr, ctez_cfmm_addr) in
+  let op = CheckerMain.SealContract (external_contracts) in
   let _ops, wrapper = CheckerMain.main (op, wrapper) in (* sealed *)
   f wrapper
 


### PR DESCRIPTION
Tiny PR I've been meaning to open for a little while. When sealing the contract we can pass the external addresses as a record instead of an uninformative tuple of addresses `address * address * address * address`. This makes is harder to pass the addresses in the wrong order (which has happened to me in the past during development).