### PR TITLE
Update doc workflow

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -11,11 +11,33 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Log in to container registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Add git branch for earthly
+        run: |
+          branch=""
+          if [ -n "$GITHUB_HEAD_REF" ]; then
+            branch="$GITHUB_HEAD_REF"
+          else
+            branch="${GITHUB_REF##*/}"
+          fi
+          git checkout -b "$branch" || true
+
+      # FIXME: Might need to swap to a PAT here since GITHUB_TOKEN is still unreliable
+      #   See: https://github.community/t/403-error-on-container-registry-push-from-github-action/173071
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install earthly
         run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.23/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+
+      # Only push earthly cache from master
+      - if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        run: echo "push_flag=--push" >> $GITHUB_ENV
+        name: Enable push to build cache
+
       - name: Build spec
-        # FIXME: Use if statement to only push on commits to master here
-        # TODO: Not sure if the output path here is what readthedocs expects
-        run: earthly --ci --push --artifact +spec/ ./result
+        run: earthly --ci ${{ env.push_flag }} --artifact +spec/ ./result


### PR DESCRIPTION
Following some discussions around why the `doc` GitHub Actions workflow was failing for #323, I noticed that the `doc` workflow definition follows a different pattern for authenticating to GitHub and deciding when to push images to the Earthly cache. I'm not sure if this is the only reason why the build in #323 fails, but either way these workflows should be following the same approach. This PR updates the `doc` workflow to use the same methodology as `ci`. 