### PR TITLE
Store the index and protected index as fixedpoints

### DIFF
--- a/patches/e2e-tests-hack.patch
+++ b/patches/e2e-tests-hack.patch
@@ -13,14 +13,14 @@
  let[@inline] bid_improvement_factor : ratio = make_ratio (Ligo.int_from_literal "33") (Ligo.int_from_literal "10000")
 
 diff --git a/src/parameters.ml b/src/parameters.ml
-index e53b279..915f26a 100644
+index 62a31b8..44ee5c2 100644
 --- src/parameters.ml
 +++ src/parameters.ml
-@@ -224,6 +224,7 @@ let[@inline] compute_current_burrow_fee_index (last_burrow_fee_index: fixedpoint
- *)
- let[@inline] compute_current_protected_index (last_protected_index: Ligo.nat) (current_index: Ligo.nat) (duration_in_seconds: Ligo.int) : Ligo.nat =
-   assert (Ligo.gt_nat_nat last_protected_index (Ligo.nat_from_literal "0n"));
+@@ -158,6 +158,7 @@ let[@inline] compute_current_burrow_fee_index (last_burrow_fee_index: fixedpoint
+ let[@inline] compute_current_protected_index (last_protected_index: fixedpoint) (current_index: fixedpoint) (duration_in_seconds: Ligo.int) : fixedpoint =
+   assert (Ligo.gt_int_int (fixedpoint_to_raw last_protected_index) (fixedpoint_to_raw fixedpoint_zero));
+   assert (Ligo.gt_int_int (fixedpoint_to_raw current_index) (fixedpoint_to_raw fixedpoint_zero));
 +  let duration_in_seconds = Ligo.mul_int_int duration_in_seconds (Ligo.int_from_literal "1000") in
-   fraction_to_nat_floor
-     (clamp_int
-        (Ligo.mul_nat_int
+   fixedpoint_of_ratio_floor
+     (make_ratio
+        (clamp_int

--- a/src/checker.ml
+++ b/src/checker.ml
@@ -1,6 +1,7 @@
 open Ctok
 open Kit
 open Tok
+open FixedPoint
 open Lqt
 open Avl
 open Parameters
@@ -784,7 +785,7 @@ let rec touch_oldest
  * exceptions (1. setting the delegate, and 2. call/callback to the oract), all
  * of the operations are outwards calls, to other contracts (no callbacks). It
  * should be safe to leave the order of the transaction reversed. *)
-let[@inline] touch_with_index (state: checker) (index: Ligo.nat) : (LigoOp.operation list * checker) =
+let[@inline] touch_with_index (state: checker) (index: fixedpoint) : (LigoOp.operation list * checker) =
   assert_checker_invariants state;
   let
     { burrows = state_burrows;
@@ -871,11 +872,12 @@ let entrypoint_touch (state, _: checker * unit) : (LigoOp.operation list * check
 (**                               ORACLE                                     *)
 (* ************************************************************************* *)
 
-let entrypoint_receive_price (state, price: checker * Ligo.nat) : (LigoOp.operation list * checker) =
+let entrypoint_receive_price (state, idx: checker * Ligo.nat) : (LigoOp.operation list * checker) =
   assert_checker_invariants state;
   if !Ligo.Tezos.sender <> state.external_contracts.oracle then
     (Ligo.failwith error_UnauthorisedCaller : LigoOp.operation list * checker)
   else
+    let price = fixedpoint_of_ratio_floor (make_ratio (Ligo.int idx) tok_scaling_factor_int) in
     (([]: LigoOp.operation list), {state with last_index = Some price})
 
 let entrypoint_receive_ctez_marginal_price (state, price: checker * (Ligo.nat * Ligo.nat)) : (LigoOp.operation list * checker) =

--- a/src/checker.mli
+++ b/src/checker.mli
@@ -2,6 +2,7 @@ open Ctok
 open Kit
 open Lqt
 open Tok
+open FixedPoint
 open LiquidationAuctionTypes
 open LiquidationAuctionPrimitiveTypes
 open CheckerTypes
@@ -19,7 +20,7 @@ val entrypoint_touch : checker * unit -> (LigoOp.operation list * checker)
 (**/**)
 (* ONLY EXPOSED FOR TESTING REASONS. *)
 val assert_checker_invariants : checker -> unit
-val touch_with_index : checker -> Ligo.nat -> (LigoOp.operation list * checker)
+val touch_with_index : checker -> fixedpoint -> (LigoOp.operation list * checker)
 val calculate_touch_reward : Ligo.timestamp -> kit
 val find_burrow : burrow_map -> burrow_id -> Burrow.burrow
 val compute_outstanding_dissonance : checker -> kit (* "real" *) * kit (* approximation *)

--- a/src/checkerTypes.ml
+++ b/src/checkerTypes.ml
@@ -1,5 +1,6 @@
 open Kit
 open Tok
+open FixedPoint
 open Burrow
 open CfmmTypes
 open Parameters
@@ -24,7 +25,7 @@ type checker =
     cfmm : cfmm;
     parameters : parameters;
     liquidation_auctions : liquidation_auctions;
-    last_index : Ligo.nat option;
+    last_index : fixedpoint option;
     last_ctez_in_tez : ratio option;
     fa2_state : fa2_state;
     external_contracts : external_contracts;
@@ -36,7 +37,7 @@ let initial_checker (external_contracts: external_contracts) =
     cfmm = initial_cfmm ();
     parameters = initial_parameters;
     liquidation_auctions = liquidation_auction_empty;
-    last_index = (None : Ligo.nat option);
+    last_index = (None : fixedpoint option);
     last_ctez_in_tez = (None : ratio option);
     fa2_state = initial_fa2_state;
     external_contracts = external_contracts;

--- a/src/fixedPoint.ml
+++ b/src/fixedPoint.ml
@@ -20,6 +20,9 @@ let fixedpoint_pow (x: fixedpoint) (y: Ligo.nat) =
       (pow_int_nat x y)
       (pow_int_nat fixedpoint_scaling_factor (Ligo.abs (Ligo.sub_nat_nat y (Ligo.nat_from_literal "1n"))))
 
+let[@inline] fixedpoint_min (x: fixedpoint) (y: fixedpoint) = min_int x y
+let[@inline] fixedpoint_max (x: fixedpoint) (y: fixedpoint) = max_int x y
+
 (* Conversions to/from other types. *)
 let fixedpoint_of_ratio_ceil  (amnt: ratio) = cdiv_int_int (Ligo.mul_int_int amnt.num fixedpoint_scaling_factor) amnt.den
 let fixedpoint_of_ratio_floor (amnt: ratio) = fdiv_int_int (Ligo.mul_int_int amnt.num fixedpoint_scaling_factor) amnt.den

--- a/src/fixedPoint.mli
+++ b/src/fixedPoint.mli
@@ -12,6 +12,9 @@ val fixedpoint_add : fixedpoint -> fixedpoint -> fixedpoint
 val fixedpoint_sub : fixedpoint -> fixedpoint -> fixedpoint
 val fixedpoint_pow : fixedpoint -> Ligo.nat -> fixedpoint
 
+val fixedpoint_min : fixedpoint -> fixedpoint -> fixedpoint
+val fixedpoint_max : fixedpoint -> fixedpoint -> fixedpoint
+
 (* Conversions to/from other types. *)
 val fixedpoint_of_ratio_ceil : ratio -> fixedpoint
 val fixedpoint_of_ratio_floor : ratio -> fixedpoint

--- a/tests/testBurrow.ml
+++ b/tests/testBurrow.ml
@@ -685,7 +685,7 @@ let suite =
         *  potentially obscured by rounding. This high of a difference between the
         *  index and protected index is unlikely to occur in real-world scenarios.
        *)
-       let parameters = Parameters.({initial_parameters with index=(Ligo.nat_from_literal "100_000_000_000n");}) in
+       let parameters = Parameters.({initial_parameters with index=index_from_chf_in_tok (Ligo.nat_from_literal "100_000_000_000n");}) in
        assert_int_equal
          ~expected:(Ligo.int_from_literal "707856")
          ~real:(Burrow.compute_collateral_to_auction parameters burrow)

--- a/tests/testChecker.ml
+++ b/tests/testChecker.ml
@@ -90,7 +90,7 @@ let checker_with_liquidatable_burrows () =
    * for the burrows to be liquidatable.
   *)
   Ligo.Tezos.new_transaction ~seconds_passed:10_000_000 ~blocks_passed:100_000 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
-  let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_100_000n") in
+  let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_100_000n")) in
   (* Touch burrows *)
   Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
   let _, checker = Checker.entrypoint_touch_burrow (checker, (alice_addr, alice_burrow_1)) in
@@ -206,7 +206,7 @@ let suite =
      fun _ ->
        Ligo.Tezos.reset ();
        let checker1 = empty_checker in
-       let ops, checker2 = Checker.touch_with_index checker1 (Ligo.nat_from_literal "0n") in
+       let ops, checker2 = Checker.touch_with_index checker1 (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "0n")) in
 
        assert_operation_list_equal ~expected:[] ~real:ops;
        assert_equal checker1 checker2; (* NOTE: we really want them to be identical here, hence the '='. *)
@@ -1421,7 +1421,7 @@ let suite =
     ("entrypoint_liquidation_auction_place_bid: should only allow the current auction" >::
      fun _ ->
        Ligo.Tezos.reset ();
-       let checker = { empty_checker with last_index = Some (Ligo.nat_from_literal "1_000_000n") } in
+       let checker = { empty_checker with last_index = Some (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n")) } in
 
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _, checker = Checker.entrypoint_touch (checker, ()) in
@@ -1432,7 +1432,7 @@ let suite =
 
        Ligo.Tezos.new_transaction ~seconds_passed:10 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", max_kit)) in
-       let checker = { checker with last_index = Some (Ligo.nat_from_literal "10_000_000n") } in
+       let checker = { checker with last_index = Some (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "10_000_000n")) } in
        let _, checker = Checker.entrypoint_touch (checker, ()) in
 
        Ligo.Tezos.new_transaction ~seconds_passed:1_000_000 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
@@ -1571,7 +1571,7 @@ let suite =
           	* take more time I guess). *)
        Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
-       let _ops, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_001n") in
+       let _ops, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_001n")) in
 
        let ops, checker = Checker.entrypoint_touch_burrow (checker, burrow_id) in
        assert_operation_list_equal ~expected:[] ~real:ops;
@@ -1587,7 +1587,7 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:(211*60) ~blocks_passed:211 ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
        let kit_before_reward = get_balance_of checker bob_addr TokenMetadata.kit_token_id in
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_200_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_200_000n")) in
        let kit_after_reward = get_balance_of checker bob_addr TokenMetadata.kit_token_id in
 
        let touch_reward = Ligo.sub_nat_nat kit_after_reward kit_before_reward in
@@ -1638,7 +1638,7 @@ let suite =
          (fun () -> Checker.view_current_liquidation_auction_details ((), checker));
 
        let kit_before_reward = get_balance_of checker bob_addr TokenMetadata.kit_token_id in
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_200_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_200_000n")) in
        let kit_after_reward = get_balance_of checker bob_addr TokenMetadata.kit_token_id in
 
        let touch_reward = Ligo.sub_nat_nat kit_after_reward kit_before_reward in
@@ -1653,7 +1653,7 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:(5*60) ~blocks_passed:5 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
        let kit_before_reward = get_balance_of checker alice_addr TokenMetadata.kit_token_id in
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_200_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_200_000n")) in
        let kit_after_reward = get_balance_of checker alice_addr TokenMetadata.kit_token_id in
 
        let touch_reward = Ligo.sub_nat_nat kit_after_reward kit_before_reward in
@@ -1662,7 +1662,7 @@ let suite =
        let auction_id =
          min_bid.auction_id in
        assert_kit_equal
-         ~expected:(kit_of_denomination (Ligo.nat_from_literal "2_709_185n"))
+         ~expected:(kit_of_denomination (Ligo.nat_from_literal "2_709_183n"))
          ~real:min_bid.minimum_bid;
 
        (* Bid the minimum first *)
@@ -1691,7 +1691,7 @@ let suite =
        Ligo.Tezos.new_transaction ~seconds_passed:(30*60) ~blocks_passed:30 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
        let kit_before_reward = get_balance_of checker alice_addr TokenMetadata.kit_token_id in
-       let _ops, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_200_000n") in
+       let _ops, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_200_000n")) in
        let kit_after_reward = get_balance_of checker alice_addr TokenMetadata.kit_token_id in
 
        let touch_reward = Ligo.sub_nat_nat kit_after_reward kit_before_reward in
@@ -1790,7 +1790,7 @@ let suite =
           	* fees alone if the index remains the same. *)
        let blocks_passed = 211 in (* NOTE: I am a little surprised/worried about this being again 211... *)
        Ligo.Tezos.new_transaction ~seconds_passed:(60*blocks_passed) ~blocks_passed:blocks_passed ~sender:bob_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _ops, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_105_283n") in (* sup *)
+       let _ops, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_105_283n")) in (* sup *)
        let _ops, checker = Checker.entrypoint_touch_burrow (checker, burrow_id) in
 
        (* Ensure that the burrow is liquidatable. *)
@@ -1821,7 +1821,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_create_burrow (empty_checker, (Ligo.nat_from_literal "0n", None, amount)) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n")) in
        (* Try to deposit some tez to the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:Common.tez_zero;
        let _ = Checker.entrypoint_deposit_collateral (checker, (Ligo.nat_from_literal "0n", amount)) in
@@ -1837,7 +1837,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_create_burrow (empty_checker, (Ligo.nat_from_literal "0n", None, amount)) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n")) in
        (* Try to withdraw some tez from the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:Common.tez_zero;
        let _ = Checker.entrypoint_withdraw_collateral (checker, (Ligo.nat_from_literal "0n", Constants.creation_deposit)) in
@@ -1853,7 +1853,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_create_burrow (empty_checker, (Ligo.nat_from_literal "0n", None, amount)) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n")) in
        (* Try to mint some kit out of the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", kit_of_denomination (Ligo.nat_from_literal "1n"))) in
@@ -1872,7 +1872,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_mint_kit (checker, (Ligo.nat_from_literal "0n", kit_of_denomination (Ligo.nat_from_literal "1n"))) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n")) in
        (* Try to burn some kit into the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.entrypoint_burn_kit (checker, (Ligo.nat_from_literal "0n", kit_of_denomination (Ligo.nat_from_literal "1n"))) in
@@ -1891,7 +1891,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_deactivate_burrow (checker, (Ligo.nat_from_literal "0n", !Ligo.Tezos.sender)) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n")) in
        (* Try to activate the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:Common.tez_zero;
        let _ = Checker.entrypoint_activate_burrow (checker, (Ligo.nat_from_literal "0n", amount)) in
@@ -1907,7 +1907,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_create_burrow (empty_checker, (Ligo.nat_from_literal "0n", None, amount)) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n")) in
        (* Try to deactivate the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.entrypoint_deactivate_burrow (checker, (Ligo.nat_from_literal "0n", !Ligo.Tezos.sender)) in
@@ -1924,7 +1924,7 @@ let suite =
        let burrow_id = (!Ligo.Tezos.sender, Ligo.nat_from_literal "0n") in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n")) in
        (* Try to mark the untouched burrow for liquidation *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        (* TODO: Would be nice to create the conditions for entrypoint_mark_for_liquidation
@@ -1946,7 +1946,7 @@ let suite =
        let _ops, checker = Checker.entrypoint_create_burrow (empty_checker, (Ligo.nat_from_literal "0n", None, amount)) in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n")) in
        (* Try to set the delegate of the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.entrypoint_set_burrow_delegate (checker, (Ligo.nat_from_literal "0n", None)) in
@@ -2102,7 +2102,7 @@ let suite =
        let burrow_id = (!Ligo.Tezos.sender, Ligo.nat_from_literal "0n") in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n")) in
        (* Try to view the max mintable kit from the untouched burrow *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.view_burrow_max_mintable_kit (burrow_id, checker) in
@@ -2119,7 +2119,7 @@ let suite =
        let burrow_id = (!Ligo.Tezos.sender, Ligo.nat_from_literal "0n") in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n")) in
        (* Try to view whether the untouched burrow is overburrowed *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.view_is_burrow_overburrowed (burrow_id, checker) in
@@ -2136,7 +2136,7 @@ let suite =
        let burrow_id = (!Ligo.Tezos.sender, Ligo.nat_from_literal "0n") in
        (* Touch checker *)
        Ligo.Tezos.new_transaction ~seconds_passed:1 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
-       let _, checker = Checker.touch_with_index checker (Ligo.nat_from_literal "1_000_000n") in
+       let _, checker = Checker.touch_with_index checker (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n")) in
        (* Try to view whether the untouched burrow is liquidatable *)
        Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
        let _ = Checker.view_is_burrow_liquidatable (burrow_id, checker) in

--- a/tests/testCheckerMain.ml
+++ b/tests/testCheckerMain.ml
@@ -379,7 +379,7 @@ let suite =
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
           (* setup: increase the index significantly (emulate the effects of Receive_price) *)
-          let sealed_wrapper = set_last_index_in_wrapper sealed_wrapper (Some (Ligo.nat_from_literal "100_000_000n")) in
+          let sealed_wrapper = set_last_index_in_wrapper sealed_wrapper (Some (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "100_000_000n"))) in
 
           (* setup: let enough time pass so that the burrow becomes liquidatable *)
           let blocks_passed = 191 in
@@ -432,7 +432,8 @@ let suite =
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
           (* setup: increase the index significantly (emulate the effects of Receive_price) *)
-          let sealed_wrapper = set_last_index_in_wrapper sealed_wrapper (Some (Ligo.nat_from_literal "1_357_906n")) in (* lowest value I could get, assuming the rest of the setting. *)
+          (* lowest value I could get, assuming the rest of the setting. *)
+          let sealed_wrapper = set_last_index_in_wrapper sealed_wrapper (Some (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_357_906n"))) in
 
           (* setup: let enough time pass so that the burrow becomes liquidatable *)
           let blocks_passed = 191 in
@@ -487,7 +488,8 @@ let suite =
           let _ops, sealed_wrapper = CheckerMain.main (op, sealed_wrapper) in
 
           (* setup: increase the index significantly (emulate the effects of Receive_price) *)
-          let sealed_wrapper = set_last_index_in_wrapper sealed_wrapper (Some (Ligo.nat_from_literal "1_357_906n")) in (* lowest value I could get, assuming the rest of the setting. *)
+          (* lowest value I could get, assuming the rest of the setting. *)
+          let sealed_wrapper = set_last_index_in_wrapper sealed_wrapper (Some (TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_357_906n"))) in
 
           (* setup: let enough time pass so that the burrow becomes liquidatable *)
           let blocks_passed = 191 in

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -1,6 +1,5 @@
 open LiquidationAuctionPrimitiveTypes
 
-(* FIXME: Temporary patch *)
 let index_from_chf_in_tok (n: Ligo.nat) =
   FixedPoint.fixedpoint_of_ratio_floor
     (Common.make_ratio (Ligo.int n) Tok.tok_scaling_factor_int)

--- a/tests/testLib.ml
+++ b/tests/testLib.ml
@@ -1,5 +1,10 @@
 open LiquidationAuctionPrimitiveTypes
 
+(* FIXME: Temporary patch *)
+let index_from_chf_in_tok (n: Ligo.nat) =
+  FixedPoint.fixedpoint_of_ratio_floor
+    (Common.make_ratio (Ligo.int n) Tok.tok_scaling_factor_int)
+
 let alice_addr = Ligo.address_from_literal "alice_addr"
 let bob_addr = Ligo.address_from_literal "bob_addr"
 let leena_addr = Ligo.address_from_literal "leena_addr"

--- a/tests/testLiquidation.ml
+++ b/tests/testLiquidation.ml
@@ -77,8 +77,8 @@ Other properties
 
 let params : parameters =
   { q = fixedpoint_of_ratio_floor (Common.make_ratio (Ligo.int_from_literal "1015") (Ligo.int_from_literal "1000"));
-    index = Ligo.nat_from_literal "320_000n";
-    protected_index = Ligo.nat_from_literal "360_000n";
+    index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "320_000n");
+    protected_index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "360_000n");
     target = fixedpoint_of_ratio_floor (Common.make_ratio (Ligo.int_from_literal "108") (Ligo.int_from_literal "100"));
     drift = fixedpoint_zero;
     drift_derivative = fixedpoint_zero;
@@ -383,9 +383,9 @@ let barely_liquidatable_test =
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.collateral_to_auction);
 
-    let expected_expected_kit =
-      Common.{ num = Ligo.int_from_literal "467912067393300348926951424";
-               den = Ligo.int_from_literal "67404402845334701604000000";
+    let expected_expected_kit = (* ~ 6 *)
+      Common.{ num = Ligo.int_from_literal "8631454156204547535041890260785392200852701184";
+               den = Ligo.int_from_literal "1243391768729109145336934644891400510900000000";
              } in
     let expected_kit = compute_expected_kit params details.collateral_to_auction in
 
@@ -445,9 +445,9 @@ let barely_non_complete_liquidatable_test =
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.collateral_to_auction);
 
-    let expected_expected_kit =
-      Common.{ num = Ligo.int_from_literal "67404402845334701604864";
-               den = Ligo.int_from_literal "6740440284533470160400";
+    let expected_expected_kit = (* ~ 10 *)
+      Common.{ num = Ligo.int_from_literal "12433917687291091454951708155556810446602240000";
+               den = Ligo.int_from_literal "1243391768729109145336934644891400510900000000";
              } in
     let expected_kit = compute_expected_kit params details.collateral_to_auction in
 
@@ -505,9 +505,9 @@ let barely_complete_liquidatable_test =
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.collateral_to_auction);
 
-    let expected_expected_kit =
-      Common.{ num = Ligo.int_from_literal "674043862432650352662675456";
-               den = Ligo.int_from_literal "67404402845334701604000000";
+    let expected_expected_kit = (* ~ 9 *)
+      Common.{ num = Ligo.int_from_literal "12433914624749789166505536985185343560688336896";
+               den = Ligo.int_from_literal "1243391768729109145336934644891400510900000000";
              } in
     let expected_kit = compute_expected_kit params details.collateral_to_auction in
 
@@ -622,9 +622,9 @@ let barely_close_liquidatable_test =
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.collateral_to_auction);
 
-    let expected_expected_kit =
-      Common.{ num = Ligo.int_from_literal "166020530642689301158035456";
-               den = Ligo.int_from_literal "67404402845334701604000000";
+    let expected_expected_kit = (* ~ 2 *)
+      Common.{ num = Ligo.int_from_literal "3062538239747143882724200296514447017190096896";
+               den = Ligo.int_from_literal "1243391768729109145336934644891400510900000000";
              } in
     let expected_kit = compute_expected_kit params details.collateral_to_auction in
 
@@ -690,9 +690,9 @@ let partial_liquidation_unit_test =
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.collateral_to_auction);
 
-    let expected_expected_kit =
-      Common.{ num = Ligo.int_from_literal "1185798177338727676948512768";
-               den = Ligo.int_from_literal "67404402845334701604000000";
+    let expected_expected_kit = (* ~ 17 *)
+      Common.{ num = Ligo.int_from_literal "21874115500438762701091585431831567247331033088";
+               den = Ligo.int_from_literal "1243391768729109145336934644891400510900000000";
              } in
     let expected_kit = compute_expected_kit params details.collateral_to_auction in
 
@@ -748,9 +748,9 @@ let complete_liquidation_unit_test =
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.collateral_to_auction);
 
-    let expected_expected_kit =
-      Common.{ num = Ligo.int_from_literal "149252606300383982125056";
-               den = Ligo.int_from_literal "6740440284533470160400";
+    let expected_expected_kit = (* ~ 22 *)
+      Common.{ num = Ligo.int_from_literal "27532246307573131078821639487304365988904960000";
+               den = Ligo.int_from_literal "1243391768729109145336934644891400510900000000";
              } in
     let expected_kit = compute_expected_kit params details.collateral_to_auction in
 
@@ -808,9 +808,9 @@ let complete_and_close_liquidation_test =
       ~expected:(Some expected_min_kit_for_unwarranted)
       ~real:(compute_min_kit_for_unwarranted params burrow details.collateral_to_auction);
 
-    let expected_expected_kit =
-      Common.{ num = Ligo.int_from_literal "165854675966722578579456";
-               den = Ligo.int_from_literal "67404402845334701604000";
+    let expected_expected_kit = (* ~ 2 *)
+      Common.{ num = Ligo.int_from_literal "3059478760986157724999201095419027989200896000";
+               den = Ligo.int_from_literal "1243391768729109145336934644891400510900000000";
              } in
     let expected_kit = compute_expected_kit params details.collateral_to_auction in
 

--- a/tests/testParameters.ml
+++ b/tests/testParameters.ml
@@ -10,7 +10,7 @@ let property_test_count = 100
 let qcheck_to_ounit t = OUnit.ounit2_of_ounit1 @@ QCheck_ounit.to_ounit_test t
 
 let rec call_touch_times
-    (index: Ligo.nat)
+    (index: fixedpoint)
     (kit_in_tok: Common.ratio)
     (n: int)
     (params: parameters)
@@ -300,7 +300,8 @@ let test_protected_index_follows_index =
     ~name:"test_protected_index_follows_index"
     ~count:property_test_count
     (QCheck.pair TestArbitrary.arb_small_positive_nat QCheck.small_nat)
-  @@ fun (index, lvl) ->
+  @@ fun (chf_in_tok, lvl) ->
+  let index = TestLib.index_from_chf_in_tok chf_in_tok in
   Ligo.Tezos.reset();
 
   (* let time pass, please *)
@@ -327,37 +328,52 @@ let test_protected_index_pace =
     let kit_in_tok = Common.one_ratio in
 
     (* UPWARD MOVES *)
-    let very_high_index = Ligo.abs (Ligo.mul_int_int (Ligo.int_from_literal "1000") (Ligo.int params.index)) in
+    let very_high_index =
+      fixedpoint_of_ratio_floor
+        (Common.make_ratio
+           (Ligo.mul_int_int (Ligo.int_from_literal "1000") (fixedpoint_to_raw params.index))
+           fixedpoint_scaling_factor
+        ) in
     (* One hour, upward move, touched in every block *)
     (* Initial : 1.000000 *)
-    (* Final   : 1.030420 (=103.0420% of initial; slightly over 3%) *)
+    (* Final   : 1.030447 (=103.0447% of initial; slightly over 3%) *)
     Ligo.Tezos.reset();
     let new_params = call_touch_times very_high_index kit_in_tok (60 (* 60 blocks ~ 1h *)) params in
-    assert_nat_equal ~expected:(Ligo.nat_from_literal "1_030_420n") ~real:new_params.protected_index;
+    assert_fixedpoint_equal
+      ~expected:(fixedpoint_of_raw (Ligo.int_from_literal "19008388551488940890")) (* between 1_030_446n and 1_030_447n *)
+      ~real:new_params.protected_index;
     (* One day, upward move, touched in every block *)
     (* Initial : 1.000000 *)
-    (* Final   : 2.053031 (=205.3031% of initial; slightly over double) *)
+    (* Final   : 2.054063 (=205.4063% of initial; slightly over double) *)
     Ligo.Tezos.reset();
     let new_params = call_touch_times very_high_index kit_in_tok (60 * 24 (* 60 blocks ~ 1h *)) params in
-    assert_nat_equal ~expected:(Ligo.nat_from_literal "2_053_031n") ~real:new_params.protected_index;
+    assert_fixedpoint_equal
+      ~expected:(fixedpoint_of_raw (Ligo.int_from_literal "37890784971118804878")) (* between 2_054_063n and 2_054_064n *)
+      ~real:new_params.protected_index;
 
     (* DOWNWARD MOVES *)
     let very_low_index =
-      Common.fraction_to_nat_floor
-        (Ligo.int params.index)
-        (Ligo.int_from_literal "1_000") in
+      fixedpoint_of_ratio_floor
+        (Common.make_ratio
+           (fixedpoint_to_raw params.index)
+           (Ligo.mul_int_int (Ligo.int_from_literal "1000") fixedpoint_scaling_factor)
+        ) in
     (* One hour, downward move, touched in every block *)
     (* Initial : 1.000000 *)
-    (* Final   : 0.970407 (=2.9593% less than initial; slightly under 3% *)
+    (* Final   : 0.970438 (=2.9562% less than initial; slightly under 3% *)
     Ligo.Tezos.reset();
     let new_params = call_touch_times very_low_index kit_in_tok (60 (* 60 blocks ~ 1h *)) params in
-    assert_nat_equal ~expected:(Ligo.nat_from_literal "970_407n") ~real:new_params.protected_index;
+    assert_fixedpoint_equal
+      ~expected:(fixedpoint_of_raw (Ligo.int_from_literal "17901426088874011260")) (* between 970_438n and 970_439n *)
+      ~real:new_params.protected_index;
     (* One day, downward move, touched in every block *)
     (* Initial : 1.000000 *)
-    (* Final   : 0.486151 (=51.3849% less than initial; slightly more than halved) *)
+    (* Final   : 0.486664 (=51.3336% less than initial; slightly more than halved) *)
     Ligo.Tezos.reset();
     let new_params = call_touch_times very_low_index kit_in_tok (60 * 24 (* 60 blocks ~ 1h *)) params in
-    assert_nat_equal ~expected:(Ligo.nat_from_literal "486_151n") ~real:new_params.protected_index
+    assert_fixedpoint_equal
+      ~expected:(fixedpoint_of_raw (Ligo.int_from_literal "8977377680627853844")) (* between 486_664n and 486_665n *)
+      ~real:new_params.protected_index
 
 (* ************************************************************************* *)
 (*                                 Prices                                    *)
@@ -367,7 +383,7 @@ let test_protected_index_pace =
  *   src/parameters.ml:29 (1_000_000mutez => 999_999mutez) *)
 let test_initial_tz_minting_equals_initial_tz_liquidation =
   "initially tz_minting equals tz_liquidation" >:: fun _ ->
-    assert_nat_equal
+    assert_fixedpoint_equal
       ~expected:(tz_liquidation initial_parameters)
       ~real:(tz_minting initial_parameters)
 
@@ -386,7 +402,8 @@ let test_minting_index_low_bounded =
     ~name:"test_minting_index_low_bounded"
     ~count:property_test_count
     (QCheck.map (fun x -> Ligo.nat_from_literal (string_of_int x ^ "n")) QCheck.(1 -- 999_999))
-  @@ fun index ->
+  @@ fun chf_in_tok ->
+  let index = TestLib.index_from_chf_in_tok chf_in_tok in
   Ligo.Tezos.reset ();
 
   (* just the next block *)
@@ -394,7 +411,7 @@ let test_minting_index_low_bounded =
 
   let _total_accrual_to_cfmm, new_params = parameters_touch index kit_in_tok params in
 
-  (tz_minting new_params >= Ligo.nat_from_literal "999_500n") (* 0.05% down, at "best" *)
+  (tz_minting new_params >= TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "999_500n")) (* 0.05% down, at "best" *)
 
 (* The pace of change of the minting index is unbounded on the high side.
  * George: What about the pace of change of the minting price (affected also by
@@ -411,13 +428,14 @@ let test_minting_index_high_unbounded =
     ~name:"test_minting_index_high_unbounded"
     ~count:property_test_count
     (QCheck.map (fun x -> Ligo.nat_from_literal (string_of_int x ^ "n")) QCheck.(1_000_001 -- max_int))
-  @@ fun index ->
+  @@ fun chf_in_tok ->
+  let index = TestLib.index_from_chf_in_tok chf_in_tok in
   Ligo.Tezos.reset ();
   (* just the next block *)
   Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
   let _total_accrual_to_cfmm, new_params = parameters_touch index kit_in_tok params in
-  assert_nat_equal
+  assert_fixedpoint_equal
     ~expected:index
     ~real:(tz_minting new_params);
   true
@@ -437,7 +455,8 @@ let test_liquidation_index_high_bounded =
     ~name:"test_liquidation_index_high_bounded"
     ~count:property_test_count
     (QCheck.map (fun x -> Ligo.nat_from_literal (string_of_int x ^ "n")) QCheck.(1_000_001 -- max_int))
-  @@ fun index ->
+  @@ fun chf_in_tok ->
+  let index = TestLib.index_from_chf_in_tok chf_in_tok in
   Ligo.Tezos.reset ();
   (* just the next block *)
   Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
@@ -445,7 +464,7 @@ let test_liquidation_index_high_bounded =
   let _total_accrual_to_cfmm, new_params = parameters_touch index kit_in_tok params in
   (* not very likely to hit the < case here I think;
    * perhaps we need a different generator *)
-  (tz_liquidation new_params <= Ligo.nat_from_literal "1_000_500n") (* 0.05% up, at "best" *)
+  (tz_liquidation new_params <= TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_500n")) (* 0.05% up, at "best" *)
 
 (* The pace of change of the liquidation index is unbounded on the low side.
  * George: What about the pace of change of the liquidation price (affected
@@ -463,12 +482,13 @@ let test_liquidation_index_low_unbounded =
     ~name:"test_liquidation_index_low_unbounded"
     ~count:property_test_count
     (QCheck.map (fun x -> Ligo.nat_from_literal (string_of_int x ^ "n")) QCheck.(1 -- 999_999))
-  @@ fun index ->
+  @@ fun chf_in_tok ->
+  let index = TestLib.index_from_chf_in_tok chf_in_tok in
   (* just the next block *)
   Ligo.Tezos.new_transaction ~seconds_passed:60 ~blocks_passed:1 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
   let _total_accrual_to_cfmm, new_params = parameters_touch index kit_in_tok params in
-  assert_nat_equal
+  assert_fixedpoint_equal
     ~expected:index
     ~real:(tz_liquidation new_params);
   true
@@ -486,8 +506,8 @@ let test_touch_0 =
     let in_params =
       Parameters.{
         q = fixedpoint_one;
-        index = Ligo.nat_from_literal "1_000_000n";
-        protected_index = Ligo.nat_from_literal "1_000_000n";
+        index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n");
+        protected_index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n");
         target = fixedpoint_one;
         drift = fixedpoint_zero;
         drift_derivative = fixedpoint_zero;
@@ -500,8 +520,8 @@ let test_touch_0 =
     let expected_out_params =
       Parameters.{
         q = fixedpoint_one;
-        index = Ligo.nat_from_literal "500_000n";
-        protected_index = Ligo.nat_from_literal "1_000_000n";
+        index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "500_000n");
+        protected_index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "1_000_000n");
         target = fixedpoint_of_hex_string "0.2AAAAAAAAAAAAAAA";
         drift_derivative = fixedpoint_zero;
         drift = fixedpoint_zero;
@@ -514,7 +534,7 @@ let test_touch_0 =
 
     (* Non-trivial values for the arguments. *)
     let kit_in_tok = Common.make_ratio (Ligo.int_from_literal "3") (Ligo.int_from_literal "1") in
-    let index = Ligo.nat_from_literal "500_000n" in
+    let index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "500_000n") in
     (* Touch in the same block. I wonder if we wish to allow this for a local function such as parameters_touch. *)
     Ligo.Tezos.new_transaction ~seconds_passed:0 ~blocks_passed:0 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
     let total_accrual_to_cfmm, out_params = parameters_touch index kit_in_tok in_params in
@@ -532,9 +552,9 @@ let test_touch_1 =
   "test_touch_1" >:: fun _ ->
     let initial_parameters : parameters =
       { q = fixedpoint_of_hex_string "0.E666666666666666"; (* 0.9 *)
-        index = Ligo.nat_from_literal "360_000n";
+        index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "360_000n");
         target = fixedpoint_of_hex_string "1.147AE147AE147AE1"; (* 1.08 *)
-        protected_index = Ligo.nat_from_literal "350_000n";
+        protected_index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "350_000n");
         drift = fixedpoint_zero;
         drift_derivative = fixedpoint_zero;
         burrow_fee_index = fixedpoint_one;
@@ -546,15 +566,15 @@ let test_touch_1 =
     Ligo.Tezos.reset ();
     Ligo.Tezos.new_transaction ~seconds_passed:3600 ~blocks_passed:60 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
-    let new_index = Ligo.nat_from_literal "340_000n" in
+    let new_index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "340_000n") in
     let kit_in_tok = Common.make_ratio (Ligo.int_from_literal "305") (Ligo.int_from_literal "1000") in
     let total_accrual_to_cfmm, new_parameters = parameters_touch new_index kit_in_tok initial_parameters in
     assert_parameters_equal
       ~expected:{
         q = fixedpoint_of_hex_string "0.E6666895A3EC8BA5"; (* 0.90000013020828555983 *)
-        index = Ligo.nat_from_literal "340_000n";
-        protected_index = Ligo.nat_from_literal "340_000n";
-        target = fixedpoint_of_hex_string "1.00D6E1B366FF4BEE"; (* 1.00327883367481013224 *)
+        index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "340_000n");
+        protected_index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "340_000n");
+        target = fixedpoint_of_hex_string "1.00D6E1B366FF4BED"; (* 1.00327883367481013224 *)
         drift_derivative = fixedpoint_of_hex_string "0.000000000012DA63"; (* 0.00000000000006697957 *)
         drift  = fixedpoint_of_hex_string "0.00000000848F8818"; (* 0.00000000012056322737 *)
         burrow_fee_index = fixedpoint_of_hex_string "1.00000991D674CC29"; (* 1.00000057039729312258 *)
@@ -571,9 +591,9 @@ let test_touch_2 =
   "test_touch_2" >:: fun _ ->
     let initial_parameters : parameters =
       { q = fixedpoint_of_hex_string "0.E666666666666666"; (* 0.9 *)
-        index = Ligo.nat_from_literal "360_000n";
+        index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "360_000n");
         target = fixedpoint_of_hex_string "1.147AE147AE147AE1"; (* 1.08 *)
-        protected_index = Ligo.nat_from_literal "350_000n";
+        protected_index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "350_000n");
         drift = fixedpoint_zero;
         drift_derivative = fixedpoint_zero;
         burrow_fee_index = fixedpoint_one;
@@ -585,15 +605,15 @@ let test_touch_2 =
     Ligo.Tezos.reset ();
     Ligo.Tezos.new_transaction ~seconds_passed:3600 ~blocks_passed:60 ~sender:alice_addr ~amount:(Ligo.tez_from_literal "0mutez");
 
-    let new_index = Ligo.nat_from_literal "340_000n" in
+    let new_index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "340_000n") in
     let kit_in_tok = Common.make_ratio (Ligo.int_from_literal "305") (Ligo.int_from_literal "1000") in
     let total_accrual_to_cfmm, new_parameters = parameters_touch new_index kit_in_tok initial_parameters in
     assert_parameters_equal
       ~expected:{
         q = fixedpoint_of_hex_string "0.E6666895A3EC8BA5";
-        index = Ligo.nat_from_literal "340000n";
-        protected_index = Ligo.nat_from_literal "340000n";
-        target = fixedpoint_of_hex_string "1.00D6E1B366FF4BEE";
+        index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "340000n");
+        protected_index = TestLib.index_from_chf_in_tok (Ligo.nat_from_literal "340000n");
+        target = fixedpoint_of_hex_string "1.00D6E1B366FF4BED";
         drift_derivative = fixedpoint_of_hex_string "0.000000000012DA63";
         drift = fixedpoint_of_hex_string "0.00000000848F8818";
         burrow_fee_index = fixedpoint_of_hex_string "1.00000991D674CC29";


### PR DESCRIPTION
This is a precursor to addressing #263. It primarily affects the tests, since the switch of the scaling factor from 10^6 to 2^64 increases precision in our calculations and many tight tests had to be adjusted. Using a fixedpoint with such precision is a good middle ground when trying to accommodate arbitrary fractions (such as the ones we expect to get from CFMMs once #263 is implemented) as well as index values with 6 decimal digits of precision (i.e., current state of affairs).