### PR TITLE
Support for non-root user in dev container

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -92,6 +92,8 @@ docs:
 spec:
     FROM +builder
     RUN pip install sphinx-rtd-theme
+    # Add local install path for sphinx since we are running as non-root user
+    ENV PATH=/home/checker/.local/bin:$PATH
     COPY docs docs
     RUN make -C docs/spec html
     SAVE ARTIFACT docs/spec/_build/html AS LOCAL docs/spec/_build/html

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ your local Docker daemon for executing builds.
 ```console
 docker run --rm -it \
   --name checker-dev-container \
+  -e CHECKER_UID=$UID
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v $PWD:/checker \
   ghcr.io/tezos-checker/checker/dev
@@ -157,7 +158,7 @@ In a new terminal, deploy the mock oracle and ctez contracts. To get
 a new terminal manually (e.g. if not using VSCode), you can use:
 
 ```console
-$ docker exec -it checker-dev-container bash
+$ docker exec -it -u checker checker-dev-container bash
 ```
 
 ```console

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ your local Docker daemon for executing builds.
 ```console
 docker run --rm -it \
   --name checker-dev-container \
-  -e CHECKER_UID=$UID
+  -e CHECKER_UID=$UID \
+  -e DOCKER_GID=$(grep "docker" /etc/group | cut -d: -f3) \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v $PWD:/checker \
   ghcr.io/tezos-checker/checker/dev

--- a/scripts/docker/entrypoint-dev-container.sh
+++ b/scripts/docker/entrypoint-dev-container.sh
@@ -12,7 +12,7 @@ if [ "${EUID}" -ne 0 ]
   exit 1
 fi
 
-# If a speific UID is supplied, make sure that the container user has that UID.
+# If a specific UID is supplied, make sure that the container user has that UID.
 # This helps reduce the frequency of permission-related errors when mounting
 # in host directories for development.
 if [ ! -z "${CHECKER_UID}" ]
@@ -25,7 +25,18 @@ then
     # Restore home directory (permissions for existing files won't be updated)
     usermod --home /home/checker checker
     # Chown any directories we absolutely must WRITE to with our new user id
+    # Note: This allows us to write to home dir but not to pre-existing files there
+    chown checker /home/checker
     chown checker /home/checker/.config
+fi
+
+# To support docker in docker, need to ensure that the docker group in the container
+# has the GID as the docker group on the host (otherwise you can't call docker commands
+# in the container).
+if [ ! -z "${DOCKER_GID}" ]
+then
+    # Update the group id to match the specified one
+    groupmod --gid $DOCKER_GID docker
 fi
 
 # Add opam switch environment variables

--- a/scripts/docker/entrypoint-dev-container.sh
+++ b/scripts/docker/entrypoint-dev-container.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Entrypoint for the checker dev container
+###############################################################################
+
+set -e
+
+# Changes to gid and uid require root access in the container
+if [ "${EUID}" -ne 0 ]
+  then echo "This script must be run as root."
+  exit 1
+fi
+
+# If a speific UID is supplied, make sure that the container user has that UID.
+# This helps reduce the frequency of permission-related errors when mounting
+# in host directories for development.
+if [ ! -z "${CHECKER_UID}" ]
+then
+    # Update the group id to match the specified one
+    groupmod --gid $CHECKER_UID checker
+    # Update the user id to match the specified one
+    # Note: Switching the user home directory to avoid slow `chown` commands
+    usermod --home /checker --uid $CHECKER_UID --gid $CHECKER_UID checker
+    # Restore home directory (permissions for existing files won't be updated)
+    usermod --home /home/checker checker
+    # Chown any directories we absolutely must WRITE to with our new user id
+    chown checker /home/checker/.config
+fi
+
+# Add opam switch environment variables
+echo 'eval $(opam env --switch=/build --set-switch)' >> /home/checker/.bashrc
+# Add the pre-installed python env to the PATH for convenience
+echo 'export PATH=/build/.venv/bin:$PATH' >> /home/checker/.bashrc
+
+# Start a shell as our user
+gosu checker bash


### PR DESCRIPTION
Updates the dev container to use a non-root user. This avoid situations where artifacts created in a volume mount require a `sudo chown` command or similar on the host since they were created using the root user in the container.

In order to accomplish this, I had to expand the entrypoint script a bit to enable re-mapping of the user and docker group within the container at runtime so that they match the respective ids on the host. This requires setting two extra environment variables when launching the contianer, and I updated the README with the new command.

To test locally you will first need to run:
   `earthly +dev-container`

Then modify the command in the README to point to the new local image you just created: `checker/dev:latest`
