### PR TITLE
Switch ligo to vendored version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = vendor/ctez
 	url = https://github.com/tezos-checker/ctez
 	branch = next_next
+[submodule "vendor/ligo"]
+	path = vendor/ligo
+	url = https://gitlab.com/ligolang/ligo.git

--- a/Earthfile
+++ b/Earthfile
@@ -419,9 +419,54 @@ cli:
 # Utilities
 # =============================================================================
 ligo-binary:
-    FROM ghcr.io/tezos-checker/ligo:0.22.0-checker
+    FROM +ligo
     SAVE ARTIFACT /root/ligo ligo
     SAVE ARTIFACT /root/ligo AS LOCAL ./bin/ligo
+
+ligo:
+    # Sadly, the ligo Dockerfile expects that a changelog.txt file exists
+    # which does not exist in the git repo. This makes it nearly impossible to
+    # integrate with the earthly build here. Running the build scripts ourselves
+    # instead...
+    # Mostly copy-pasted from https://gitlab.com/ligolang/ligo/-/blob/0.34.0/Dockerfile
+    FROM alpine:3.12
+
+    RUN apk update && apk upgrade && apk --no-cache add \
+        build-base snappy-dev alpine-sdk wget \
+        bash ncurses-dev xz m4 git pkgconfig findutils rsync \
+        gmp-dev libev-dev libressl-dev linux-headers pcre-dev perl zlib-dev hidapi-dev \
+        libffi-dev \
+        cargo
+
+    WORKDIR /ligo
+
+    RUN wget -O /usr/local/bin/opam https://github.com/ocaml/opam/releases/download/2.1.0/opam-2.1.0-x86_64-linux
+    RUN chmod u+x /usr/local/bin/opam
+    RUN opam init --disable-sandboxing --bare
+
+    ENV RUSTFLAGS='--codegen target-feature=-crt-static'
+
+    # Install opam switch & deps
+    COPY /vendor/ligo/scripts/setup_switch.sh /ligo/scripts/setup_switch.sh
+    RUN opam update && sh scripts/setup_switch.sh
+    COPY /vendor/ligo/scripts/install_opam_deps.sh /ligo/scripts/install_opam_deps.sh
+    COPY /vendor/ligo/ligo.opam /ligo
+    COPY /vendor/ligo/ligo.opam.locked /ligo
+    COPY /vendor/ligo/vendors /ligo/vendors
+
+    # install all transitive deps
+    RUN opam update && sh scripts/install_opam_deps.sh
+    ENV PATH=/home/root/.cargo/bin:$PATH
+
+    # Install LIGO
+    COPY /vendor/ligo/src /ligo/src
+    COPY /vendor/ligo/dune /ligo
+    COPY /vendor/ligo/dune-project /ligo/dune-project
+    # COPY /vendor/ligo/scripts/version.sh /ligo/scripts/version.sh
+    RUN LIGO_VERSION=checker opam exec -- dune build -p ligo --profile static
+
+    RUN cp /ligo/_build/install/default/bin/ligo /root/ligo
+    SAVE IMAGE --push ghcr.io/tezos-checker/checker/earthly-cache:ligo
 
 zcash-params:
     FROM alpine:3.14

--- a/Earthfile
+++ b/Earthfile
@@ -513,6 +513,8 @@ flextesa:
 
     # Build flextesa
     RUN eval $(opam env) && \
+        # Note: setting profile to `dune` to disable deprecation alerts as errors
+        export DUNE_PROFILE=dune && \
         make build && \
         mkdir ./bin && \
         cp -L ./flextesa ./bin

--- a/checker_tools/client/checker.py
+++ b/checker_tools/client/checker.py
@@ -504,7 +504,7 @@ def ligo_compile(src_file: Path, entrypoint: str, out_file: Path):
     """Compiles an mligo file into michelson using ligo"""
     try:
         res = subprocess.run(
-            ["ligo", "compile-contract", str(src_file), entrypoint],
+            ["ligo", "compile", "contract", str(src_file), "--entry-point", entrypoint],
             check=True,
             capture_output=True,
         )

--- a/scripts/compile-ligo.rb
+++ b/scripts/compile-ligo.rb
@@ -32,8 +32,8 @@ protocol_arg = ["--protocol", PROTOCOL]
 puts "Compiling the main contract."
 ###################################
 
-compiled_contract, exit_status = Open3.capture2("ligo", "compile-contract", MAIN_FILE, "main")
-exit_status.success? or raise "compile-contract failed:\n#{compiled_contract}"
+compiled_contract, exit_status = Open3.capture2("ligo", "compile", "contract", MAIN_FILE, "--entry-point", "main")
+exit_status.success? or raise "compile contract failed:\n#{compiled_contract}"
 
 begin
   # Convert the contract to binary to measure the size.
@@ -50,8 +50,8 @@ end
 puts "Compiling the tez wrapper contract."
 ##########################################
 
-compiled_wtez_contract, exit_status = Open3.capture2("ligo", "compile-contract", WTEZ_FILE, "main")
-exit_status.success? or raise "compile-contract failed:\n#{compiled_wtez_contract}"
+compiled_wtez_contract, exit_status = Open3.capture2("ligo", "compile", "contract", WTEZ_FILE, "--entry-point", "main")
+exit_status.success? or raise "compile contract failed:\n#{compiled_wtez_contract}"
 
 begin
   # Convert the contract to binary to measure the size.
