### PR TITLE
Update vendored ctez to next_next

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor/ctez"]
 	path = vendor/ctez
 	url = https://github.com/tezos-checker/ctez
-	branch = next
+	branch = next_next


### PR DESCRIPTION
So far we've been running our end to end tests, etc. against ctez's `next` branch. This PR updates the vendored version to `next_next`, which is the more recent version of ctez.

Also updated the approach used for fetching the various `tezos-*` binaries in the Earthly build for `flextesa` since the script provided with flextesa is flaky (refers to transient build artifacts which can expire instead of actual releases).