### PR TITLE
Fix broken paths in comment CI pipeline

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           docker run \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            -v $PWD/scripts:/root/scripts \
+            -v $PWD/scripts:/home/checker/scripts \
             -v $HOME/.config/hub:/home/checker/.config/hub \
             checker/deps-full:latest \
             poetry run python scripts/comment-prs.py

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           docker run \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            -v $PWD/scripts:/home/checker/scripts \
+            -v $PWD/scripts:/build/scripts \
             -v $HOME/.config/hub:/home/checker/.config/hub \
             checker/deps-full:latest \
-            poetry run python /home/checker/scripts/comment-prs.py
+            poetry run python scripts/comment-prs.py

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -41,6 +41,6 @@ jobs:
           docker run \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -v $PWD/scripts:/root/scripts \
-            -v $HOME/.config:/root/.config \
+            -v $HOME/.config/hub:/home/checker/.config/hub \
             checker/deps-full:latest \
             poetry run python scripts/comment-prs.py

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -43,4 +43,4 @@ jobs:
             -v $PWD/scripts:/home/checker/scripts \
             -v $HOME/.config/hub:/home/checker/.config/hub \
             checker/deps-full:latest \
-            poetry run python scripts/comment-prs.py
+            poetry run python /home/checker/scripts/comment-prs.py


### PR DESCRIPTION
Fixes a couple of paths in the comment bot CI pipeline which are no longer valid following recent updates to the Earthly build. Tested manually here: https://github.com/tezos-checker/checker/runs/4532345315?check_suite_focus=true