@@ -68,8 +68,8 @@ end
 puts "Compiling the wctez contract."
 ##########################################
 
-compiled_wctez_contract, exit_status = Open3.capture2("ligo", "compile-contract", WCTEZ_FILE, "main")
-exit_status.success? or raise "compile-contract failed:\n#{compiled_wctez_contract}"
+compiled_wctez_contract, exit_status = Open3.capture2("ligo", "compile", "contract", WCTEZ_FILE, "--entry-point", "main")
+exit_status.success? or raise "compile contract failed:\n#{compiled_wctez_contract}"
 
 begin
   # Convert the contract to binary to measure the size.
@@ -86,8 +86,8 @@ end
 puts "Compiling the mock FA2 contract."
 ##########################################
 
-compiled_mock_fa2_contract, exit_status = Open3.capture2("ligo", "compile-contract", MOCK_FA2_FILE, "main")
-exit_status.success? or raise "compile-contract failed:\n#{compiled_mock_fa2_contract}"
+compiled_mock_fa2_contract, exit_status = Open3.capture2("ligo", "compile", "contract", MOCK_FA2_FILE, "--entry-point", "main")
+exit_status.success? or raise "compile contract failed:\n#{compiled_mock_fa2_contract}"
 
 begin
   # Convert the contract to binary to measure the size.
@@ -109,7 +109,7 @@ def compile_type_json(type, file)
   # ligo does not have a compile-type command. So, we use UNPACK to make the type appear
   # in the generated michelson and grab the type from there.
   stdout, stderr, exit_status = Open3.capture3(
-    "ligo", "compile-expression", "cameligo",
+    "ligo", "compile", "expression", "cameligo",
     "--init-file", file,
     "--michelson-format", "json",
     "fun (i: bytes) -> (Bytes.unpack i: (#{type}) option)"
@@ -121,7 +121,7 @@ end
 
 def compile_code_json(expr, file)
   stdout, stderr, exit_status = Open3.capture3(
-    "ligo", "compile-expression", "cameligo",
+    "ligo", "compile", "expression", "cameligo",
     "--init-file", file,
     "--michelson-format", "json",
     expr
@@ -260,7 +260,7 @@ entrypoints.each_slice([entrypoints.length / Etc.nprocessors, 1].max) { |batch|
   threads << Thread.new {
     batch.each { |entrypoint|
       stdout, stderr, exit_status = Open3.capture3(
-        "ligo", "compile-expression", "cameligo",
+        "ligo", "compile", "expression", "cameligo",
         "--init-file", MAIN_FILE,
         "Bytes.pack lazy_fun_#{entrypoint[:name]}"
       )

--- a/src/checkerMain.ml
+++ b/src/checkerMain.ml
@@ -55,8 +55,7 @@ let main (op, state: params * wrapper): LigoOp.operation list * wrapper =
 
   let ops, lazy_functions, metadata, deployment_state = match deployment_state with
     | Unsealed deployer ->
-      begin match !Ligo.Tezos.sender = deployer with
-        | true ->
+      begin if !Ligo.Tezos.sender = deployer then
           begin match op with
             | DeployFunction p ->
               let lfi, bs = p in
@@ -98,7 +97,7 @@ let main (op, state: params * wrapper): LigoOp.operation list * wrapper =
                * accessibility is sufficiently marked on the pattern itself. *)
               ((Ligo.failwith error_ContractNotDeployed [@coverage off]): LigoOp.operation list * lazy_function_map * (string, Ligo.bytes) Ligo.big_map * deployment_state)
           end
-        | false ->
+        else
           (* Note: disabling coverage for the unreported but accessed right-hand side;
            * accessibility is sufficiently marked on the pattern itself. *)
           ((Ligo.failwith error_UnauthorisedCaller [@coverage off]): LigoOp.operation list * lazy_function_map * (string, Ligo.bytes) Ligo.big_map * deployment_state)

--- a/util/README.md
+++ b/util/README.md
@@ -4,7 +4,7 @@
 Example commands:
 
 ```
-ligo compile-contract mock_oracle.mligo main > mock_oracle.tz
+ligo compile contract mock_oracle.mligo --entrypoint main > mock_oracle.tz
 ```
 
 ```
@@ -12,7 +12,7 @@ tezos-client originate contract mock_oracle transferring 0 from bob running mock
 ```
 
 ```
-ligo compile-contract mock_cfmm_oracle.mligo main > mock_cfmm_oracle.tz
+ligo compile contract mock_cfmm_oracle.mligo --entrypoint main > mock_cfmm_oracle.tz
 ```
 
 ```


### PR DESCRIPTION
Due to issues with configurations within ligo and the large size of Checker's entrypoints, we've had to compile the contract using a patched version of ligo. Thankfully, [recent updates](https://gitlab.com/ligolang/ligo/-/issues/1227#note_820191587) have made it possible to compile checker with upstream ligo. This PR switches over our builds to use upstream ligo instead of our fork.

One particularity of this PR is that since ligo does not currently publish arm binaries, we vendor / rebuild it within our Earthfile in order to continue to support M1 Mac users.